### PR TITLE
Add metacall include path and metacall library path in c loader

### DIFF
--- a/source/cli/metacallcli/source/application.cpp
+++ b/source/cli/metacallcli/source/application.cpp
@@ -454,7 +454,7 @@ bool command_cb_load(application &app, tokenizer &t)
 	}
 
 	std::string loaders[] = {
-		"mock", "py", "node", "rb", "cs", "cob", "ts", "js", "file", "wasm", "rs"
+		"mock", "py", "node", "rb", "cs", "cob", "ts", "js", "file", "wasm", "rs", "c"
 	};
 
 	// check if invalid loader tag
@@ -544,7 +544,8 @@ void application::parameter_iterator::operator()(const char *parameter)
 		{ "jsx", "ts" },
 		{ "tsx", "ts" },
 		/* Rust Loader */
-		{ "rs", "rs" }
+		{ "rs", "rs" },
+		{ "c", "c" }
 
 		/* Note: By default js extension uses NodeJS loader instead of JavaScript V8 */
 		/* Probably in the future we can differenciate between them, but it is not trivial */

--- a/source/loaders/c_loader/source/c_loader_impl.cpp
+++ b/source/loaders/c_loader/source/c_loader_impl.cpp
@@ -35,6 +35,7 @@
 
 #include <metacall/metacall.h>
 
+#include <iostream>
 #include <iterator>
 #include <map>
 #include <new>
@@ -327,8 +328,21 @@ static loader_impl_c_handle c_loader_impl_handle_create(loader_impl_c c_impl)
 	/* TODO: Add some warnings? */
 	/* tcc_set_warning */
 
-	/* TODO: Take the c_loader and add the execution paths for include (and library?) folders */
 	/* tcc_add_include_path, tcc_add_library_path */
+	const char *loader_lib_path = loader_library_path();
+	const char *include_dir = "../include";
+	char join_path[PORTABILITY_PATH_SIZE];
+	char metacall_incl_path[PORTABILITY_PATH_SIZE];
+
+	size_t join_path_size = portability_path_join(loader_lib_path, strlen(loader_lib_path) + 1, include_dir, strlen(include_dir) + 1, join_path, PORTABILITY_PATH_SIZE);
+	(void)portability_path_canonical(join_path, join_path_size, metacall_incl_path, PORTABILITY_PATH_SIZE);
+
+	/*Add metacall include path*/
+	tcc_add_include_path(c_handle->state, metacall_incl_path);
+
+	/*Add metacall library path (in other to find libmetacall.so)*/
+	tcc_add_library_path(c_handle->state, c_impl->libtcc_runtime_path.c_str());
+
 	(void)c_impl;
 
 	return c_handle;


### PR DESCRIPTION
# Description
Add metacall include path so including metacall/metacall.h `#include <metacall/metacall.h>` works.
Add metacall library path so libtcc can find libmetacall.so.

Fixes #(issue_no)

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh build &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_SANITIZER` or `./docker-compose.sh test &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
