### PR TITLE
ci: docker image sync push to dockerhub

### DIFF
--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -4,9 +4,12 @@ on:
   # to enable manual triggering of this workflow.
   workflow_dispatch:
 
-  # trigger for pushes to develop
+  # trigger for pushes to master
   push:
-    branches: [develop]
+    branches: [master]
+
+env:
+  IMAGE_NAME: registry.hub.docker.com/metacall/core
 
 jobs:
   build-metaCall:
@@ -24,4 +27,5 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       # Run Docker Command - Pull
+      - run: echo ${IMAGE_NAME}
       - run: sh ./docker-compose.sh pull

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -25,11 +25,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      # - name: Login to DockerHub
+      #   uses: docker/login-action@v1
+      #   with:
+      #     username: ${{ secrets.DOCKER_HUB_USERNAME }}
+      #     password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       # Run Docker Command - Pull
       - run: echo ${IMAGE_NAME}

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -1,15 +1,16 @@
 name: Test, Build and Push Docker Image
 
-on:
-  # to enable manual triggering of this workflow.
-  workflow_dispatch:
+# on:
+#   # to enable manual triggering of this workflow.
+#   workflow_dispatch:
 
-  # trigger for pushes to master
-  push:
-    branches: [master]
+#   # trigger for pushes to master
+#   push:
+#     branches: [master]
 
-  pull_request:
-    branches: [develop, master]
+#   pull_request:
+#     branches: [develop, master]
+on: [push, pull_request]
 
 env:
   IMAGE_NAME: registry.hub.docker.com/metacall/core

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -1,0 +1,9 @@
+name: Test, Build and Push Docker Image
+
+on:
+  # to enable manual triggering of this workflow.
+  workflow_dispatch:
+
+  # trigger for pushes to develop
+  push:
+    branches: [develop]

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -7,3 +7,21 @@ on:
   # trigger for pushes to develop
   push:
     branches: [develop]
+
+jobs:
+  build-metaCall:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the code
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      # Run Docker Command - Pull
+      - run: sh ./docker-compose.sh pull

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -1,23 +1,18 @@
 name: Test, Build and Push Docker Image
 
-# on:
-#   # to enable manual triggering of this workflow.
-#   workflow_dispatch:
+on:
+  # to enable manual triggering of this workflow.
+  workflow_dispatch:
 
-#   # trigger for pushes to master
-#   push:
-#     branches: [master]
-
-#   pull_request:
-#     branches: [develop, master]
-on: [push, pull_request]
+  # trigger for pushes to master
+  push:
+    branches: [master]
 
 env:
   IMAGE_NAME: registry.hub.docker.com/metacall/core
 
 jobs:
   build-metaCall:
-    name: Pull Metacall Images
     runs-on: ubuntu-latest
     steps:
       # Checkout the code
@@ -25,12 +20,24 @@ jobs:
         with:
           fetch-depth: 0
 
-      # - name: Login to DockerHub
-      #   uses: docker/login-action@v1
-      #   with:
-      #     username: ${{ secrets.DOCKER_HUB_USERNAME }}
-      #     password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      # This Will Print the `IMAGE_NAME` configured in the environment variable
+      - name: Name of Image Configured in environment variable
+        run: echo ${IMAGE_NAME}
 
       # Run Docker Command - Pull
-      - run: echo ${IMAGE_NAME}
-      - run: sh ./docker-compose.sh pull
+      - name: Pull Metacall Docker Image
+        run: sh ./docker-compose.sh pull
+
+      # Run Docker Command - Build
+      - name: Build Metacall Docker Image
+        run: sh ./docker-compose.sh build
+
+      # Run Docker Command - Push
+      - name: Push Metacall Docker Image
+        run: sh ./docker-compose.sh push

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   build-metaCall:
+    name: Pull Metacall Images
     runs-on: ubuntu-latest
     steps:
       # Checkout the code

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: [master]
 
+  pull_request:
+    branches: [develop, master]
+
 env:
   IMAGE_NAME: registry.hub.docker.com/metacall/core
 


### PR DESCRIPTION
# Description

This Will Fix the CI/CD Pipeline for the docker images push w/ new pushes to the dockerhub of [`metacall/core`](https://hub.docker.com/r/metacall/core)

### Note

Before Merging this PR we will need to add these two Env Vars. in GitHub Secrets of this repo.

```
DOCKER_HUB_USERNAME
```
```
DOCKER_HUB_ACCESS_TOKEN
```

which we can create from here: https://docs.docker.com/docker-hub/access-tokens/


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
