### PR TITLE
Add support for imports to Wasm loader

### DIFF
--- a/source/scripts/wasm/tests/source/exports1.wat
+++ b/source/scripts/wasm/tests/source/exports1.wat
@@ -1,0 +1,9 @@
+(module
+  (memory (export "memory") 1)
+  (table (export "table") 1 funcref)
+  (global (export "immutable_global") i32 (i32.const 1))
+  (global (export "mutable_global") (mut i32) (i32.const 1))
+  (func (export "duplicate_func") (result i32)
+    i32.const 1
+  )
+)

--- a/source/scripts/wasm/tests/source/exports2.wat
+++ b/source/scripts/wasm/tests/source/exports2.wat
@@ -1,0 +1,5 @@
+(module
+  (func (export "duplicate_func") (result i64)
+    i64.const 2
+  )
+)

--- a/source/scripts/wasm/tests/source/imports.wat
+++ b/source/scripts/wasm/tests/source/imports.wat
@@ -1,0 +1,12 @@
+(module
+  (import "exports1" "memory" (memory 1))
+  (import "exports1" "table" (table 1 funcref))
+  (import "exports1" "immutable_global" (global i32))
+  (import "exports1" "mutable_global" (global (mut i32)))
+
+  (import "exports1" "duplicate_func" (func $duplicate_func_i32 (result i32)))
+  (import "exports2" "duplicate_func" (func $duplicate_func_i64 (result i64)))
+
+  (func (export "duplicate_func_i32") (result i32) (call $duplicate_func_i32))
+  (func (export "duplicate_func_i64") (result i64) (call $duplicate_func_i64))
+)

--- a/source/tests/wasm_loader_test/source/wasm_loader_test.cpp
+++ b/source/tests/wasm_loader_test/source/wasm_loader_test.cpp
@@ -181,3 +181,35 @@ TEST_F(wasm_loader_test, CallFunctions)
 	ret = metacall("trap");
 	ASSERT_EQ(NULL, ret);
 }
+
+TEST_F(wasm_loader_test, LinkModules)
+{
+	const char *modules[] = {
+		"exports1.wat",
+		"exports2.wat",
+		"imports.wat"
+	};
+
+	// FIXME: Duplicate symbols cause memory leak from `reflect`
+	ASSERT_EQ(0, metacall_load_from_file("wasm", modules, sizeof(modules) / sizeof(modules[0]), NULL));
+
+	void *ret = metacall("duplicate_func_i32");
+	ASSERT_EQ(METACALL_INT, metacall_value_id(ret));
+	ASSERT_EQ(1, metacall_value_to_int(ret));
+	metacall_value_destroy(ret);
+
+	ret = metacall("duplicate_func_i64");
+	ASSERT_EQ(METACALL_LONG, metacall_value_id(ret));
+	ASSERT_EQ(2, metacall_value_to_long(ret));
+	metacall_value_destroy(ret);
+}
+
+TEST_F(wasm_loader_test, InvalidLinkModules)
+{
+	const char *modules[] = {
+		"exports1.wat",
+		"imports.wat"
+	};
+
+	ASSERT_EQ(1, metacall_load_from_file("wasm", modules, sizeof(modules) / sizeof(modules[0]), NULL));
+}


### PR DESCRIPTION
# Description

This PR adds support for imports to the Wasm loader using a linker that looks in previously loaded handles for matching exports.

Note that the `LinkingModules` test takes a while to run under Memcheck, so the timeout of 60 seconds may be reached on slower PCs.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [X] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [X] I have tested my code with `OPTION_BUILD_SANITIZER` and `OPTION_TEST_MEMORYCHECK`. 
- [X] I have run `make clang-format` in order to format my code and my code follows the style guidelines.