### PR TITLE
Add support for Wasm text format

### DIFF
--- a/cmake/FindWasmtime.cmake
+++ b/cmake/FindWasmtime.cmake
@@ -57,9 +57,9 @@ find_library(WASMTIME_LIBRARY
 )
 
 find_path(WASMTIME_INCLUDE_DIR
-	NAMES wasm.h
+	NAMES wasm.h wasmtime.h
 	PATHS ${WASMTIME_DOWNLOAD_INCLUDE_DIR}
-	DOC "Wasm C API header"
+	DOC "Wasmtime C API headers"
 )
 
 if(WASMTIME_LIBRARY AND WASMTIME_INCLUDE_DIR)
@@ -103,9 +103,9 @@ else()
 	)
 
 	find_path(WASMTIME_INCLUDE_DIR
-		NAMES wasm.h
+		NAMES wasm.h wasmtime.h
 		PATHS ${WASMTIME_DOWNLOAD_INCLUDE_DIR}
 		NO_DEFAULT_PATH
-		DOC "Wasm C API header"
+		DOC "Wasmtime C API headers"
 	)
 endif()

--- a/source/tests/wasm_loader_test/source/wasm_loader_test.cpp
+++ b/source/tests/wasm_loader_test/source/wasm_loader_test.cpp
@@ -72,9 +72,9 @@ TEST_F(wasm_loader_test, InitializeAndDestroy)
 	ASSERT_EQ(0, metacall_destroy());
 }
 
-TEST_F(wasm_loader_test, LoadFromMemory)
+TEST_F(wasm_loader_test, LoadBinaryFromMemory)
 {
-	// See https://webassembly.github.io/spec/core/binary/modules.html#binary-magic
+	// See https://webassembly.github.io/spec/core/binary/modules.html#binary-module
 	const char empty_module[] = {
 		0x00, 0x61, 0x73, 0x6d, // Magic bytes
 		0x01, 0x00, 0x00, 0x00	// Version
@@ -85,20 +85,35 @@ TEST_F(wasm_loader_test, LoadFromMemory)
 	ASSERT_NE(0, metacall_load_from_memory("wasm", invalid_module, sizeof(invalid_module), NULL));
 }
 
+TEST_F(wasm_loader_test, LoadTextFromMemory)
+{
+	const char *empty_module = "(module)";
+	ASSERT_EQ(0, metacall_load_from_memory("wasm", empty_module, strlen(empty_module), NULL));
+
+	const char *invalid_module = "(invalid)";
+	ASSERT_NE(0, metacall_load_from_memory("wasm", invalid_module, strlen(invalid_module), NULL));
+}
+
 // TODO: Make this conditional
 //#if defined(OPTION_BUILD_SCRIPTS) && defined(OPTION_BUILD_SCRIPTS_WASM)
 TEST_F(wasm_loader_test, LoadFromFile)
 {
-	const char *empty_module_filename = "empty_module.wasm";
-	const char *invalid_module_filename = "invalid_module.wasm";
+	const char *empty_module_filename = "empty_module.wat";
+	const char *invalid_module_filename = "invalid_module.wat";
 
 	ASSERT_EQ(0, metacall_load_from_file("wasm", &empty_module_filename, 1, NULL));
 	ASSERT_NE(0, metacall_load_from_file("wasm", &invalid_module_filename, 1, NULL));
 }
 
+TEST_F(wasm_loader_test, LoadFromPackage)
+{
+	ASSERT_EQ(0, metacall_load_from_package("wasm", "empty_module.wasm", NULL));
+	ASSERT_NE(0, metacall_load_from_package("wasm", "invalid_module.wasm", NULL));
+}
+
 TEST_F(wasm_loader_test, DiscoverFunctions)
 {
-	const char *functions_module_filename = "functions.wasm";
+	const char *functions_module_filename = "functions.wat";
 	void *handle;
 
 	ASSERT_EQ(0, metacall_load_from_file("wasm", &functions_module_filename, 1, &handle));
@@ -116,7 +131,7 @@ TEST_F(wasm_loader_test, DiscoverFunctions)
 
 TEST_F(wasm_loader_test, CallFunctions)
 {
-	const char *functions_module_filename = "functions.wasm";
+	const char *functions_module_filename = "functions.wat";
 
 	ASSERT_EQ(0, metacall_load_from_file("wasm", &functions_module_filename, 1, NULL));
 


### PR DESCRIPTION
# Description

This PR adds support for the Wasm text format in addition to the binary format.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [X] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [X] I have tested my code with `OPTION_BUILD_SANITIZER` and `OPTION_TEST_MEMORYCHECK`. 
- [X] I have run `make clang-format` in order to format my code and my code follows the style guidelines.