### PR TITLE
Refactor Wasm loader

### DIFF
--- a/source/loaders/wasm_loader/CMakeLists.txt
+++ b/source/loaders/wasm_loader/CMakeLists.txt
@@ -48,11 +48,15 @@ set(source_path  "${CMAKE_CURRENT_SOURCE_DIR}/source")
 set(headers
 	${include_path}/wasm_loader.h
 	${include_path}/wasm_loader_impl.h
+	${include_path}/wasm_loader_function.h
+	${include_path}/wasm_loader_handle.h
 )
 
 set(sources
 	${source_path}/wasm_loader.c
 	${source_path}/wasm_loader_impl.c
+	${source_path}/wasm_loader_function.c
+	${source_path}/wasm_loader_handle.c
 )
 
 # Group source files

--- a/source/loaders/wasm_loader/include/wasm_loader/wasm_loader_function.h
+++ b/source/loaders/wasm_loader/include/wasm_loader/wasm_loader_function.h
@@ -1,0 +1,43 @@
+/*
+ *	Loader Library by Parra Studios
+ *	A plugin for loading WebAssembly code at run-time into a process.
+ *
+ *	Copyright (C) 2016 - 2021 Vicente Eduardo Ferrer Garcia <vic798@gmail.com>
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *	Unless required by applicable law or agreed to in writing, software
+ *	distributed under the License is distributed on an "AS IS" BASIS,
+ *	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *	See the License for the specific language governing permissions and
+ *	limitations under the License.
+ *
+ */
+
+#ifndef WASM_LOADER_FUNCTION_H
+#define WASM_LOADER_FUNCTION_H 1
+
+#include <wasm_loader/wasm_loader_api.h>
+
+#include <reflect/reflect_function.h>
+
+#include <wasm.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct loader_impl_wasm_function_type *loader_impl_wasm_function;
+
+WASM_LOADER_API function_interface function_wasm_singleton(void);
+WASM_LOADER_API loader_impl_wasm_function loader_impl_wasm_function_create(const wasm_func_t *func);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WASM_LOADER_FUNCTION_H */

--- a/source/loaders/wasm_loader/include/wasm_loader/wasm_loader_handle.h
+++ b/source/loaders/wasm_loader/include/wasm_loader/wasm_loader_handle.h
@@ -1,0 +1,48 @@
+/*
+ *	Loader Library by Parra Studios
+ *	A plugin for loading WebAssembly code at run-time into a process.
+ *
+ *	Copyright (C) 2016 - 2021 Vicente Eduardo Ferrer Garcia <vic798@gmail.com>
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *	Unless required by applicable law or agreed to in writing, software
+ *	distributed under the License is distributed on an "AS IS" BASIS,
+ *	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *	See the License for the specific language governing permissions and
+ *	limitations under the License.
+ *
+ */
+
+#ifndef WASM_LOADER_HANDLE_H
+#define WASM_LOADER_HANDLE_H 1
+
+#include <loader/loader.h>
+
+#include <wasm_loader/wasm_loader_api.h>
+
+#include <adt/adt_vector.h>
+
+#include <wasm.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct loader_impl_wasm_handle_type *loader_impl_wasm_handle;
+typedef struct loader_impl_wasm_module_type loader_impl_wasm_module;
+
+WASM_LOADER_API loader_impl_wasm_handle wasm_loader_handle_create(size_t num_modules);
+WASM_LOADER_API void wasm_loader_handle_destroy(loader_impl_wasm_handle handle);
+WASM_LOADER_API int wasm_loader_handle_add_module(loader_impl_wasm_handle handle, const loader_naming_name name, wasm_store_t *store, const wasm_byte_vec_t *binary);
+WASM_LOADER_API int wasm_loader_handle_discover(loader_impl impl, loader_impl_wasm_handle handle, scope scp);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WASM_LOADER_HANDLE_H */

--- a/source/loaders/wasm_loader/include/wasm_loader/wasm_loader_impl.h
+++ b/source/loaders/wasm_loader/include/wasm_loader/wasm_loader_impl.h
@@ -25,26 +25,17 @@
 
 #include <loader/loader_impl_interface.h>
 
-#include <configuration/configuration.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 WASM_LOADER_API loader_impl_data wasm_loader_impl_initialize(loader_impl impl, configuration config);
-
 WASM_LOADER_API int wasm_loader_impl_execution_path(loader_impl impl, const loader_naming_path path);
-
 WASM_LOADER_API loader_handle wasm_loader_impl_load_from_file(loader_impl impl, const loader_naming_path paths[], size_t size);
-
 WASM_LOADER_API loader_handle wasm_loader_impl_load_from_memory(loader_impl impl, const loader_naming_name name, const char *buffer, size_t size);
-
 WASM_LOADER_API loader_handle wasm_loader_impl_load_from_package(loader_impl impl, const loader_naming_path path);
-
 WASM_LOADER_API int wasm_loader_impl_clear(loader_impl impl, loader_handle handle);
-
 WASM_LOADER_API int wasm_loader_impl_discover(loader_impl impl, loader_handle handle, context ctx);
-
 WASM_LOADER_API int wasm_loader_impl_destroy(loader_impl impl);
 
 #ifdef __cplusplus

