### PR TITLE
Java loader execution path

### DIFF
--- a/source/loaders/java_loader/bootstrap/lib/bootstrap.java
+++ b/source/loaders/java_loader/bootstrap/lib/bootstrap.java
@@ -89,6 +89,8 @@ public class bootstrap {
   }
 
   public static String[] loadFromFile(String[] paths) {
+    Handle handleObject = new Handle(); // Handle Class to store classes and names
+
     // load all scripts and store them into a Handle class, then return it
     for (int i = 0; i < paths.length; i++) {
       System.out.println("Path provided " + paths[i]);
@@ -118,7 +120,7 @@ public class bootstrap {
               File execPathFile = new File(curExecPath);
               URLClassLoader clsLoader = new URLClassLoader(new URL[] { execPathFile.toURI().toURL() });
 
-              handleArray.addClass(classname, clsLoader.loadClass(classname));
+              handleObject.addClass(classname, clsLoader.loadClass(classname));
               clsLoader.close();
 
               // handleArray.addClass(classname, Class.forName(classname));
@@ -145,7 +147,9 @@ public class bootstrap {
       }
     }
 
-    return handleArray.getStringArray();
+    System.out.println(handleObject.getStringArray());
+
+    return handleObject.getStringArray();
   }
 
   public static void DiscoverData(String classname) {

--- a/source/loaders/java_loader/source/java_loader_impl.cpp
+++ b/source/loaders/java_loader/source/java_loader_impl.cpp
@@ -43,7 +43,7 @@ typedef struct loader_impl_java_type
 
 typedef struct loader_impl_java_handle_type
 {
-	jobject *handle; // Pointer to the handle JNI object
+	jobject handle; // Pointer to the handle JNI object
 
 } * loader_impl_java_handle;
 
@@ -215,7 +215,7 @@ loader_handle java_loader_impl_load_from_file(loader_impl impl, const loader_nam
 			if (mid != nullptr)
 			{
 				jobject result = java_impl->env->CallObjectMethod(classPtr, mid, arr);
-				java_handle->handle = &result;
+				java_handle->handle = result;
 
 				return static_cast<loader_handle>(java_handle);
 			}

--- a/source/loaders/java_loader/source/java_loader_impl.cpp
+++ b/source/loaders/java_loader/source/java_loader_impl.cpp
@@ -200,38 +200,26 @@ loader_handle java_loader_impl_load_from_file(loader_impl impl, const loader_nam
 
 		jobjectArray arr = java_impl->env->NewObjectArray(size, java_impl->env->FindClass("java/lang/String"), java_impl->env->NewStringUTF(""));
 
-		for (size_t i = 0; i < size; i++)
+		for (size_t i = 0; i < size; i++) // Create JNI compatible array of paths
 		{
 			std::cout << "PATH = " << paths[i] << std::endl;
 			java_impl->env->SetObjectArrayElement(arr, i, java_impl->env->NewStringUTF(paths[i]));
 		}
-		log_write("metacall", LOG_LEVEL_ERROR, "jArray Made");
 
 		jclass classPtr = java_impl->env->FindClass("bootstrap");
-		if (classPtr == nullptr)
-		{
-			log_write("metacall", LOG_LEVEL_ERROR, "Error Here");
-
-			return NULL;
-		}
-		else
+		if (classPtr != nullptr)
 		{
 			log_write("metacall", LOG_LEVEL_ERROR, "Bootstrap Found");
 
 			jmethodID mid = java_impl->env->GetStaticMethodID(classPtr, "loadFromFile", "([Ljava/lang/String;)[Ljava/lang/String;");
-			if (mid == nullptr)
-			{
-				log_write("metacall", LOG_LEVEL_ERROR, "Error Here 2");
-
-				return NULL;
-			}
-			else
+			if (mid != nullptr)
 			{
 				jobject result = java_impl->env->CallObjectMethod(classPtr, mid, arr);
+				java_handle->handle = &result;
+
+				return static_cast<loader_handle>(java_handle);
 			}
 		}
-
-		return static_cast<loader_handle>(java_handle);
 	}
 
 	return NULL;


### PR DESCRIPTION
# Description
 - Execution path bootstrap changed to  use a java set to store path and iterate over it to find and load compiled class.
 - Bootstrap load_from_file now returns a handle object to metacall which is stored in loader_impl_java_handle_type struct.

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.

Fixes #(issue_no)

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [ ] My code follows the style guidelines (clang-format) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_SANITIZER` and `OPTION_TEST_MEMORYCHECK`. 
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging) 


