### PR TITLE
Add loading from package to Python port

### DIFF
--- a/source/loader/source/loader_impl.c
+++ b/source/loader/source/loader_impl.c
@@ -852,7 +852,7 @@ int loader_impl_load_from_package(loader_impl impl, const loader_naming_path pat
 
 		loader_naming_name package_name;
 
-		if (interface_impl != NULL && loader_path_get_name(path, package_name) > 1)
+		if (interface_impl != NULL && loader_path_get_fullname(path, package_name) > 1)
 		{
 			loader_handle handle;
 

--- a/source/scripts/python/wasm_test/source/wasm_test.py
+++ b/source/scripts/python/wasm_test/source/wasm_test.py
@@ -3,8 +3,11 @@
 from metacall import metacall, metacall_load_from_file
 
 import empty_module.wat
+import empty_module.wasm
 
-from functions.wat import *
+# We can't import both functions.wasm and functions.wat here because their
+# definitions would collide.
+from functions.wasm import *
 
 assert none_ret_none() is None
 assert i32_ret_none(0) is None
@@ -16,12 +19,18 @@ assert trap() is None
 
 # We test an invalid load file attempt first to avoid polluting the global
 # handle for the next test.
-assert not metacall_load_from_file(
-    "wasm", ["exports1.wat", "imports.wat"]
-)
+assert not metacall_load_from_file("wasm", ["exports1.wat", "imports.wat"])
 
 assert metacall_load_from_file(
     "wasm", ["exports1.wat", "exports2.wat", "imports.wat"]
 )
 assert metacall("duplicate_func_i32") == 1
 assert metacall("duplicate_func_i64") == 2
+
+for module in ("invalid_module.wat", "invalid_module.wasm"):
+    try:
+        __import__(module)
+    except ImportError:
+        pass
+    else:
+        raise AssertionError("Importing an invalid module should result in an ImportError")


### PR DESCRIPTION
# Description

This PR adds support for loading from a package to the Python port using the `import` keyword by checking the file extension.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [X] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [X] I have tested my code with `OPTION_BUILD_SANITIZER` and `OPTION_TEST_MEMORYCHECK`. 
- [X] I have run `make clang-format` in order to format my code and my code follows the style guidelines.