### PR TITLE
fix unix function to strip lib name

### DIFF
--- a/source/dynlink/CMakeLists.txt
+++ b/source/dynlink/CMakeLists.txt
@@ -132,7 +132,6 @@ set_target_properties(${target}
 #
 # Include directories
 #
-
 target_include_directories(${target}
 	PRIVATE
 	${PROJECT_BINARY_DIR}/source/include
@@ -140,7 +139,6 @@ target_include_directories(${target}
 	${CMAKE_CURRENT_BINARY_DIR}/include
 
 	${DYNAMIC_LOADING_INCLUDE_DIR} # Native dynamic load library
-
 	PUBLIC
 	${DEFAULT_INCLUDE_DIRECTORIES}
 
@@ -161,6 +159,7 @@ target_link_libraries(${target}
 	${META_PROJECT_NAME}::format
 	${META_PROJECT_NAME}::threading
 	${META_PROJECT_NAME}::log
+	${META_PROJECT_NAME}::portability
 
 	PUBLIC
 	${DEFAULT_LIBRARIES}

--- a/source/dynlink/include/dynlink/dynlink_impl.h
+++ b/source/dynlink/include/dynlink/dynlink_impl.h
@@ -119,6 +119,18 @@ DYNLINK_API void dynlink_impl_unload(dynlink handle, dynlink_impl impl);
 */
 DYNLINK_API char *dynlink_impl_lib_path(dynlink_name name);
 
+/**
+*  @brief
+*    Returns the directory of the file from its absolute path
+*
+*  @param[in] metacall_lib_path
+*    Absolute path of the metacall dynamic library
+*
+*  @return
+*    Returns a reference to a string that holds the directory path of the library pointed by the path
+*/
+DYNLINK_API char *dynlink_impl_lib_dir_path(char *metacall_lib_path);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/dynlink/source/dynlink_impl.c
+++ b/source/dynlink/source/dynlink_impl.c
@@ -22,9 +22,9 @@
 
 #include <dynlink/dynlink_impl.h>
 
+#include <portability/portability_path.h>
 #include <stdlib.h>
 #include <string.h>
-#include <portability/portability_path.h>
 
 /* -- Methods -- */
 
@@ -104,8 +104,7 @@ char *dynlink_impl_lib_dir_path(char *metacall_lib_path)
 	/* TODO: Review this */
 	size_t metacall_lib_path_size = strlen(metacall_lib_path);
 	char *metacall_lib_dir_path = malloc(sizeof(char) * (metacall_lib_path_size + 1));
-	size_t metacall_lib_dir_path_size = strlen(metacall_lib_dir_path);
-	metacall_lib_dir_path_size = portability_path_get_directory(metacall_lib_path, metacall_lib_path_size, metacall_lib_dir_path, metacall_lib_dir_path_size);
+	size_t metacall_lib_dir_path_size = portability_path_get_directory(metacall_lib_path, metacall_lib_path_size, metacall_lib_dir_path, metacall_lib_path_size);
 	metacall_lib_dir_path[metacall_lib_dir_path_size - 2] = '\0';
 	return metacall_lib_dir_path;
 }

--- a/source/dynlink/source/dynlink_impl.c
+++ b/source/dynlink/source/dynlink_impl.c
@@ -24,6 +24,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <portability/portability_path.h>
 
 /* -- Methods -- */
 
@@ -96,4 +97,15 @@ char *dynlink_impl_lib_path(dynlink_name name)
 	}
 
 	return NULL;
+}
+
+char *dynlink_impl_lib_dir_path(char *metacall_lib_path)
+{
+	/* TODO: Review this */
+	size_t metacall_lib_path_size = strlen(metacall_lib_path);
+	char *metacall_lib_dir_path = malloc(sizeof(char) * (metacall_lib_path_size + 1));
+	size_t metacall_lib_dir_path_size = strlen(metacall_lib_dir_path);
+	metacall_lib_dir_path_size = portability_path_get_directory(metacall_lib_path, metacall_lib_path_size, metacall_lib_dir_path, metacall_lib_dir_path_size);
+	metacall_lib_dir_path[metacall_lib_dir_path_size - 2] = '\0';
+	return metacall_lib_dir_path;
 }

--- a/source/dynlink/source/dynlink_impl_unix.c
+++ b/source/dynlink/source/dynlink_impl_unix.c
@@ -152,6 +152,16 @@ static int dynlink_impl_interface_phdr_callback_unix(struct dl_phdr_info *info, 
 	return 0;
 }
 
+static char *dynlink_impl_interface_strip_lib_path_unix(char *metacall_lib_path, char *metacall_lib_name)
+{
+	/* TODO: Review this */
+	size_t lib_path_len = strlen(metacall_lib_path) - (strlen(metacall_lib_name) + 1);
+	char *custom_lib_path = malloc(sizeof(char) * (lib_path_len + 1));
+	custom_lib_path[lib_path_len] = 0;
+	strncpy(custom_lib_path, metacall_lib_path, lib_path_len);
+	return custom_lib_path;
+}
+
 char *dynlink_impl_interface_lib_path_unix(dynlink_name name, int (*comparator)(dynlink_path, dynlink_name))
 {
 	struct dynlink_lib_path_type data = {
@@ -170,8 +180,8 @@ char *dynlink_impl_interface_lib_path_unix(dynlink_name name, int (*comparator)(
 			return NULL;
 		}
 	}
-
-	return data.path;
+	char *metacall_lib_path = dynlink_impl_interface_strip_lib_path_unix(data.path, data.name_impl);
+	return metacall_lib_path;
 }
 
 dynlink_impl_interface dynlink_impl_interface_singleton_unix(void)

--- a/source/dynlink/source/dynlink_impl_unix.c
+++ b/source/dynlink/source/dynlink_impl_unix.c
@@ -180,7 +180,7 @@ char *dynlink_impl_interface_lib_path_unix(dynlink_name name, int (*comparator)(
 			return NULL;
 		}
 	}
-	char *metacall_lib_path = dynlink_impl_interface_strip_lib_path_unix(data.path, data.name_impl);
+	char *metacall_lib_path = dynlink_impl_lib_dir_path(data.path);
 	return metacall_lib_path;
 }
 

--- a/source/dynlink/source/dynlink_impl_unix.c
+++ b/source/dynlink/source/dynlink_impl_unix.c
@@ -152,16 +152,6 @@ static int dynlink_impl_interface_phdr_callback_unix(struct dl_phdr_info *info, 
 	return 0;
 }
 
-static char *dynlink_impl_interface_strip_lib_path_unix(char *metacall_lib_path, char *metacall_lib_name)
-{
-	/* TODO: Review this */
-	size_t lib_path_len = strlen(metacall_lib_path) - (strlen(metacall_lib_name) + 1);
-	char *custom_lib_path = malloc(sizeof(char) * (lib_path_len + 1));
-	custom_lib_path[lib_path_len] = 0;
-	strncpy(custom_lib_path, metacall_lib_path, lib_path_len);
-	return custom_lib_path;
-}
-
 char *dynlink_impl_interface_lib_path_unix(dynlink_name name, int (*comparator)(dynlink_path, dynlink_name))
 {
 	struct dynlink_lib_path_type data = {

--- a/source/dynlink/source/dynlink_impl_win32.c
+++ b/source/dynlink/source/dynlink_impl_win32.c
@@ -99,16 +99,6 @@ int dynlink_impl_interface_unload_win32(dynlink handle, dynlink_impl impl)
 	return (FreeLibrary(impl) == FALSE);
 }
 
-static char *dynlink_impl_interface_strip_lib_path_win32(char *metacall_lib_path, char *metacall_lib_name)
-{
-	/* TODO: Review this */
-	size_t lib_path_len = strlen(metacall_lib_path) - (strlen(metacall_lib_name) + 1);
-	char *custom_lib_path = malloc(sizeof(char) * (lib_path_len + 1));
-	custom_lib_path[lib_path_len] = 0;
-	strncpy(custom_lib_path, metacall_lib_path, lib_path_len);
-	return custom_lib_path;
-}
-
 char *dynlink_impl_interface_lib_path_win32(dynlink_name name, int (*comparator)(dynlink_path, dynlink_name))
 {
 	/* TODO: Review this */
@@ -135,7 +125,7 @@ char *dynlink_impl_interface_lib_path_win32(dynlink_name name, int (*comparator)
 				if (comparator(lib_path, metacall_lib_name) == 0)
 				{
 					found_lib_path = 1;
-					metacall_lib_path = dynlink_impl_interface_strip_lib_path_win32(lib_path, metacall_lib_name);
+					metacall_lib_path = dynlink_impl_lib_dir_path(lib_path);
 					break;
 				}
 			}


### PR DESCRIPTION
# Description
fixes the linux implementation of `dynlink_impl_interface_lib_path_unix` function to pass tests consistently in windows and linux.
