### PR TITLE
Add multiple path support for loaders on impl_execution_path

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@ Fixes #(issue_no)
 - [ ] My changes generate no new warnings.
 - [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
 - [ ] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
-- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh &> output` and attached the output.
+- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh build &> output` and attached the output.
 - [ ] I have tested my code with `OPTION_BUILD_SANITIZER` and `OPTION_TEST_MEMORYCHECK`. 
 - [ ] I have tested with `Helgrind` in case my code works with threading.
 - [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

--- a/source/loaders/CMakeLists.txt
+++ b/source/loaders/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 option(OPTION_BUILD_LOADERS_C "Build C Foreign Function Interface library loader plugin." OFF)
 option(OPTION_BUILD_LOADERS_COB "Build GNU/COBOL 2.2 loader plugin." OFF)
 option(OPTION_BUILD_LOADERS_CR "Build Crystal 0.33.0 loader plugin." OFF)
-option(OPTION_BUILD_LOADERS_CS "Build C# CoreCLR 5.0.6 Runtime loader plugin." OFF)
+option(OPTION_BUILD_LOADERS_CS "Build C# CoreCLR 5.0.7 Runtime loader plugin." OFF)
 option(OPTION_BUILD_LOADERS_DART "Build Dart VM 2.8.4 Runtime loader plugin." OFF)
 option(OPTION_BUILD_LOADERS_FILE "Build File System loader plugin." OFF)
 option(OPTION_BUILD_LOADERS_JAVA "Build Java Virtual Machine loader plugin." OFF)
@@ -29,7 +29,7 @@ add_subdirectory(c_loader) # Foreign Function Interface library
 add_subdirectory(cob_loader) # GNU/Cobol 2.2 Runtime
 add_subdirectory(cr_loader) # Crystal 0.33.0 Runtime
 add_subdirectory(dart_loader) # Dart VM 2.8.4 Runtime
-add_subdirectory(cs_loader) # CoreCLR 5.0.6 Runtime
+add_subdirectory(cs_loader) # CoreCLR 5.0.7 Runtime
 add_subdirectory(file_loader) # File System
 add_subdirectory(java_loader) # Java Virtual Machine
 add_subdirectory(jl_loader) # Julia Runtime

--- a/tools/metacall-configure.sh
+++ b/tools/metacall-configure.sh
@@ -200,7 +200,7 @@ sub_configure() {
 	if [ $BUILD_NETCORE5 = 1 ]; then
 		BUILD_STRING="$BUILD_STRING \
 			-DOPTION_BUILD_LOADERS_CS=On \
-			-DDOTNET_CORE_PATH=/usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.6/"
+			-DDOTNET_CORE_PATH=/usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.7/"
 
 		if [ $BUILD_SCRIPTS = 1 ]; then
 			BUILD_STRING="$BUILD_STRING -DOPTION_BUILD_SCRIPTS_CS=On"

--- a/tools/metacall-environment.sh
+++ b/tools/metacall-environment.sh
@@ -339,7 +339,7 @@ sub_metacall(){
 	elif [ INSTALL_NETCORE2 = 1 ]; then
 		NETCORE_VERSION=2.2.8
 	elif [ INSTALL_NETCORE5 = 1 ]; then
-		NETCORE_VERSION=5.0.6
+		NETCORE_VERSION=5.0.7
 	else
 		NETCORE_VERSION=0
 	fi

--- a/tools/metacall-runtime.sh
+++ b/tools/metacall-runtime.sh
@@ -128,7 +128,7 @@ sub_netcore5(){
 	rm packages-microsoft-prod.deb
 
 	$SUDO_CMD apt-get update
-	sub_apt_install_hold dotnet-runtime-5.0=5.0.6-1
+	sub_apt_install_hold dotnet-runtime-5.0=5.0.7-1
 }
 
 # V8


### PR DESCRIPTION
# Description

Instead of implementing the path splitting in each loader, the execution_path function will be called every time a new path has to be appended.

TODO: Test it on Windows?? Although it should work as it is right now.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [x] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_SANITIZER` and `OPTION_TEST_MEMORYCHECK`. 
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
