### PR TITLE
Add install, update, uninstall helpers.

### DIFF
--- a/source/ports/py_port/package/helper.py
+++ b/source/ports/py_port/package/helper.py
@@ -1,0 +1,216 @@
+import subprocess
+import sys
+
+import os
+import re
+import requests
+import shutil
+import tarfile
+
+LIB_CONTENT = [
+    'bootstrap.js',
+    'CSLoader.dll',
+    'libcs_loader.so',
+    'libcxx_port.so',
+    'libicudata.so.52.1',
+    'libicui18n.so.52.1',
+    'libicuuc.so.52.1',
+    'libjs_loader.so',
+    'libmetacall.so',
+    'libmetacall_serial.so',
+    'libmock_loader.so',
+    'libnode.so.57',
+    'libnode_loader.so',
+    'libpy_loader.so',
+    'librapid_json_serial.so',
+    'librb_loader.so',
+    'libv8.so.5.1.117',
+    '_py_port.so',
+    'rb_port.so',
+    'System.Runtime.Loader.dll',
+    'trampoline.node'
+]
+
+
+def file_size(num, suffix='B'):
+    for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi']:
+        if abs(num) < 1024.0:
+            return "%3.1f%s%s" % (num, unit, suffix)
+        num /= 1024.0
+    return "%.1f%s%s" % (num, 'Yi', suffix)
+
+
+def find_assets(patterns):
+    api_url = 'https://api.github.com/repos/metacall/core/releases/latest'
+    urls = []
+    res = requests.get(api_url)
+    data = res.json()
+    data = [li['browser_download_url'] for li in data['assets']]
+    for p in patterns:
+        regex = re.compile(p)
+        urls.append(list(filter(regex.search, data))[0])
+    return urls
+
+
+def download(urls):
+    for url in urls:
+        filename = '/tmp/{}'.format(url.split("/")[-1])
+
+        if os.path.isfile(filename + '.tmp'):
+            os.remove(filename + '.tmp')
+
+        with open(filename + '.tmp', 'wb') as file:
+            res = requests.get(url, stream=True)
+            total_length = res.headers.get('content-length')
+
+            if total_length is None:
+                print('Downloading {} from {}\n'.format(url.split("/")[-1], url))
+                file.write(res.content)
+            else:
+                dl = 0
+                total_length = int(total_length)
+                print('Downloading {} (total: {}) from {}\n'.format(url.split("/")[-1], total_length, url))
+                for data in res.iter_content(chunk_size=4096):
+                    dl += len(data)
+                    file.write(data)
+                    done = int(50 * dl / total_length)
+                    sys.stdout.write("\r[%s%s]" % ('=' * done, ' ' * (50 - done)))
+                    sys.stdout.write(
+                        '\r[{}{}] - {}/{}'.format('=' * done, ' ' * (50 - done),
+                                                  file_size(dl), file_size(total_length))
+                    )
+                    sys.stdout.flush()
+                print('\n')
+
+        os.rename(filename + '.tmp', filename)
+
+
+def unpack(files):
+    for filename in files:
+        filename = filename.split("/")[-1]
+        print('Extracting {} ...'.format(filename))
+        with tarfile.open(filename) as file:
+            file.extractall()
+
+
+def overwrite(src, dest):
+    if os.path.isdir(src):
+        if not os.path.isdir(dest):
+            os.makedirs(dest)
+        files = os.listdir(src)
+        for file in files:
+            overwrite(os.path.join(src, file), os.path.join(dest, file))
+    else:
+        print('copying {} to {}'.format(src, dest))
+        shutil.copyfile(src, dest)
+
+
+def spawn(args):
+    process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, error = process.communicate()
+
+    return output, error, process.returncode
+
+
+def install(ignore=False):
+    if ignore is False:
+        if os.path.isfile('/usr/local/bin/metacallcli'):
+            print('MetaCall CLI is already installed')
+            exit(0)
+
+    if os.getuid() != 0:
+        print('You need to have root privileges to run this script.')
+        exit(-1)
+
+    os.chdir('/tmp/')
+
+    docs = ''  # link to documentation if this script failed to download the cli
+
+    try:
+
+        print('Searching for files ...')
+
+        assets = find_assets([r'metacall-[0-9].[0-9].[0.9]-runtime.tar.gz',
+                              r'metacall-[0-9].[0-9].[0.9]-examples.tar.gz'])
+
+        missing_files = [file for file in assets if not os.path.isfile(file.split('/')[-1])]
+
+        if len(missing_files) != 0:
+            download(missing_files)
+
+        unpack(assets)
+
+        overwrite('/tmp/usr/local/', '/usr/local/')
+
+        print('\n')
+
+        output, error, code = spawn(['ldconfig', '-n', '-v', '/usr/local/lib/'])
+        if code != 0:
+            print('Failed to install MetaCall\n{}\n'
+                  'please proceed with the manual installation. {}'.format(error.decode('utf-8'), docs))
+            exit(1)
+        else:
+            print(output.decode('utf-8'))
+
+        spawn(['chmod', '+x', '/usr/local/bin/metacallcli'])
+
+        print('\nCleaning things up ...')
+
+        shutil.rmtree('/tmp/usr')
+        for file in assets:
+            path = '/tmp/' + file.split('/')[-1]
+            if os.path.isfile(path):
+                os.remove(path)
+
+        print('MetaCall CLI is successfully installed.')
+
+    except ConnectionError:
+        print('Downloading process failed, please proceed with the manual installation. {}'.format(docs))
+    except tarfile.ExtractError:
+        print('Extraction process failed, please proceed with the manual installation. {}'.format(docs))
+    except KeyboardInterrupt:
+        print('\nCanceled by user.')
+
+
+def update():
+    install(ignore=True)
+
+
+def uninstall():
+    if os.path.isdir('/usr/local/share/metacall'):
+        shutil.rmtree('/usr/local/share/metacall')
+    if os.path.isfile('/usr/local/bin/metacallcli'):
+        os.remove('/usr/local/bin/metacallcli')
+
+    for file in LIB_CONTENT:
+        if os.path.isfile('/usr/local/lib/' + file):
+            os.remove('/usr/local/lib/' + file)
+
+    spawn(['ldconfig'])
+
+    exit(0)
+
+
+def uninstall_prompt():
+    message = '''This action would remove:\n   /usr/local/bin/metacallcli\n   /usr/local/bin/share/metacall/*\n   {}
+* this action DOES NOT uninstall the python package, only MetaCall CLI and MetaCall libs
+* for a complete uninstall you have to run metacall-uninstall && pip uninstall metacall 
+* (the order of execution is important)
+  
+Proceed (y/n)? '''.format(''.join('''/usr/local/lib/{}\n   '''.format(l) for l in LIB_CONTENT))
+
+    answers = {'yes': True, 'y': True, 'no': False, 'n': False}
+
+    try:
+        while True:
+            sys.stdout.write(message)
+            choice = input().lower()
+            if choice in answers:
+                if answers[choice]:
+                    uninstall()
+                else:
+                    exit(0)
+            else:
+                sys.stdout.write("Please respond with 'yes' or 'no' (or 'y' or 'n').\n")
+    except KeyboardInterrupt:
+        exit(1)

