### PR TITLE
[CLI] Validate function in call command

### DIFF
--- a/source/cli/metacallcli/source/application.cpp
+++ b/source/cli/metacallcli/source/application.cpp
@@ -296,8 +296,9 @@ bool command_cb_call(application &app, tokenizer &t)
 
 		else
 		{
-			std::cout << "\nCould not find function `" << func_name << "`" << std::endl;
-			std::cout << "Make sure it is loaded\n"
+			std::cout << std::endl
+					  << "Could not find function `" << func_name << "`" << std::endl;
+			std::cout << "Make sure it is loaded" << std::endl
 					  << std::endl;
 
 			metacall_allocator_destroy(allocator);


### PR DESCRIPTION
# Description
The `call` command in the CLI would just print `(null)` if the passed function had not been loaded.
This change validates if the function entered has been loaded, and if not, it prints out an error message and stops the command.

### Before 
![image](https://user-images.githubusercontent.com/20405311/116324323-8f605c00-a7dd-11eb-9291-ffbc54dee6e8.png)

### After
![image](https://user-images.githubusercontent.com/20405311/116324509-e82ff480-a7dd-11eb-9e18-f99d7e8990c6.png)


### Tests passing:
![image](https://user-images.githubusercontent.com/20405311/116324267-7788d800-a7dd-11eb-8798-990fa4e42ff4.png)



## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [x] My code follows the style guidelines (clang-format) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [x] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] I have tested my code with `OPTION_BUILD_SANITIZER` and `OPTION_TEST_MEMORYCHECK`. 
- [ ] I have tested with `Helgrind` in case my code works with threading.



