### PR TITLE
Forward CMAKE_INSTALL_PREFIX to node's "make install"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ _start-cmd.bat
 !tools/core/.dockerignore
 !tools/dev/.dockerignore
 !tools/node/.dockerignore
+
+# macOS files
+.DS_Store

--- a/cmake/FindNodeJS.cmake
+++ b/cmake/FindNodeJS.cmake
@@ -343,7 +343,7 @@ if(NOT NODEJS_LIBRARY)
 
 			message(STATUS "Install NodeJS shared library")
 
-			execute_process(COMMAND sh -c "make install" WORKING_DIRECTORY "${NODEJS_OUTPUT_PATH}" OUTPUT_QUIET)
+			execute_process(COMMAND sh -c "make install PREFIX=\"${CMAKE_INSTALL_PREFIX}\"" WORKING_DIRECTORY "${NODEJS_OUTPUT_PATH}" OUTPUT_QUIET)
 		endif()
 	endif()
 


### PR DESCRIPTION
Node was previously building to /usr/local even though I had specified a prefix with CMAKE_INSTALL_PREFIX. This change forwards the install prefix to node's build script

I also added `.DS_Store` to the gitignore because those files just show up on macOS all the time