### PR TITLE
format fixed for loader_impl_mock_function declaration

### DIFF
--- a/source/loaders/mock_loader/include/mock_loader/mock_loader_function_interface.h
+++ b/source/loaders/mock_loader/include/mock_loader/mock_loader_function_interface.h
@@ -31,15 +31,11 @@
 extern "C" {
 #endif
 
-struct loader_impl_mock_function_type;
-
-typedef struct loader_impl_mock_function_type *loader_impl_mock_function;
-
-struct loader_impl_mock_function_type
+typedef struct loader_impl_mock_function_type
 {
 	loader_handle handle;
 	void *function_mock_data;
-};
+} * loader_impl_mock_function;
 
 MOCK_LOADER_API function_impl_interface_singleton mock_loader_impl_function_interface(void);
 


### PR DESCRIPTION
# Description
The declaration of pointers to struct followed the following format in the loader module.
```c
typedef struct loader_impl_function_type
{
	loader_impl_function_create create;
	loader_impl_function_interface interface;
	loader_impl_function_destroy destroy;

} * loader_impl_function;
```
This was different in mock loader so, changed it to make it uniform everywhere :)


<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation Update

# Checklist:

- [x] My code follows the style guidelines (Clean Code) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested my code with `OPTION_BUILD_SANITIZER` and `OPTION_TEST_MEMORYCHECK`. 
- [ ] I have tested with `Helgrind` in case my code works with threading. 

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging) 


