### PR TITLE
Wasm loader: Add support for multiple return values

### DIFF
--- a/source/loaders/wasm_loader/source/wasm_loader_impl.c
+++ b/source/loaders/wasm_loader/source/wasm_loader_impl.c
@@ -142,6 +142,24 @@ value wasm_loader_impl_wasm_to_reflect_type(wasm_val_t val)
 	}
 }
 
+value wasm_loader_impl_wasm_results_to_reflect_type(const wasm_val_vec_t *results)
+{
+	if (results->size == 1)
+	{
+		return wasm_loader_impl_wasm_to_reflect_type(results->data[0]);
+	}
+	else
+	{
+		value values[results->size];
+		for (size_t idx = 0; idx < results->size; idx++)
+		{
+			values[idx] = wasm_loader_impl_wasm_to_reflect_type(results->data[idx]);
+		}
+
+		return value_create_array(values, results->size);
+	}
+}
+
 void wasm_loader_impl_log_trap(const wasm_trap_t *trap)
 {
 	wasm_byte_vec_t message;
@@ -173,9 +191,7 @@ value wasm_loader_impl_call_func(const signature sig, const wasm_func_t *func, c
 	}
 	else if (signature_get_return(sig) != NULL)
 	{
-		// TODO: Add support for multiple returns
-		wasm_val_t wasm_ret = results.data[0];
-		ret = wasm_loader_impl_wasm_to_reflect_type(wasm_ret);
+		ret = wasm_loader_impl_wasm_results_to_reflect_type(&results);
 	}
 
 	wasm_val_vec_delete(&results);
@@ -269,6 +285,7 @@ int wasm_loader_impl_initialize_types(loader_impl impl)
 		{ TYPE_LONG, "i64" },
 		{ TYPE_FLOAT, "f32" },
 		{ TYPE_DOUBLE, "f64" },
+		{ TYPE_ARRAY, "array" },
 	};
 
 	const size_t size = COUNT_OF(type_names);
@@ -652,14 +669,8 @@ int wasm_loader_impl_discover_function(loader_impl impl, scope scp, const wasm_e
 
 	if (results->size > 0)
 	{
-		// TODO: Add support for multiple return values
-		if (results->size > 1)
-		{
-			log_write("metacall", LOG_LEVEL_WARNING, "WebAssembly loader does not support multiple return values yet, using first return value");
-		}
-
-		signature_set_return(sig,
-			wasm_loader_impl_val_kind_to_type(impl, wasm_valtype_kind(results->data[0])));
+		type ret_type = results->size == 1 ? wasm_loader_impl_val_kind_to_type(impl, wasm_valtype_kind(results->data[0])) : loader_impl_type(impl, "array");
+		signature_set_return(sig, ret_type);
 	}
 
 	for (size_t param_idx = 0; param_idx < params->size; param_idx++)

--- a/source/tests/wasm_loader_test/source/wasm_loader_test.cpp
+++ b/source/tests/wasm_loader_test/source/wasm_loader_test.cpp
@@ -110,9 +110,8 @@ TEST_F(wasm_loader_test, DiscoverFunctions)
 	TestFunction(handle, "i32_f32_i64_f64_ret_none", { METACALL_INT, METACALL_FLOAT, METACALL_LONG, METACALL_DOUBLE }, METACALL_INVALID);
 	TestFunction(handle, "none_ret_i32", {}, METACALL_INT);
 
-	// TODO: Add support for multiple return values
-	TestFunction(handle, "none_ret_i32_f32_i64_f64", {}, METACALL_INT);
-	TestFunction(handle, "i32_f32_i64_f64_ret_i32_f32_i64_f64", { METACALL_INT, METACALL_FLOAT, METACALL_LONG, METACALL_DOUBLE }, METACALL_INT);
+	TestFunction(handle, "none_ret_i32_f32_i64_f64", {}, METACALL_ARRAY);
+	TestFunction(handle, "i32_f32_i64_f64_ret_i32_f32_i64_f64", { METACALL_INT, METACALL_FLOAT, METACALL_LONG, METACALL_DOUBLE }, METACALL_ARRAY);
 }
 
 TEST_F(wasm_loader_test, CallFunctions)
@@ -135,15 +134,32 @@ TEST_F(wasm_loader_test, CallFunctions)
 	ASSERT_EQ(1, metacall_value_to_int(ret));
 	metacall_value_destroy(ret);
 
-	// TODO: Add support for multiple return values
 	ret = metacall("none_ret_i32_f32_i64_f64");
-	ASSERT_EQ(METACALL_INT, metacall_value_id(ret));
-	ASSERT_EQ(1, metacall_value_to_int(ret));
+	ASSERT_EQ(METACALL_ARRAY, metacall_value_id(ret));
+
+	void **values = metacall_value_to_array(ret);
+	ASSERT_EQ(METACALL_INT, metacall_value_id(values[0]));
+	ASSERT_EQ(METACALL_FLOAT, metacall_value_id(values[1]));
+	ASSERT_EQ(METACALL_LONG, metacall_value_id(values[2]));
+	ASSERT_EQ(METACALL_DOUBLE, metacall_value_id(values[3]));
+	ASSERT_EQ(1, metacall_value_to_int(values[0]));
+	ASSERT_EQ(2, metacall_value_to_float(values[1]));
+	ASSERT_EQ(3, metacall_value_to_long(values[2]));
+	ASSERT_EQ(4, metacall_value_to_double(values[3]));
 	metacall_value_destroy(ret);
 
 	ret = metacall("i32_f32_i64_f64_ret_i32_f32_i64_f64", 0, 0, 0, 0);
-	ASSERT_EQ(METACALL_INT, metacall_value_id(ret));
-	ASSERT_EQ(1, metacall_value_to_int(ret));
+	ASSERT_EQ(METACALL_ARRAY, metacall_value_id(ret));
+
+	values = metacall_value_to_array(ret);
+	ASSERT_EQ(METACALL_INT, metacall_value_id(values[0]));
+	ASSERT_EQ(METACALL_FLOAT, metacall_value_id(values[1]));
+	ASSERT_EQ(METACALL_LONG, metacall_value_id(values[2]));
+	ASSERT_EQ(METACALL_DOUBLE, metacall_value_id(values[3]));
+	ASSERT_EQ(1, metacall_value_to_int(values[0]));
+	ASSERT_EQ(2, metacall_value_to_float(values[1]));
+	ASSERT_EQ(3, metacall_value_to_long(values[2]));
+	ASSERT_EQ(4, metacall_value_to_double(values[3]));
 	metacall_value_destroy(ret);
 
 	// The return value should be NULL when a trap is reached


### PR DESCRIPTION
# Description
This PR adds support for multiple return values to the Wasm loader. If a function has more than one return value, calling the function from Metacall will now return an array containing the values instead.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [X] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [X] I have tested my code with `OPTION_BUILD_SANITIZER` and `OPTION_TEST_MEMORYCHECK`. 
- [X] I have run `make clang-format` in order to format my code and my code follows the style guidelines.