### PR TITLE
feat: load tsconfig from the root of the project

### DIFF
--- a/source/loaders/ts_loader/bootstrap/lib/bootstrap.ts
+++ b/source/loaders/ts_loader/bootstrap/lib/bootstrap.ts
@@ -79,8 +79,12 @@ class TypeScriptLanguageServiceHost {
 		console.log(message);
 	}
 
-	getCompilationSettings() {
-		// TODO: Make it able to load tsconfig.json files
+	getCompilationSettings(currentDirectory) {
+		if (currentDirectory) {
+			const tsconfig = path.join(currentDirectory, 'tsconfig.json');
+			return node_require(tsconfig);
+		}
+
 		const options = {
 			esModuleInterop: true,
 			jsx: 2, /* React */
@@ -167,7 +171,8 @@ function ts_loader_trampoline_initialize() {
 	registry = ts.createDocumentRegistry();
 	servicesHost = new TypeScriptLanguageServiceHost();
 	services = ts.createLanguageService(servicesHost, registry);
-	const lib = path.dirname(servicesHost.getDefaultLibFileName(servicesHost.getCompilationSettings()));
+	const currentDirectory = servicesHost.getCurrentDirectory()
+	const lib = path.dirname(servicesHost.getDefaultLibFileName(servicesHost.getCompilationSettings(currentDirectory)));
 
 	// Load TypeScript Runtime
 	fs.readdirSync(lib).map(file => {

--- a/source/loaders/ts_loader/bootstrap/lib/bootstrap.ts
+++ b/source/loaders/ts_loader/bootstrap/lib/bootstrap.ts
@@ -81,8 +81,18 @@ class TypeScriptLanguageServiceHost {
 
 	getCompilationSettings(currentDirectory) {
 		if (currentDirectory) {
-			const tsconfig = path.join(currentDirectory, 'tsconfig.json');
-			return node_require(tsconfig);
+			const configFileName = ts.findConfigFile(
+				currentDirectory,
+				ts.sys.fileExists,
+				'tsconfig.json'
+			  );
+			  const configFile = ts.readConfigFile(configFileName, ts.sys.readFile);
+			  const compilerOptions = ts.parseJsonConfigFileContent(
+				configFile.config,
+				ts.sys,
+				'./'
+			  );
+			  return compilerOptions.raw;
 		}
 
 		const options = {

--- a/source/loaders/ts_loader/bootstrap/lib/bootstrap.ts
+++ b/source/loaders/ts_loader/bootstrap/lib/bootstrap.ts
@@ -90,7 +90,7 @@ class TypeScriptLanguageServiceHost {
 			  const compilerOptions = ts.parseJsonConfigFileContent(
 				configFile.config,
 				ts.sys,
-				'./'
+				currentDirectory
 			  );
 			  return compilerOptions.raw;
 		}


### PR DESCRIPTION
I was able to load the `tsconfig.json` file from the root of the project directory. ~~One issue that I came across was that if the `tsconfig.json` file has comments in it, it doesn't work.~~
Edit: works for all types of JSON

### Example: 

This works:
```
{
  "compilerOptions": {
    "target": "es5",
    "module": "commonjs",
    "strict": true,
    "esModuleInterop": true,
    "skipLibCheck": true,
    "forceConsistentCasingInFileNames": true,
    "outDir": "dist",
    "sourceMap": true
  }
}
```

This doesn't:
```
{
  "compilerOptions": {
    "target": "es5", /* comment */
    "module": "commonjs",
    "strict": true,
    "esModuleInterop": true,
    "skipLibCheck": true,
    "forceConsistentCasingInFileNames": true,
    "outDir": "dist",
    "sourceMap": true
  }
}
```