--- a/source/ports/py_port/package/setup.py
+++ b/source/ports/py_port/package/setup.py
@@ -5,11 +5,11 @@ https://packaging.python.org/en/latest/distributing.html
 https://github.com/pypa/sampleproject
 """
 
-# Always prefer setuptools over distutils
-from setuptools import setup, find_packages
 # To use a consistent encoding
 from codecs import open
 from os import path
+# Always prefer setuptools over distutils
+from setuptools import setup, find_packages
 
 here = path.abspath(path.dirname(__file__))
 
@@ -23,7 +23,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.1.0',
+    version='0.1.9',
 
     description='A library for providing inter-language foreign function interface calls',
     long_description=long_description,
@@ -82,7 +82,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['peppercorn'],
+    install_requires=['peppercorn', 'requests'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,
@@ -109,9 +109,11 @@ setup(
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # pip to create the appropriate form of executable for the target platform.
-    #entry_points={
-    #    'console_scripts': [
-    #        'sample=sample:main',
-    #    ],
-    #},
+    entry_points={
+       'console_scripts': [
+           'metacall-install=helper:install',
+           'metacall-uninstall=helper:uninstall_prompt',
+           'metacall-update=helper:update'
+       ],
+    },
 )


### PR DESCRIPTION
These helpers make installation, update and uninstall of MetaCall (CLI, runtime-libs), easy.

this isn't necessarily just for the python package. you can slightly change it to be used globally as a way of managing this project.

the content of /usr/local/lib (`LIB_CONTENT`) is hardcoded for now.
this could improve by storing the filenames in a text file while unpacking ([package data](https://docs.python.org/3/distutils/setupscript.html#installing-package-data)) 

OR, simply move the content inside a directory. so that it can be safely removed (you can still load them with `ldconfig -n -v /usr/local/lib/metacall`)

you can try it out with `pip install -e .`

also replace `docs` with the manual installation guide

here is the output of each command:

**metacall-install**
```
Searching for files ...
Downloading metacall-0.1.0-runtime.tar.gz (total: 28511614) from https://github.com/metacall/core/releases/download/v0.1.9/metacall-0.1.0-runtime.tar.gz

[==================================================] - 27.2MiB/27.2MiBiB

Downloading metacall-0.1.0-examples.tar.gz (total: 37373) from https://github.com/metacall/core/releases/download/v0.1.9/metacall-0.1.0-examples.tar.gz

[==================================================] - 36.5KiB/36.5KiB

Extracting metacall-0.1.0-runtime.tar.gz ...
Extracting metacall-0.1.0-examples.tar.gz ...
copying /tmp/usr/local/share/metacall/AUTHORS to /usr/local/share/metacall/AUTHORS
copying /tmp/usr/local/share/metacall/configurations/cs_loader.json to /usr/local/share/metacall/configurations/cs_loader.json
copying /tmp/usr/local/share/metacall/configurations/global.json to /usr/local/share/metacall/configurations/global.json
copying /tmp/usr/local/share/metacall/README.md to /usr/local/share/metacall/README.md
copying /tmp/usr/local/share/metacall/LICENSE to /usr/local/share/metacall/LICENSE
copying /tmp/usr/local/share/metacall/VERSION to /usr/local/share/metacall/VERSION
copying /tmp/usr/local/lib/libicudata.so.52.1 to /usr/local/lib/libicudata.so.52.1
copying /tmp/usr/local/lib/librb_loader.so to /usr/local/lib/librb_loader.so
copying /tmp/usr/local/lib/_py_port.so to /usr/local/lib/_py_port.so
copying /tmp/usr/local/lib/CSLoader.dll to /usr/local/lib/CSLoader.dll
copying /tmp/usr/local/lib/trampoline.node to /usr/local/lib/trampoline.node
copying /tmp/usr/local/lib/libv8.so.5.1.117 to /usr/local/lib/libv8.so.5.1.117
copying /tmp/usr/local/lib/libnode_loader.so to /usr/local/lib/libnode_loader.so
copying /tmp/usr/local/lib/libmetacall_serial.so to /usr/local/lib/libmetacall_serial.so
copying /tmp/usr/local/lib/System.Runtime.Loader.dll to /usr/local/lib/System.Runtime.Loader.dll
copying /tmp/usr/local/lib/rb_port.so to /usr/local/lib/rb_port.so
copying /tmp/usr/local/lib/libmock_loader.so to /usr/local/lib/libmock_loader.so
copying /tmp/usr/local/lib/libnode.so.57 to /usr/local/lib/libnode.so.57
copying /tmp/usr/local/lib/libpy_loader.so to /usr/local/lib/libpy_loader.so
copying /tmp/usr/local/lib/libmetacall.so to /usr/local/lib/libmetacall.so
copying /tmp/usr/local/lib/libicuuc.so.52.1 to /usr/local/lib/libicuuc.so.52.1
copying /tmp/usr/local/lib/libjs_loader.so to /usr/local/lib/libjs_loader.so
copying /tmp/usr/local/lib/bootstrap.js to /usr/local/lib/bootstrap.js
copying /tmp/usr/local/lib/libcxx_port.so to /usr/local/lib/libcxx_port.so
copying /tmp/usr/local/lib/libicui18n.so.52.1 to /usr/local/lib/libicui18n.so.52.1
copying /tmp/usr/local/lib/libcs_loader.so to /usr/local/lib/libcs_loader.so
copying /tmp/usr/local/lib/librapid_json_serial.so to /usr/local/lib/librapid_json_serial.so
copying /tmp/usr/local/bin/metacallcli to /usr/local/bin/metacallcli


/usr/local/lib:
	librapid_json_serial.so -> librapid_json_serial.so
	libcs_loader.so -> libcs_loader.so
	libicui18n.so.52 -> libicui18n.so.52.1 (changed)
	libcxx_port.so -> libcxx_port.so
	libjs_loader.so -> libjs_loader.so
	libicuuc.so.52 -> libicuuc.so.52.1 (changed)
	libmetacall.so -> libmetacall.so
	libpy_loader.so -> libpy_loader.so
	libnode.so.57 -> libnode.so.57
	libmock_loader.so -> libmock_loader.so
	libmetacall_serial.so -> libmetacall_serial.so
	libnode_loader.so -> libnode_loader.so
	libv8.so.5.1.117 -> libv8.so.5.1.117
	librb_loader.so -> librb_loader.so
	libicudata.so.52 -> libicudata.so.52.1 (changed)


Cleaning things up ...
MetaCall CLI is successfully installed.
```
**metacall-uninstall**
```
This action would remove:
   /usr/local/bin/metacallcli
   /usr/local/bin/share/metacall/*
   /usr/local/lib/bootstrap.js
   /usr/local/lib/CSLoader.dll
   /usr/local/lib/libcs_loader.so
   /usr/local/lib/libcxx_port.so
   /usr/local/lib/libicudata.so.52.1
   /usr/local/lib/libicui18n.so.52.1
   /usr/local/lib/libicuuc.so.52.1
   /usr/local/lib/libjs_loader.so
   /usr/local/lib/libmetacall.so
   /usr/local/lib/libmetacall_serial.so
   /usr/local/lib/libmock_loader.so
   /usr/local/lib/libnode.so.57
   /usr/local/lib/libnode_loader.so
   /usr/local/lib/libpy_loader.so
   /usr/local/lib/librapid_json_serial.so
   /usr/local/lib/librb_loader.so
   /usr/local/lib/libv8.so.5.1.117
   /usr/local/lib/_py_port.so
   /usr/local/lib/rb_port.so
   /usr/local/lib/System.Runtime.Loader.dll
   /usr/local/lib/trampoline.node
   
* this action DOES NOT uninstall the python package, only MetaCall CLI and MetaCall libs
* for a complete uninstall you have to run metacall-uninstall && pip uninstall metacall 
* (the order of execution is important)
  
Proceed (y/n)?
```
there is also metacall-update Which is same as install but ignores the existing files.