--- a/source/loaders/wasm_loader/source/wasm_loader_function.c
+++ b/source/loaders/wasm_loader/source/wasm_loader_function.c
@@ -1,0 +1,198 @@
+#include <wasm_loader/wasm_loader_function.h>
+
+#include <reflect/reflect_type.h>
+#include <reflect/reflect_value_type.h>
+
+#include <log/log.h>
+
+#include <wasm.h>
+
+struct loader_impl_wasm_function_type
+{
+	const wasm_func_t *func;
+};
+
+static function_return function_wasm_interface_invoke(function func, function_impl impl, function_args args, size_t args_size);
+static void function_wasm_interface_destroy(function func, function_impl impl);
+
+function_interface function_wasm_singleton(void)
+{
+	static struct function_interface_type wasm_function_interface = {
+		NULL,
+		&function_wasm_interface_invoke,
+		// Threads are only in Phase 2 of the standardization process
+		// (see https://github.com/WebAssembly/proposals) and are currently
+		// not fully implemented in Wasmtime
+		// (see https://docs.wasmtime.dev/stability-wasm-proposals-support.html)
+		NULL,
+		&function_wasm_interface_destroy
+	};
+
+	return &wasm_function_interface;
+}
+
+loader_impl_wasm_function loader_impl_wasm_function_create(const wasm_func_t *func)
+{
+	loader_impl_wasm_function func_impl = malloc(sizeof(struct loader_impl_wasm_function_type));
+	if (func_impl == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Failed to allocate memory for function handle");
+		return NULL;
+	}
+
+	// Ugly hack to subvert the type system and initialize a const member
+	*(wasm_func_t **)&func_impl->func = (wasm_func_t *)func;
+
+	return func_impl;
+}
+
+static int reflect_to_wasm_type(value val, wasm_val_t *ret)
+{
+	type_id val_type = value_type_id(val);
+	if (val_type == TYPE_INT)
+	{
+		*ret = (wasm_val_t)WASM_I32_VAL(value_to_int(val));
+	}
+	else if (val_type == TYPE_LONG)
+	{
+		*ret = (wasm_val_t)WASM_I64_VAL(value_to_long(val));
+	}
+	else if (val_type == TYPE_FLOAT)
+	{
+		*ret = (wasm_val_t)WASM_F32_VAL(value_to_float(val));
+	}
+	else if (val_type == TYPE_DOUBLE)
+	{
+		*ret = (wasm_val_t)WASM_F64_VAL(value_to_double(val));
+	}
+	else
+	{
+		return 1;
+	}
+
+	return 0;
+}
+
+static value wasm_to_reflect_type(wasm_val_t val)
+{
+	if (val.kind == WASM_I32)
+	{
+		return value_create_int(val.of.i32);
+	}
+	else if (val.kind == WASM_I64)
+	{
+		return value_create_long(val.of.i64);
+	}
+	else if (val.kind == WASM_F32)
+	{
+		return value_create_float(val.of.f32);
+	}
+	else if (val.kind == WASM_F64)
+	{
+		return value_create_double(val.of.f64);
+	}
+	else
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Unrecognized Wasm value kind (kind %d)", val.kind);
+		return NULL;
+	}
+}
+
+static value wasm_results_to_reflect_type(const wasm_val_vec_t *results)
+{
+	if (results->size == 1)
+	{
+		return wasm_to_reflect_type(results->data[0]);
+	}
+	else
+	{
+		value values[results->size];
+		for (size_t idx = 0; idx < results->size; idx++)
+		{
+			values[idx] = wasm_to_reflect_type(results->data[idx]);
+		}
+
+		return value_create_array(values, results->size);
+	}
+}
+
+static void log_trap(const wasm_trap_t *trap)
+{
+	wasm_byte_vec_t message;
+	wasm_trap_message(trap, &message);
+	log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Executed trap with message \"%s\"", message.data);
+	wasm_byte_vec_delete(&message);
+}
+
+static value call_func(const signature sig, const wasm_func_t *func, const wasm_val_vec_t args)
+{
+	// No way to check if vector allocation fails
+	wasm_val_vec_t results;
+	wasm_val_vec_new_uninitialized(&results, wasm_func_result_arity(func));
+
+	wasm_trap_t *trap = wasm_func_call(func, &args, &results);
+
+	value ret = NULL;
+	if (trap != NULL)
+	{
+		// BEWARE: Wasmtime executes an undefined instruction in order to
+		// transfer control to its trap handlers, which can cause Valgrind and
+		// other debuggers to act out. In Valgrind, this can be suppressed
+		// using the `--sigill-diagnostics=no` flag. Other debuggers support
+		// similar behavior.
+		// See https://github.com/bytecodealliance/wasmtime/issues/3061 for
+		// more information
+		log_trap(trap);
+		wasm_trap_delete(trap);
+	}
+	else if (signature_get_return(sig) != NULL)
+	{
+		ret = wasm_results_to_reflect_type(&results);
+	}
+
+	wasm_val_vec_delete(&results);
+	return ret;
+}
+
+static function_return function_wasm_interface_invoke(function func, function_impl impl, function_args args, size_t args_size)
+{
+	loader_impl_wasm_function wasm_func = (loader_impl_wasm_function)impl;
+	signature sig = function_signature(func);
+
+	if (args_size != signature_count(sig))
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Invalid number of arguments (%d expected, %d given)", args_size, signature_count(sig));
+		return NULL;
+	}
+
+	wasm_val_t wasm_args[args_size];
+	for (size_t idx = 0; idx < args_size; idx++)
+	{
+		type param_type = signature_get_type(sig, idx);
+		type_id param_type_id = type_index(param_type);
+		type_id arg_type_id = value_type_id(args[idx]);
+
+		if (param_type_id != arg_type_id)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Invalid type for argument %d (expected %d, was %d)", idx, param_type_id, arg_type_id);
+			return NULL;
+		}
+
+		if (reflect_to_wasm_type(args[idx], &wasm_args[idx]) != 0)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Unsupported type for argument %d", idx);
+			return NULL;
+		}
+	}
+
+	const wasm_val_vec_t args_vec = WASM_ARRAY_VEC(wasm_args);
+
+	return call_func(sig, wasm_func->func, args_vec);
+}
+
+static void function_wasm_interface_destroy(function func, function_impl impl)
+{
+	(void)func;
+
+	free((loader_impl_wasm_function)impl);
+}

