### PR TITLE
Nice to have: platform independent Bash, armv6j support

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Default options
 BUILD_DIR="build"

--- a/source/log/source/log.c
+++ b/source/log/source/log.c
@@ -211,8 +211,11 @@ int log_write_impl_va(const char * name, const size_t line, const char * func, c
 	record_ctor.file = file;
 	record_ctor.level = level;
 	record_ctor.message = message;
+#ifdef __arm__
+	record_ctor.data = &variable_args;
+#else
 	record_ctor.data = variable_args;
-
+#endif
 	result = log_impl_write(impl, &record_ctor);
 
 	va_end(variable_args);

--- a/source/log/source/log_policy_format_text.c
+++ b/source/log/source/log_policy_format_text.c
@@ -227,9 +227,11 @@ static size_t log_policy_format_text_serialize_impl_va(log_policy policy, const 
 	if (log_record_data(record) != NULL)
 	{
 		va_list args_copy;
-
+#ifdef __arm__
+		va_copy(args_copy, *((va_list*)log_record_data(record)));
+#else
 		va_copy(args_copy, log_record_data(record));
-
+#endif
 		body_length = vsnprintf(buffer_body, size, log_record_message(record), args_copy);
 
 		va_end(args_copy);


### PR DESCRIPTION
b89932c adds support for FreeBSD by changing #!/bin/bash to #!/usr/bin/env bash
3909d46 adds armv6j support by properly handling va_list