### PR TITLE
Check for valid loader tag in load command

### DIFF
--- a/source/cli/metacallcli/source/application.cpp
+++ b/source/cli/metacallcli/source/application.cpp
@@ -8,7 +8,6 @@
 
 /* -- Headers -- */
 
-#include <iterator>
 #include <metacallcli/application.hpp>
 #include <metacallcli/parser.hpp>
 #include <metacallcli/tokenizer.hpp>
@@ -770,6 +769,8 @@ void application::execute(tokenizer &t)
 
 		command_debug(*it, t);
 
+		std::cout << "See `help` for list of available commands" << std::endl;
+
 		return;
 	}
 
@@ -778,6 +779,8 @@ void application::execute(tokenizer &t)
 		std::cout << "[WARNING]: Invalid command execution" << std::endl;
 
 		command_debug(*it, t);
+
+		std::cout << "See `help` for correct usage" << std::endl;
 
 		return;
 	}

--- a/source/cli/metacallcli/source/application.cpp
+++ b/source/cli/metacallcli/source/application.cpp
@@ -8,6 +8,7 @@
 
 /* -- Headers -- */
 
+#include <iterator>
 #include <metacallcli/application.hpp>
 #include <metacallcli/parser.hpp>
 #include <metacallcli/tokenizer.hpp>
@@ -375,6 +376,16 @@ bool command_cb_load(application &app, tokenizer &t)
 	if (p.is<std::string>())
 	{
 		loader_tag = *it;
+	}
+
+	std::string loaders[] = {
+		"mock", "py", "node", "rb", "cs", "cob", "ts", "js", "file"
+	};
+
+	// check if invalid loader tag
+	if (std::find(std::begin(loaders), std::end(loaders), loader_tag) == std::end(loaders))
+	{
+		return false;
 	}
 
 	do


### PR DESCRIPTION
# Description
The `load` command in the CLI didn't prompt the user if:
- No loader tag was provided
- An invalid loader tag was provided

This change handles both the cases and raises an invalid usage error in these cases.

Also, the help message have been improved to prompt the user to use the `help` command to see correct usage, or list of available commands.

### Earlier 
![image](https://user-images.githubusercontent.com/20405311/112571817-d211cb80-8e0e-11eb-9344-aa256963d10f.png)

### Now
![image](https://user-images.githubusercontent.com/20405311/112571792-c58d7300-8e0e-11eb-8b86-8f02df24ae2b.png)


## Type of change
- [x] New feature (non-breaking change which adds functionality)




# Checklist:

- [x] My code follows the style guidelines (Clean Code) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested my code with `OPTION_BUILD_SANITIZER` and `OPTION_TEST_MEMORYCHECK`. 
- [ ] I have tested with `Helgrind` in case my code works with threading. 



