### PR TITLE
Fix clang-format fallback check in pre-commit hook

### DIFF
--- a/githooks/pre-commit-clang-format
+++ b/githooks/pre-commit-clang-format
@@ -24,7 +24,7 @@
 RECOMMENDED_CLANG_FORMAT_MAJOR="11"
 
 CLANG_FORMAT=`which clang-format-$RECOMMENDED_CLANG_FORMAT_MAJOR 2>/dev/null`
-if [ -z "${CLANG_FORMAT+x}" ]; then
+if [ -z "$CLANG_FORMAT" ]; then
   CLANG_FORMAT=`which clang-format 2>/dev/null`
 fi
 


### PR DESCRIPTION
# Description

If a path for `clang-format-11` is not found, the hook should instead look for a path for `clang-format` instead. This fails due to the test checking whether the `CLANG_FORMAT` variable is unset, rather than just empty. This PR fixes that.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines (Clean Code) of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [X] I have tested my code with `OPTION_BUILD_SANITIZER` and `OPTION_TEST_MEMORYCHECK`. 
- [X] I have tested with `Helgrind` in case my code works with threading. 

