### PR TITLE
changed required llvm version in llvm_loader

### DIFF
--- a/source/loaders/llvm_loader/CMakeLists.txt
+++ b/source/loaders/llvm_loader/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 # External dependencies
 #
 
-find_package(LLVM 11.0.1 REQUIRED)
+find_package(LLVM 11 REQUIRED)
 
 #
 # Plugin name and options

--- a/source/loaders/llvm_loader/source/llvm_loader_impl.cpp
+++ b/source/loaders/llvm_loader/source/llvm_loader_impl.cpp
@@ -65,22 +65,22 @@
 	#pragma GCC diagnostic pop
 #endif
 
-using namespace llvm;
-using namespace std;
+// using namespace llvm;
+// using namespace std;
 
-using llvm::ArrayRef;
-using llvm::EngineBuilder;
-using llvm::ExecutionEngine;
-using llvm::Function;
-using llvm::GenericValue;
-using llvm::LLVMContext;
-using llvm::Module;
-using llvm::parseIRFile;
-using llvm::SMDiagnostic;
-using llvm::StringRef;
-using std::cout;
-using std::endl;
-using std::unique_ptr;
+// using llvm::ArrayRef;
+// using llvm::EngineBuilder;
+// using llvm::ExecutionEngine;
+// using llvm::Function;
+// using llvm::GenericValue;
+// using llvm::LLVMContext;
+// using llvm::Module;
+// using llvm::parseIRFile;
+// using llvm::SMDiagnostic;
+// using llvm::StringRef;
+// using std::cout;
+// using std::endl;
+// using std::unique_ptr;
 
 typedef struct loader_impl_llvm_function_type
 {
@@ -100,8 +100,8 @@ typedef struct loader_impl_llvm_handle_type
 typedef struct loader_impl_llvm_type
 {
 	// TODO: The reference to LLVM interpreter must be stored here (Is this correct?)
-	LLVMContext context;
-	SMDiagnostic error;
+	llvm::LLVMContext context;
+	llvm::SMDiagnostic error;
 
 } * loader_impl_llvm;
 
@@ -344,7 +344,7 @@ loader_handle llvm_loader_impl_load_from_package(loader_impl impl, const loader_
 	/* TODO */
 	// The same as load_from_file but this should load from binary format instead of readable format (input.ll)
 
-	(void)impl;
+	(void)llvm_impl;
 	(void)path;
 
 	// TODO: Return here the pointer to loader_impl_llvm_handle_type


### PR DESCRIPTION
# Description

Changed required llvm version in llvm_loader from 11.0.1 to 11.0.0

# Checklist:

- [ ] My code follows the style guidelines (clang-format) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_SANITIZER` and `OPTION_TEST_MEMORYCHECK`. 
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging) 