--- a/source/loaders/wasm_loader/source/wasm_loader_handle.c
+++ b/source/loaders/wasm_loader/source/wasm_loader_handle.c
@@ -1,0 +1,385 @@
+#include <wasm_loader/wasm_loader_function.h>
+#include <wasm_loader/wasm_loader_handle.h>
+
+#include <log/log.h>
+
+struct loader_impl_wasm_module_type
+{
+	loader_naming_name name;
+	wasm_module_t *module;
+	wasm_instance_t *instance;
+	wasm_extern_vec_t exports;
+	wasm_exporttype_vec_t export_types;
+	wasm_extern_vec_t imports;
+};
+
+struct loader_impl_wasm_handle_type
+{
+	vector modules;
+};
+
+static int discover_module(loader_impl impl, scope scp, const loader_impl_wasm_module *module);
+static int initialize_module_imports(loader_impl_wasm_handle handle, loader_impl_wasm_module *module);
+static void delete_module(loader_impl_wasm_module *module);
+
+loader_impl_wasm_handle wasm_loader_handle_create(size_t num_modules)
+{
+	loader_impl_wasm_handle handle = malloc(sizeof(struct loader_impl_wasm_handle_type));
+
+	if (handle == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Failed to allocate memory for handle");
+		goto error_handle_alloc;
+	}
+
+	handle->modules = vector_create_reserve_type(loader_impl_wasm_module, num_modules);
+
+	if (handle->modules == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Failed to allocate memory for modules");
+		goto error_modules_alloc;
+	}
+
+	return handle;
+
+error_modules_alloc:
+	free(handle);
+error_handle_alloc:
+	return NULL;
+}
+
+void wasm_loader_handle_destroy(loader_impl_wasm_handle handle)
+{
+	for (size_t idx = 0; idx < vector_size(handle->modules); idx++)
+	{
+		loader_impl_wasm_module *module = vector_at(handle->modules, idx);
+		delete_module(module);
+	}
+
+	vector_destroy(handle->modules);
+	free(handle);
+}
+
+int wasm_loader_handle_add_module(loader_impl_wasm_handle handle, const loader_naming_name name, wasm_store_t *store, const wasm_byte_vec_t *binary)
+{
+	loader_impl_wasm_module module;
+	module.module = wasm_module_new(store, binary);
+
+	if (module.module == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Failed to create module");
+		goto error_module_new;
+	}
+
+	if (initialize_module_imports(handle, &module) != 0)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Could not satisfy all imports required by module");
+		goto error_initialize_imports;
+	}
+
+	strncpy(module.name, name, sizeof(module.name));
+
+	// There is no way to check whether `wasm_module_exports` or
+	// `wasm_instance_new` fail, so just hope for the best.
+	wasm_module_exports(module.module, &module.export_types);
+
+	module.instance = wasm_instance_new(store, module.module, &module.imports, NULL);
+	wasm_instance_exports(module.instance, &module.exports);
+
+	vector_push_back_var(handle->modules, module);
+
+	return 0;
+
+error_initialize_imports:
+	wasm_module_delete(module.module);
+error_module_new:
+	return 1;
+}
+
+int wasm_loader_handle_discover(loader_impl impl, loader_impl_wasm_handle handle, scope scp)
+{
+	for (size_t idx = 0; idx < vector_size(handle->modules); idx++)
+	{
+		if (discover_module(impl, scp, vector_at(handle->modules, idx)) != 0)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Handle discovery failed");
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+static bool is_same_valtype(const wasm_valtype_t *a, const wasm_valtype_t *b)
+{
+	return wasm_valtype_kind(a) == wasm_valtype_kind(b);
+}
+
+static bool is_same_valtype_vec(const wasm_valtype_vec_t *a, const wasm_valtype_vec_t *b)
+{
+	if (a->size != b->size)
+	{
+		return false;
+	}
+
+	for (size_t i = 0; i < a->size; i++)
+	{
+		if (!is_same_valtype(a->data[i], b->data[i]))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static type valkind_to_type(loader_impl impl, wasm_valkind_t kind)
+{
+	switch (kind)
+	{
+		case WASM_I32:
+			return loader_impl_type(impl, "i32");
+		case WASM_I64:
+			return loader_impl_type(impl, "i64");
+		case WASM_F32:
+			return loader_impl_type(impl, "f32");
+		case WASM_F64:
+			return loader_impl_type(impl, "f64");
+		default:
+			return NULL;
+	}
+}
+
+static char *get_export_type_name(const wasm_exporttype_t *export_type)
+{
+	const wasm_name_t *name = wasm_exporttype_name(export_type);
+	char *null_terminated_name = malloc(name->size + 1);
+
+	if (null_terminated_name == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Failed to allocate memory for name of export type");
+		return NULL;
+	}
+
+	strncpy(null_terminated_name, name->data, name->size);
+	null_terminated_name[name->size] = '\0';
+
+	return null_terminated_name;
+}
+
+static int discover_function(loader_impl impl, scope scp, const wasm_externtype_t *extern_type, const char *name, const wasm_extern_t *extern_val)
+{
+	if (scope_get(scp, name) != NULL)
+	{
+		log_write("metacall", LOG_LEVEL_WARNING, "WebAssembly loader: A function named \"%s\" is already defined, skipping redefinition", name);
+		return 0;
+	}
+
+	const wasm_functype_t *func_type =
+		wasm_externtype_as_functype_const(extern_type);
+	const wasm_valtype_vec_t *params = wasm_functype_params(func_type);
+	const wasm_valtype_vec_t *results = wasm_functype_results(func_type);
+
+	loader_impl_wasm_function func_impl = loader_impl_wasm_function_create(wasm_extern_as_func_const(extern_val));
+	if (func_impl == NULL)
+	{
+		return 1;
+	}
+
+	function func = function_create(name, params->size, func_impl, &function_wasm_singleton);
+	signature sig = function_signature(func);
+
+	if (results->size > 0)
+	{
+		type ret_type = results->size == 1 ? valkind_to_type(impl, wasm_valtype_kind(results->data[0])) : loader_impl_type(impl, "array");
+		signature_set_return(sig, ret_type);
+	}
+
+	for (size_t param_idx = 0; param_idx < params->size; param_idx++)
+	{
+		signature_set(sig, param_idx, "unnamed",
+			valkind_to_type(impl, wasm_valtype_kind(params->data[param_idx])));
+	}
+
+	scope_define(scp, function_name(func), value_create_function(func));
+
+	return 0;
+}
+
+static int discover_export(loader_impl impl, scope scp, const wasm_exporttype_t *export_type, const wasm_extern_t *export)
+{
+	int ret = 1;
+
+	// All of the `wasm_*` calls here return pointers to memory owned by
+	// `export_types`, so no need to do any error checking or cleanup.
+	const wasm_externtype_t *extern_type = wasm_exporttype_type(export_type);
+	const wasm_externkind_t kind = wasm_externtype_kind(extern_type);
+	char *export_name = get_export_type_name(export_type);
+
+	if (export_name == NULL)
+	{
+		goto error_export_name_alloc;
+	}
+
+	if (kind == WASM_EXTERN_FUNC)
+	{
+		if (discover_function(impl, scp, extern_type, export_name, export) != 0)
+		{
+			goto error_discover_function;
+		}
+	}
+
+	ret = 0;
+
+error_discover_function:
+	free(export_name);
+error_export_name_alloc:
+	return ret;
+}
+
+static int discover_module(loader_impl impl, scope scp, const loader_impl_wasm_module *module)
+{
+	for (size_t i = 0; i < module->export_types.size; i++)
+	{
+		// There is a 1-to-1 correspondence between between the instance
+		// exports and the module exports, so we can use the same index.
+		const wasm_exporttype_t *export_type = module->export_types.data[i];
+		const wasm_extern_t *export = module->exports.data[i];
+		if (discover_export(impl, scp, export_type, export) != 0)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Module discovery failed");
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+static bool is_suitable_limit(const wasm_limits_t *import, const wasm_limits_t *export)
+{
+	return import->min <= export->min && import->max <= export->max;
+}
+
+static bool matches_memory_import(const wasm_memorytype_t *import, const wasm_memorytype_t *export)
+{
+	return is_suitable_limit(wasm_memorytype_limits(import), wasm_memorytype_limits(export));
+}
+
+static bool matches_func_import(const wasm_functype_t *import, const wasm_functype_t *export)
+{
+	return is_same_valtype_vec(wasm_functype_params(import), wasm_functype_params(export)) &&
+		   is_same_valtype_vec(wasm_functype_results(import), wasm_functype_results(export));
+}
+
+static bool matches_table_import(const wasm_tabletype_t *import, const wasm_tabletype_t *export)
+{
+	return is_same_valtype(wasm_tabletype_element(import), wasm_tabletype_element(export)) && is_suitable_limit(wasm_tabletype_limits(import), wasm_tabletype_limits(export));
+}
+
+static bool matches_global_import(const wasm_globaltype_t *import, const wasm_globaltype_t *export)
+{
+	return is_same_valtype(wasm_globaltype_content(import), wasm_globaltype_content(export)) && wasm_globaltype_mutability(import) == wasm_globaltype_mutability(export);
+}
+
+static bool matches_import(const wasm_externtype_t *import, const wasm_externtype_t *export)
+{
+	const wasm_externkind_t import_kind = wasm_externtype_kind(import);
+	const wasm_externkind_t export_kind = wasm_externtype_kind(export);
+
+	if (import_kind != export_kind)
+	{
+		return false;
+	}
+
+	if (import_kind == WASM_EXTERN_FUNC)
+	{
+		return matches_func_import(wasm_externtype_as_functype_const(import), wasm_externtype_as_functype_const(export));
+	}
+	else if (import_kind == WASM_EXTERN_MEMORY)
+	{
+		return matches_memory_import(wasm_externtype_as_memorytype_const(import), wasm_externtype_as_memorytype_const(export));
+	}
+	else if (import_kind == WASM_EXTERN_TABLE)
+	{
+		return matches_table_import(wasm_externtype_as_tabletype_const(import), wasm_externtype_as_tabletype_const(export));
+	}
+	else if (import_kind == WASM_EXTERN_GLOBAL)
+	{
+		return matches_global_import(wasm_externtype_as_globaltype_const(import), wasm_externtype_as_globaltype_const(export));
+	}
+	else
+	{
+		return false;
+	}
+}
+
+static const wasm_extern_t *find_export(loader_impl_wasm_handle handle, const wasm_importtype_t *import_type)
+{
+	const wasm_name_t *module_name = wasm_importtype_module(import_type);
+	const wasm_name_t *name = wasm_importtype_name(import_type);
+	const wasm_externtype_t *type = wasm_importtype_type(import_type);
+
+	for (size_t module_idx = 0; module_idx < vector_size(handle->modules); module_idx++)
+	{
+		loader_impl_wasm_module *module = vector_at(handle->modules, module_idx);
+
+		// module->name is null-terminated, so no need to compare sizes first
+		if (strncmp(module->name, module_name->data, module_name->size) != 0)
+		{
+			continue;
+		}
+
+		for (size_t export_idx = 0; export_idx < module->exports.size; export_idx++)
+		{
+			const wasm_name_t *export_name = wasm_exporttype_name(module->export_types.data[export_idx]);
+			wasm_externtype_t *export_type = wasm_extern_type(module->exports.data[export_idx]);
+
+			if (export_name->size == name->size && strncmp(export_name->data, name->data, name->size) == 0 &&
+				matches_import(type, export_type))
+			{
+				wasm_externtype_delete(export_type);
+				return module->exports.data[export_idx];
+			}
+
+			wasm_externtype_delete(export_type);
+		}
+	}
+
+	return NULL;
+}
+
+static int initialize_module_imports(loader_impl_wasm_handle handle, loader_impl_wasm_module *module)
+{
+	wasm_importtype_vec_t import_types;
+	wasm_module_imports(module->module, &import_types);
+	wasm_extern_vec_new_uninitialized(&module->imports, import_types.size);
+
+	for (size_t i = 0; i < import_types.size; i++)
+	{
+		const wasm_extern_t *import = find_export(handle, import_types.data[i]);
+
+		if (import == NULL)
+		{
+			goto error_find_import;
+		}
+
+		module->imports.data[i] = wasm_extern_copy(import);
+	}
+
+	wasm_importtype_vec_delete(&import_types);
+	return 0;
+
+error_find_import:
+	wasm_extern_vec_delete(&module->imports);
+	wasm_importtype_vec_delete(&import_types);
+	return 1;
+}
+
+static void delete_module(loader_impl_wasm_module *module)
+{
+	wasm_exporttype_vec_delete(&module->export_types);
+	wasm_extern_vec_delete(&module->exports);
+	wasm_instance_delete(module->instance);
+	wasm_extern_vec_delete(&module->imports);
+	wasm_module_delete(module->module);
+}

--- a/source/loaders/wasm_loader/source/wasm_loader_impl.c
+++ b/source/loaders/wasm_loader/source/wasm_loader_impl.c
@@ -18,49 +18,26 @@
  *
  */
 
+#include <wasm_loader/wasm_loader_function.h>
+#include <wasm_loader/wasm_loader_handle.h>
 #include <wasm_loader/wasm_loader_impl.h>
 
 #include <loader/loader.h>
 #include <loader/loader_impl.h>
 
 #include <reflect/reflect_context.h>
-#include <reflect/reflect_function.h>
 #include <reflect/reflect_scope.h>
 #include <reflect/reflect_type.h>
 
 #include <log/log.h>
 
-#include <adt/adt_vector.h>
-
 #include <stdlib.h>
-
-#include <wasm.h>
 
 #ifdef WASMTIME
 	#include <wasmtime.h>
 #endif
 
 #define COUNT_OF(array) (sizeof(array) / sizeof(array[0]))
-
-typedef struct loader_impl_wasm_function_type
-{
-	const wasm_func_t *func;
-} * loader_impl_wasm_function;
-
-typedef struct loader_impl_wasm_module_type
-{
-	loader_naming_name name;
-	wasm_module_t *module;
-	wasm_instance_t *instance;
-	wasm_extern_vec_t exports;
-	wasm_exporttype_vec_t export_types;
-	wasm_extern_vec_t imports;
-} loader_impl_wasm_module;
-
-typedef struct loader_impl_wasm_handle_type
-{
-	vector modules;
-} * loader_impl_wasm_handle;
 
 typedef struct loader_impl_wasm_type
 {
@@ -69,204 +46,15 @@ typedef struct loader_impl_wasm_type
 	vector paths;
 } * loader_impl_wasm;
 
-int wasm_loader_impl_reflect_to_wasm_type(value val, wasm_val_t *ret)
-{
-	type_id val_type = value_type_id(val);
-	if (val_type == TYPE_INT)
-	{
-		*ret = (wasm_val_t)WASM_I32_VAL(value_to_int(val));
-	}
-	else if (val_type == TYPE_LONG)
-	{
-		*ret = (wasm_val_t)WASM_I64_VAL(value_to_long(val));
-	}
-	else if (val_type == TYPE_FLOAT)
-	{
-		*ret = (wasm_val_t)WASM_F32_VAL(value_to_float(val));
-	}
-	else if (val_type == TYPE_DOUBLE)
-	{
-		*ret = (wasm_val_t)WASM_F64_VAL(value_to_double(val));
-	}
-	else
-	{
-		return 1;
-	}
+static int initialize_types(loader_impl impl);
 
-	return 0;
-}
+static FILE *open_file_absolute(const char *path, size_t *file_size);
+static FILE *open_file_relative(loader_impl_wasm impl, const char *path, size_t *file_size);
+static char *read_buffer_from_file(loader_impl impl, const char *path, size_t *file_size);
 
-value wasm_loader_impl_wasm_to_reflect_type(wasm_val_t val)
-{
-	if (val.kind == WASM_I32)
-	{
-		return value_create_int(val.of.i32);
-	}
-	else if (val.kind == WASM_I64)
-	{
-		return value_create_long(val.of.i64);
-	}
-	else if (val.kind == WASM_F32)
-	{
-		return value_create_float(val.of.f32);
-	}
-	else if (val.kind == WASM_F64)
-	{
-		return value_create_double(val.of.f64);
-	}
-	else
-	{
-		log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Unrecognized Wasm value kind (kind %d)", val.kind);
-		return NULL;
-	}
-}
-
-value wasm_loader_impl_wasm_results_to_reflect_type(const wasm_val_vec_t *results)
-{
-	if (results->size == 1)
-	{
-		return wasm_loader_impl_wasm_to_reflect_type(results->data[0]);
-	}
-	else
-	{
-		value values[results->size];
-		for (size_t idx = 0; idx < results->size; idx++)
-		{
-			values[idx] = wasm_loader_impl_wasm_to_reflect_type(results->data[idx]);
-		}
-
-		return value_create_array(values, results->size);
-	}
-}
-
-void wasm_loader_impl_log_trap(const wasm_trap_t *trap)
-{
-	wasm_byte_vec_t message;
-	wasm_trap_message(trap, &message);
-	log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Executed trap with message \"%s\"", message.data);
-	wasm_byte_vec_delete(&message);
-}
-
-value wasm_loader_impl_call_func(const signature sig, const wasm_func_t *func, const wasm_val_vec_t args)
-{
-	// No way to check if vector allocation fails
-	wasm_val_vec_t results;
-	wasm_val_vec_new_uninitialized(&results, wasm_func_result_arity(func));
-
-	wasm_trap_t *trap = wasm_func_call(func, &args, &results);
-
-	value ret = NULL;
-	if (trap != NULL)
-	{
-		// BEWARE: Wasmtime executes an undefined instruction in order to
-		// transfer control to its trap handlers, which can cause Valgrind and
-		// other debuggers to act out. In Valgrind, this can be suppressed
-		// using the `--sigill-diagnostics=no` flag. Other debuggers support
-		// similar behavior.
-		// See https://github.com/bytecodealliance/wasmtime/issues/3061 for
-		// more information
-		wasm_loader_impl_log_trap(trap);
-		wasm_trap_delete(trap);
-	}
-	else if (signature_get_return(sig) != NULL)
-	{
-		ret = wasm_loader_impl_wasm_results_to_reflect_type(&results);
-	}
-
-	wasm_val_vec_delete(&results);
-	return ret;
-}
-
-function_return function_wasm_interface_invoke(function func, function_impl impl, function_args args, size_t args_size)
-{
-	loader_impl_wasm_function wasm_func = (loader_impl_wasm_function)impl;
-	signature sig = function_signature(func);
-
-	if (args_size != signature_count(sig))
-	{
-		log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Invalid number of arguments (%d expected, %d given)", args_size, signature_count(sig));
-		return NULL;
-	}
-
-	// TODO: How lenient should we be with types? For now, we just assume
-	//       arguments are the exact types required
-	wasm_val_t wasm_args[args_size];
-	for (size_t idx = 0; idx < args_size; idx++)
-	{
-		// TODO: This causes an invalid read for some reason
-#if 0
-		type param_type = signature_get_type(sig, idx);
-		type_id param_type_id = value_type_id(param_type);
-		type_id arg_type_id = value_type_id(args[idx]);
-
-		if (param_type_id != arg_type_id)
-		{
-            log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Invalid type for argument %d", idx);
-			return NULL;
-		}
-#endif
-
-		if (wasm_loader_impl_reflect_to_wasm_type(args[idx], &wasm_args[idx]) != 0)
-		{
-			log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Invalid type for argument %d", idx);
-			return NULL;
-		}
-	}
-
-	const wasm_val_vec_t args_vec = WASM_ARRAY_VEC(wasm_args);
-
-	return wasm_loader_impl_call_func(sig, wasm_func->func, args_vec);
-}
-
-void function_wasm_interface_destroy(function func, function_impl impl)
-{
-	(void)func;
-
-	free((loader_impl_wasm_function)impl);
-}
-
-function_interface function_wasm_singleton(void)
-{
-	static struct function_interface_type wasm_function_interface = {
-		NULL,
-		&function_wasm_interface_invoke,
-		// Threads are only in Phase 2 of the standardization process
-		// (see https://github.com/WebAssembly/proposals) and are currently
-		// not fully implemented in Wasmtime
-		// (see https://docs.wasmtime.dev/stability-wasm-proposals-support.html)
-		NULL,
-		&function_wasm_interface_destroy
-	};
-
-	return &wasm_function_interface;
-}
-
-int wasm_loader_impl_initialize_types(loader_impl impl)
-{
-	// TODO: Implement ANYREF and FUNCREF?
-	static struct
-	{
-		type_id id;
-		const char *name;
-	} type_names[] = {
-		{ TYPE_INT, "i32" },
-		{ TYPE_LONG, "i64" },
-		{ TYPE_FLOAT, "f32" },
-		{ TYPE_DOUBLE, "f64" },
-		{ TYPE_ARRAY, "array" },
-	};
-
-	const size_t size = COUNT_OF(type_names);
-
-	for (size_t i = 0; i < size; i++)
-	{
-		// TODO: Do we need error handling here?
-		type t = type_create(type_names[i].id, type_names[i].name, NULL, NULL);
-		loader_impl_type_define(impl, type_name(t), t);
-	}
-
-	return 0;
-}
+static int try_wat2wasm(const char *buffer, size_t size, wasm_byte_vec_t *binary);
+static int load_module_from_package(loader_impl impl, loader_impl_wasm_handle handle, const char *path);
+static int load_module_from_file(loader_impl impl, loader_impl_wasm_handle handle, const char *path);
 
 loader_impl_data wasm_loader_impl_initialize(loader_impl impl, configuration config)
 {
@@ -280,7 +68,7 @@ loader_impl_data wasm_loader_impl_initialize(loader_impl impl, configuration con
 		goto error_impl_alloc;
 	}
 
-	if (wasm_loader_impl_initialize_types(impl) != 0)
+	if (initialize_types(impl) != 0)
 	{
 		log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Failed to initialize types");
 		goto error_types_init;
@@ -337,7 +125,155 @@ int wasm_loader_impl_execution_path(loader_impl impl, const loader_naming_path p
 	return 0;
 }
 
-FILE *wasm_loader_impl_open_file_absolute(const char *path, size_t *file_size)
+loader_handle wasm_loader_impl_load_from_file(loader_impl impl, const loader_naming_path paths[], size_t size)
+{
+	loader_impl_wasm_handle handle = wasm_loader_handle_create(size);
+
+	if (handle == NULL)
+	{
+		goto error_alloc_handle;
+	}
+
+	for (size_t idx = 0; idx < size; idx++)
+	{
+		if (load_module_from_file(impl, handle, paths[idx]) != 0)
+		{
+			goto error_load_module;
+		}
+	}
+
+	return handle;
+
+error_load_module:
+	wasm_loader_impl_clear(impl, handle);
+error_alloc_handle:
+	return NULL;
+}
+
+loader_handle wasm_loader_impl_load_from_memory(loader_impl impl, const loader_naming_name name, const char *buffer, size_t size)
+{
+	loader_impl_wasm wasm_impl = loader_impl_get(impl);
+	loader_impl_wasm_handle handle = wasm_loader_handle_create(1);
+
+	if (handle == NULL)
+	{
+		goto error_alloc_handle;
+	}
+
+	wasm_byte_vec_t binary;
+	// There is sadly no way to check whether `wasm_byte_vec_new`
+	// fails, so we just have to hope for the best here.
+	wasm_byte_vec_new(&binary, size, buffer);
+	if (!wasm_module_validate(wasm_impl->store, &binary))
+	{
+		log_write("metacall", LOG_LEVEL_DEBUG, "WebAssembly loader: Buffer is not valid binary module, trying wat2wasm");
+
+		wasm_byte_vec_delete(&binary);
+		if (try_wat2wasm(buffer, size, &binary) != 0)
+		{
+			goto error_convert_buffer;
+		}
+	}
+
+	if (wasm_loader_handle_add_module(handle, name, wasm_impl->store, &binary) != 0)
+	{
+		goto error_load_module;
+	}
+
+	wasm_byte_vec_delete(&binary);
+
+	return handle;
+
+error_load_module:
+	wasm_byte_vec_delete(&binary);
+error_convert_buffer:
+	wasm_loader_impl_clear(impl, handle);
+error_alloc_handle:
+	return NULL;
+}
+
+loader_handle wasm_loader_impl_load_from_package(loader_impl impl, const loader_naming_path path)
+{
+	loader_impl_wasm_handle handle = wasm_loader_handle_create(1);
+
+	if (handle == NULL)
+	{
+		goto error_alloc_handle;
+	}
+
+	if (load_module_from_package(impl, handle, path) != 0)
+	{
+		goto error_load_module;
+	}
+
+	return handle;
+
+error_load_module:
+	wasm_loader_impl_clear(impl, handle);
+error_alloc_handle:
+	return NULL;
+}
+
+int wasm_loader_impl_clear(loader_impl impl, loader_handle handle)
+{
+	(void)impl;
+
+	wasm_loader_handle_destroy(handle);
+
+	return 0;
+}
+
+int wasm_loader_impl_discover(loader_impl impl, loader_handle handle, context ctx)
+{
+	return wasm_loader_handle_discover(impl, handle, context_scope(ctx));
+}
+
+int wasm_loader_impl_destroy(loader_impl impl)
+{
+	loader_impl_wasm wasm_impl = loader_impl_get(impl);
+	loader_unload_children(impl);
+	vector_destroy(wasm_impl->paths);
+	wasm_store_delete(wasm_impl->store);
+	wasm_engine_delete(wasm_impl->engine);
+	free(wasm_impl);
+
+	log_write("metacall", LOG_LEVEL_DEBUG, "WebAssembly loader destroyed");
+
+	return 0;
+}
+
+static int initialize_types(loader_impl impl)
+{
+	// TODO: Implement ANYREF and FUNCREF?
+	static struct
+	{
+		type_id id;
+		const char *name;
+	} type_names[] = {
+		{ TYPE_INT, "i32" },
+		{ TYPE_LONG, "i64" },
+		{ TYPE_FLOAT, "f32" },
+		{ TYPE_DOUBLE, "f64" },
+		{ TYPE_ARRAY, "array" },
+	};
+
+	const size_t size = COUNT_OF(type_names);
+
+	for (size_t i = 0; i < size; i++)
+	{
+		type t = type_create(type_names[i].id, type_names[i].name, NULL, NULL);
+		if (t == NULL)
+		{
+			return 1;
+		}
+
+		loader_impl_type_define(impl, type_name(t), t);
+	}
+
+	return 0;
+}
+
+static FILE *open_file_absolute(const char *path, size_t *file_size)
 {
 	FILE *file = fopen(path, "rb");
 	if (file == NULL)
@@ -367,17 +303,18 @@ error_open_file:
 	return NULL;
 }
 
-FILE *wasm_loader_impl_open_file_relative(loader_impl_wasm impl, const char *path, size_t *file_size)
+static FILE *open_file_relative(loader_impl_wasm impl, const char *path, size_t *file_size)
 {
 	for (size_t i = 0; i < vector_size(impl->paths); i++)
 	{
 		loader_naming_path *exec_path = vector_at(impl->paths, i);
 
-		// FIXME: This could fail if the resulting path is longer than sizeof(loader_naming_path)
+		// FIXME: This could fail if the resulting path is longer than sizeof(loader_naming_path).
+		//        This should probably be handled in `loader_path_join`.
 		loader_naming_path abs_path;
 		(void)loader_path_join(*exec_path, strlen(*exec_path) + 1, path, strlen(path) + 1, abs_path);
 
-		FILE *file = wasm_loader_impl_open_file_absolute(abs_path, file_size);
+		FILE *file = open_file_absolute(abs_path, file_size);
 
 		if (file == NULL)
 		{
@@ -392,218 +329,11 @@ FILE *wasm_loader_impl_open_file_relative(loader_impl_wasm impl, const char *pat
 	return NULL;
 }
 
-loader_impl_wasm_handle wasm_loader_impl_create_handle(size_t num_modules)
-{
-	loader_impl_wasm_handle handle = malloc(sizeof(struct loader_impl_wasm_handle_type));
-
-	if (handle == NULL)
-	{
-		log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Failed to allocate memory for handle");
-		goto error_handle_alloc;
-	}
-
-	handle->modules = vector_create_reserve_type(loader_impl_wasm_module, num_modules);
-
-	if (handle->modules == NULL)
-	{
-		log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Failed to allocate memory for modules");
-		goto error_modules_alloc;
-	}
-
-	return handle;
-
-error_modules_alloc:
-	free(handle);
-error_handle_alloc:
-	return NULL;
-}
-
-bool wasm_loader_impl_is_same_valtype(const wasm_valtype_t *a, const wasm_valtype_t *b)
-{
-	return wasm_valtype_kind(a) == wasm_valtype_kind(b);
-}
-
-bool wasm_loader_impl_is_same_valtype_vec(const wasm_valtype_vec_t *a, const wasm_valtype_vec_t *b)
-{
-	if (a->size != b->size)
-	{
-		return false;
-	}
-
-	for (size_t i = 0; i < a->size; i++)
-	{
-		if (!wasm_loader_impl_is_same_valtype(a->data[i], b->data[i]))
-		{
-			return false;
-		}
-	}
-
-	return true;
-}
-
-bool wasm_loader_impl_is_suitable_limit(const wasm_limits_t *import, const wasm_limits_t *export)
-{
-	return import->min <= export->min && import->max <= export->max;
-}
-
-bool wasm_loader_impl_matches_memory_import(const wasm_memorytype_t *import, const wasm_memorytype_t *export)
-{
-	return wasm_loader_impl_is_suitable_limit(wasm_memorytype_limits(import), wasm_memorytype_limits(export));
-}
-
-bool wasm_loader_impl_matches_func_import(const wasm_functype_t *import, const wasm_functype_t *export)
-{
-	return wasm_loader_impl_is_same_valtype_vec(wasm_functype_params(import), wasm_functype_params(export)) &&
-		   wasm_loader_impl_is_same_valtype_vec(wasm_functype_results(import), wasm_functype_results(export));
-}
-
-bool wasm_loader_impl_matches_table_import(const wasm_tabletype_t *import, const wasm_tabletype_t *export)
-{
-	return wasm_loader_impl_is_same_valtype(wasm_tabletype_element(import), wasm_tabletype_element(export)) && wasm_loader_impl_is_suitable_limit(wasm_tabletype_limits(import), wasm_tabletype_limits(export));
-}
-
-bool wasm_loader_impl_matches_global_import(const wasm_globaltype_t *import, const wasm_globaltype_t *export)
-{
-	return wasm_loader_impl_is_same_valtype(wasm_globaltype_content(import), wasm_globaltype_content(export)) && wasm_globaltype_mutability(import) == wasm_globaltype_mutability(export);
-}
-
-bool wasm_loader_impl_matches_import(const wasm_externtype_t *import, const wasm_externtype_t *export)
-{
-	const wasm_externkind_t import_kind = wasm_externtype_kind(import);
-	const wasm_externkind_t export_kind = wasm_externtype_kind(export);
-
-	if (import_kind != export_kind)
-	{
-		return false;
-	}
-
-	if (import_kind == WASM_EXTERN_FUNC)
-	{
-		return wasm_loader_impl_matches_func_import(wasm_externtype_as_functype_const(import), wasm_externtype_as_functype_const(export));
-	}
-	else if (import_kind == WASM_EXTERN_MEMORY)
-	{
-		return wasm_loader_impl_matches_memory_import(wasm_externtype_as_memorytype_const(import), wasm_externtype_as_memorytype_const(export));
-	}
-	else if (import_kind == WASM_EXTERN_TABLE)
-	{
-		return wasm_loader_impl_matches_table_import(wasm_externtype_as_tabletype_const(import), wasm_externtype_as_tabletype_const(export));
-	}
-	else if (import_kind == WASM_EXTERN_GLOBAL)
-	{
-		return wasm_loader_impl_matches_global_import(wasm_externtype_as_globaltype_const(import), wasm_externtype_as_globaltype_const(export));
-	}
-	else
-	{
-		return false;
-	}
-}
-
-const wasm_extern_t *wasm_loader_impl_find_export(loader_impl_wasm_handle handle, const wasm_importtype_t *import_type)
-{
-	const wasm_name_t *module_name = wasm_importtype_module(import_type);
-	const wasm_name_t *name = wasm_importtype_name(import_type);
-	const wasm_externtype_t *type = wasm_importtype_type(import_type);
-
-	for (size_t module_idx = 0; module_idx < vector_size(handle->modules); module_idx++)
-	{
-		loader_impl_wasm_module *module = vector_at(handle->modules, module_idx);
-
-		// module->name is null-terminated, so no need to compare sizes first
-		if (strncmp(module->name, module_name->data, module_name->size) != 0)
-		{
-			continue;
-		}
-
-		for (size_t export_idx = 0; export_idx < module->exports.size; export_idx++)
-		{
-			const wasm_name_t *export_name = wasm_exporttype_name(module->export_types.data[export_idx]);
-			wasm_externtype_t *export_type = wasm_extern_type(module->exports.data[export_idx]);
-
-			if (export_name->size == name->size && strncmp(export_name->data, name->data, name->size) == 0 &&
-				wasm_loader_impl_matches_import(type, export_type))
-			{
-				wasm_externtype_delete(export_type);
-				return module->exports.data[export_idx];
-			}
-
-			wasm_externtype_delete(export_type);
-		}
-	}
-
-	return NULL;
-}
-
-int wasm_loader_impl_module_initialize_imports(loader_impl_wasm_handle handle, loader_impl_wasm_module *module)
-{
-	wasm_importtype_vec_t import_types;
-	wasm_module_imports(module->module, &import_types);
-	wasm_extern_vec_new_uninitialized(&module->imports, import_types.size);
-
-	for (size_t i = 0; i < import_types.size; i++)
-	{
-		const wasm_extern_t *import = wasm_loader_impl_find_export(handle, import_types.data[i]);
-
-		if (import == NULL)
-		{
-			goto error_find_import;
-		}
-
-		module->imports.data[i] = wasm_extern_copy(import);
-	}
-
-	wasm_importtype_vec_delete(&import_types);
-	return 0;
-
-error_find_import:
-	wasm_extern_vec_delete(&module->imports);
-	wasm_importtype_vec_delete(&import_types);
-	return 1;
-}
-
-int wasm_loader_impl_handle_add_module(loader_impl impl, loader_impl_wasm_handle handle, const loader_naming_name name, const wasm_byte_vec_t *binary)
+static char *read_buffer_from_file(loader_impl impl, const char *path, size_t *file_size)
 {
 	loader_impl_wasm wasm_impl = loader_impl_get(impl);
 
-	loader_impl_wasm_module module;
-	module.module = wasm_module_new(wasm_impl->store, binary);
-
-	if (module.module == NULL)
-	{
-		log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Failed to create module");
-		goto error_module_new;
-	}
-
-	if (wasm_loader_impl_module_initialize_imports(handle, &module) != 0)
-	{
-		log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Could not satisfy all imports required by module");
-		goto error_initialize_imports;
-	}
-
-	strncpy(module.name, name, sizeof(module.name));
-
-	// There is no way to check whether `wasm_module_exports` or
-	// `wasm_instance_new` fail, so just hope for the best.
-	wasm_module_exports(module.module, &module.export_types);
-
-	module.instance = wasm_instance_new(wasm_impl->store, module.module, &module.imports, NULL);
-	wasm_instance_exports(module.instance, &module.exports);
-
-	vector_push_back_var(handle->modules, module);
-
-	return 0;
-
-error_initialize_imports:
-	wasm_module_delete(module.module);
-error_module_new:
-	return 1;
-}
-
-char *wasm_loader_impl_read_buffer_from_file(loader_impl impl, const char *path, size_t *file_size)
-{
-	loader_impl_wasm wasm_impl = loader_impl_get(impl);
-
-	FILE *file = wasm_loader_impl_open_file_relative(wasm_impl, path, file_size);
+	FILE *file = open_file_relative(wasm_impl, path, file_size);
 
 	if (file == NULL)
 	{
@@ -637,7 +367,7 @@ error_open_file:
 }
 
 #ifdef WASMTIME
-void wasm_loader_impl_handle_wasmtime_error(wasmtime_error_t *error)
+static void wasm_loader_impl_handle_wasmtime_error(wasmtime_error_t *error)
 {
 	wasm_name_t message;
 	wasmtime_error_message(error, &message);
@@ -649,7 +379,7 @@ void wasm_loader_impl_handle_wasmtime_error(wasmtime_error_t *error)
 }
 #endif
 
-int wasm_loader_impl_try_wat2wasm(const char *buffer, size_t size, wasm_byte_vec_t *binary)
+static int try_wat2wasm(const char *buffer, size_t size, wasm_byte_vec_t *binary)
 {
 #ifdef WASMTIME
 	wasmtime_error_t *error = wasmtime_wat2wasm(buffer, size, binary);
@@ -662,121 +392,21 @@ int wasm_loader_impl_try_wat2wasm(const char *buffer, size_t size, wasm_byte_vec
 
 	return 0;
 #else
+	(void)buffer;
+	(void)size;
+	(void)binary;
+
 	log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Current WebAssembly runtime does not support conversion from text format to binary format");
 	return 1;
 #endif
 }
 
-int wasm_loader_impl_load_module_from_file(loader_impl impl, loader_impl_wasm_handle handle, const char *path)
-{
-	static const loader_naming_tag TEXT_EXTENSION = "wat";
-
-	int ret = 1;
-
-	size_t size;
-	char *buffer = wasm_loader_impl_read_buffer_from_file(impl, path, &size);
-
-	if (buffer == NULL)
-	{
-		goto error_read_file;
-	}
-
-	wasm_byte_vec_t binary;
-	if (wasm_loader_impl_try_wat2wasm(buffer, size, &binary) != 0)
-	{
-		goto error_convert_buffer;
-	}
-
-	loader_naming_name module_name;
-	loader_path_get_module_name(path, module_name, TEXT_EXTENSION);
-	if (wasm_loader_impl_handle_add_module(impl, handle, module_name, &binary) != 0)
-	{
-		goto error_add_module;
-	}
-
-	ret = 0;
-
-error_add_module:
-	wasm_byte_vec_delete(&binary);
-error_convert_buffer:
-error_read_file:
-	free(buffer);
-	return ret;
-}
-
-loader_handle wasm_loader_impl_load_from_file(loader_impl impl, const loader_naming_path paths[], size_t size)
-{
-	loader_impl_wasm_handle handle = wasm_loader_impl_create_handle(size);
-
-	if (handle == NULL)
-	{
-		goto error_alloc_handle;
-	}
-
-	for (size_t idx = 0; idx < size; idx++)
-	{
-		if (wasm_loader_impl_load_module_from_file(impl, handle, paths[idx]) != 0)
-		{
-			goto error_load_module;
-		}
-	}
-
-	return handle;
-
-error_load_module:
-	wasm_loader_impl_clear(impl, handle);
-error_alloc_handle:
-	return NULL;
-}
-
-loader_handle wasm_loader_impl_load_from_memory(loader_impl impl, const loader_naming_name name, const char *buffer, size_t size)
-{
-	loader_impl_wasm wasm_impl = loader_impl_get(impl);
-	loader_impl_wasm_handle handle = wasm_loader_impl_create_handle(1);
-
-	if (handle == NULL)
-	{
-		goto error_alloc_handle;
-	}
-
-	wasm_byte_vec_t binary;
-	// There is sadly no way to check whether `wasm_byte_vec_new`
-	// fails, so we just have to hope for the best here.
-	wasm_byte_vec_new(&binary, size, buffer);
-	if (!wasm_module_validate(wasm_impl->store, &binary))
-	{
-		log_write("metacall", LOG_LEVEL_DEBUG, "WebAssembly loader: Buffer is not valid binary module, trying wat2wasm");
-
-		wasm_byte_vec_delete(&binary);
-		if (wasm_loader_impl_try_wat2wasm(buffer, size, &binary) != 0)
-		{
-			goto error_convert_buffer;
-		}
-	}
-
-	if (wasm_loader_impl_handle_add_module(impl, handle, name, &binary) != 0)
-	{
-		goto error_load_module;
-	}
-
-	wasm_byte_vec_delete(&binary);
-
-	return handle;
-
-error_load_module:
-	wasm_byte_vec_delete(&binary);
-error_convert_buffer:
-	wasm_loader_impl_clear(impl, handle);
-error_alloc_handle:
-	return NULL;
-}
-
-int wasm_loader_impl_load_module_from_package(loader_impl impl, loader_impl_wasm_handle handle, const char *path)
+static int load_module_from_package(loader_impl impl, loader_impl_wasm_handle handle, const char *path)
 {
 	int ret = 1;
 
 	size_t size;
-	char *buffer = wasm_loader_impl_read_buffer_from_file(impl, path, &size);
+	char *buffer = read_buffer_from_file(impl, path, &size);
 
 	if (buffer == NULL)
 	{
@@ -788,7 +418,9 @@ int wasm_loader_impl_load_module_from_package(loader_impl impl, loader_impl_wasm
 
 	loader_naming_name module_name;
 	loader_path_get_name(path, module_name);
-	if (wasm_loader_impl_handle_add_module(impl, handle, module_name, &binary) != 0)
+
+	loader_impl_wasm wasm_impl = loader_impl_get(impl);
+	if (wasm_loader_handle_add_module(handle, module_name, wasm_impl->store, &binary) != 0)
 	{
 		goto error_add_module;
 	}
@@ -802,203 +434,41 @@ error_read_file:
 	return ret;
 }
 
-loader_handle wasm_loader_impl_load_from_package(loader_impl impl, const loader_naming_path path)
+static int load_module_from_file(loader_impl impl, loader_impl_wasm_handle handle, const char *path)
 {
-	loader_impl_wasm_handle handle = wasm_loader_impl_create_handle(1);
+	static const loader_naming_tag TEXT_EXTENSION = "wat";
 
-	if (handle == NULL)
-	{
-		goto error_alloc_handle;
-	}
-
-	if (wasm_loader_impl_load_module_from_package(impl, handle, path) != 0)
-	{
-		goto error_load_module;
-	}
-
-	return handle;
-
-error_load_module:
-	wasm_loader_impl_clear(impl, handle);
-error_alloc_handle:
-	return NULL;
-}
-
-int wasm_loader_impl_clear(loader_impl impl, loader_handle handle)
-{
-	(void)impl;
-
-	loader_impl_wasm_handle wasm_handle = (loader_impl_wasm_handle)handle;
-
-	// TODO: Refactor into separate function
-	for (size_t idx = 0; idx < vector_size(wasm_handle->modules); idx++)
-	{
-		loader_impl_wasm_module *module = vector_at(wasm_handle->modules, idx);
-		wasm_exporttype_vec_delete(&module->export_types);
-		wasm_extern_vec_delete(&module->exports);
-		wasm_instance_delete(module->instance);
-		wasm_extern_vec_delete(&module->imports);
-		wasm_module_delete(module->module);
-	}
-
-	vector_destroy(wasm_handle->modules);
-	free(wasm_handle);
-
-	return 0;
-}
-
-type wasm_loader_impl_val_kind_to_type(loader_impl impl, wasm_valkind_t kind)
-{
-	switch (kind)
-	{
-		case WASM_I32:
-			return loader_impl_type(impl, "i32");
-		case WASM_I64:
-			return loader_impl_type(impl, "i64");
-		case WASM_F32:
-			return loader_impl_type(impl, "f32");
-		case WASM_F64:
-			return loader_impl_type(impl, "f64");
-		default:
-			return NULL;
-	}
-}
-
-char *wasm_loader_impl_get_export_type_name(const wasm_exporttype_t *export_type)
-{
-	const wasm_name_t *name = wasm_exporttype_name(export_type);
-	char *null_terminated_name = malloc(name->size + 1);
-
-	if (null_terminated_name == NULL)
-	{
-		log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Failed to allocate memory for name of export type");
-		return NULL;
-	}
-
-	strncpy(null_terminated_name, name->data, name->size);
-	null_terminated_name[name->size] = '\0';
-
-	return null_terminated_name;
-}
-
-int wasm_loader_impl_discover_function(loader_impl impl, scope scp, const wasm_externtype_t *extern_type, const char *name, const wasm_extern_t *extern_val)
-{
-	if (scope_get(scp, name) != NULL)
-	{
-		log_write("metacall", LOG_LEVEL_WARNING, "WebAssembly loader: A function named \"%s\" is already defined, skipping redefinition", name);
-		return 0;
-	}
-
-	const wasm_functype_t *func_type =
-		wasm_externtype_as_functype_const(extern_type);
-	const wasm_valtype_vec_t *params = wasm_functype_params(func_type);
-	const wasm_valtype_vec_t *results = wasm_functype_results(func_type);
-
-	loader_impl_wasm_function func_impl = malloc(sizeof(struct loader_impl_wasm_function_type));
-	if (func_impl == NULL)
-	{
-		log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Failed to allocate memory for function handle");
-		return 1;
-	}
-
-	func_impl->func = wasm_extern_as_func_const(extern_val);
-
-	function func = function_create(name, params->size, func_impl, &function_wasm_singleton);
-	signature sig = function_signature(func);
-
-	if (results->size > 0)
-	{
-		type ret_type = results->size == 1 ? wasm_loader_impl_val_kind_to_type(impl, wasm_valtype_kind(results->data[0])) : loader_impl_type(impl, "array");
-		signature_set_return(sig, ret_type);
-	}
-
-	for (size_t param_idx = 0; param_idx < params->size; param_idx++)
-	{
-		signature_set(sig, param_idx, "unnamed",
-			wasm_loader_impl_val_kind_to_type(impl, wasm_valtype_kind(params->data[param_idx])));
-	}
-
-	scope_define(scp, function_name(func), value_create_function(func));
-
-	return 0;
-}
-
-int wasm_loader_impl_discover_export(loader_impl impl, scope scp, const wasm_exporttype_t *export_type, const wasm_extern_t *export)
-{
 	int ret = 1;
 
-	// All of the `wasm_*` calls here return pointers to memory owned by
-	// `export_types`, so no need to do any error checking or cleanup.
-	const wasm_externtype_t *extern_type = wasm_exporttype_type(export_type);
-	const wasm_externkind_t kind = wasm_externtype_kind(extern_type);
-	char *export_name = wasm_loader_impl_get_export_type_name(export_type);
+	size_t size;
+	char *buffer = read_buffer_from_file(impl, path, &size);
 
-	if (export_name == NULL)
+	if (buffer == NULL)
 	{
-		goto error_export_name_alloc;
+		goto error_read_file;
 	}
 
-	if (kind == WASM_EXTERN_FUNC)
+	wasm_byte_vec_t binary;
+	if (try_wat2wasm(buffer, size, &binary) != 0)
 	{
-		if (wasm_loader_impl_discover_function(impl, scp, extern_type, export_name, export) != 0)
-		{
-			goto error_discover_function;
-		}
+		goto error_convert_buffer;
+	}
+
+	loader_naming_name module_name;
+	loader_path_get_module_name(path, module_name, TEXT_EXTENSION);
+
+	loader_impl_wasm wasm_impl = loader_impl_get(impl);
+	if (wasm_loader_handle_add_module(handle, module_name, wasm_impl->store, &binary) != 0)
+	{
+		goto error_add_module;
 	}
 
 	ret = 0;
 
-error_discover_function:
-	free(export_name);
-error_export_name_alloc:
+error_add_module:
+	wasm_byte_vec_delete(&binary);
+error_convert_buffer:
+error_read_file:
+	free(buffer);
 	return ret;
-}
-
-int wasm_loader_impl_discover_module(loader_impl impl, scope scp, const loader_impl_wasm_module *module)
-{
-	for (size_t i = 0; i < module->export_types.size; i++)
-	{
-		// There is a 1-to-1 correspondence between between the instance
-		// exports and the module exports, so we can use the same index.
-		const wasm_exporttype_t *export_type = module->export_types.data[i];
-		const wasm_extern_t *export = module->exports.data[i];
-		if (wasm_loader_impl_discover_export(impl, scp, export_type, export) != 0)
-		{
-			log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Module discovery failed");
-			return 1;
-		}
-	}
-
-	return 0;
-}
-
-int wasm_loader_impl_discover(loader_impl impl, loader_handle handle, context ctx)
-{
-	loader_impl_wasm_handle wasm_handle = (loader_impl_wasm_handle)handle;
-	scope scp = context_scope(ctx);
-
-	for (size_t idx = 0; idx < vector_size(wasm_handle->modules); idx++)
-	{
-		if (wasm_loader_impl_discover_module(impl, scp, vector_at(wasm_handle->modules, idx)) != 0)
-		{
-			log_write("metacall", LOG_LEVEL_ERROR, "WebAssembly loader: Handle discovery failed");
-			return 1;
-		}
-	}
-
-	return 0;
-}
-
-int wasm_loader_impl_destroy(loader_impl impl)
-{
-	loader_impl_wasm wasm_impl = loader_impl_get(impl);
-	loader_unload_children(impl);
-	vector_destroy(wasm_impl->paths);
-	wasm_store_delete(wasm_impl->store);
-	wasm_engine_delete(wasm_impl->engine);
-	free(wasm_impl);
-
-	log_write("metacall", LOG_LEVEL_DEBUG, "WebAssembly loader destroyed");
-
-	return 0;
 }


### PR DESCRIPTION
# Description

Refactor the Wasm loader by splitting it into different files, making private functions static and improving function naming.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [X] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [X] I have tested my code with `OPTION_BUILD_SANITIZER` and `OPTION_TEST_MEMORYCHECK`. 
- [X] I have run `make clang-format` in order to format my code and my code follows the style guidelines.