### PR TITLE
Parse Rust AST instead of HIR.

### DIFF
--- a/source/loaders/rs_loader/rust/compiler/src/ast.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/ast.rs
@@ -1,0 +1,107 @@
+use super::rustc_ast::{
+    AngleBracketedArg, AngleBracketedArgs, FnRetTy, FnSig, GenericArg, GenericArgs, MutTy, TyKind,
+};
+use super::{Function, FunctionParameter, FunctionType, Mutability, Reference};
+
+fn handle_ty(ty: &rustc_ast::Ty) -> FunctionParameter {
+    let mut result = FunctionParameter {
+        name: String::new(),
+        mutability: Mutability::No,
+        reference: Reference::No,
+        ty: FunctionType::Null,
+        generic: vec![],
+    };
+    match &ty.kind {
+        TyKind::Path(_, path) => {
+            let segment = &path.segments[0];
+            let symbol_string = segment.ident.name.to_string();
+            match symbol_string.as_str() {
+                "i16" => result.ty = FunctionType::I16,
+                "i32" => result.ty = FunctionType::I32,
+                "i64" => result.ty = FunctionType::I64,
+                "u16" => result.ty = FunctionType::U16,
+                "u32" => result.ty = FunctionType::U32,
+                "u64" => result.ty = FunctionType::U64,
+                "usize" => result.ty = FunctionType::Usize,
+                "f32" => result.ty = FunctionType::F32,
+                "f64" => result.ty = FunctionType::F64,
+                "bool" => result.ty = FunctionType::Bool,
+                "str" => result.ty = FunctionType::Str,
+                "Vec" => {
+                    result.ty = FunctionType::Array;
+                    if let Some(args) = &segment.args {
+                        match &**args {
+                            GenericArgs::AngleBracketed(AngleBracketedArgs { args, .. }) => {
+                                for arg in args {
+                                    match arg {
+                                        AngleBracketedArg::Arg(GenericArg::Type(ty)) => {
+                                            result.generic.push(handle_ty(ty))
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                            }
+                            GenericArgs::Parenthesized(_) => {}
+                        }
+                    }
+                }
+                "HashMap" => {
+                    result.ty = FunctionType::Map;
+                    if let Some(args) = &segment.args {
+                        match &**args {
+                            GenericArgs::AngleBracketed(AngleBracketedArgs { args, .. }) => {
+                                for arg in args {
+                                    match arg {
+                                        AngleBracketedArg::Arg(GenericArg::Type(ty)) => {
+                                            result.generic.push(handle_ty(ty))
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                            }
+                            GenericArgs::Parenthesized(_) => {}
+                        }
+                    }
+                }
+                "String" => result.ty = FunctionType::String,
+                _ => {}
+            }
+            result.name = symbol_string;
+        }
+        TyKind::Rptr(_, MutTy { ty, mutbl }) => {
+            let mut inner_ty = handle_ty(ty);
+            inner_ty.reference = Reference::Yes;
+            match mutbl {
+                rustc_hir::Mutability::Mut => inner_ty.mutability = Mutability::Yes,
+                rustc_hir::Mutability::Not => inner_ty.mutability = Mutability::No,
+            }
+            return inner_ty;
+        }
+        TyKind::ImplicitSelf => {
+            result.name = "self".to_string();
+            result.ty = FunctionType::This
+        }
+        _ => {}
+    }
+    result
+}
+
+pub fn handle_fn(name: String, sig: &FnSig) -> Function {
+    let mut function = Function {
+        name,
+        ret: None,
+        args: vec![],
+    };
+    // parse input and output
+    for arg in &sig.decl.inputs {
+        function.args.push(handle_ty(&arg.ty));
+    }
+
+    match &sig.decl.output {
+        FnRetTy::Default(_) => function.ret = None,
+        FnRetTy::Ty(ty) => {
+            function.ret = Some(handle_ty(&ty));
+        }
+    }
+    function
+}

--- a/source/loaders/rs_loader/rust/compiler/src/wrapper/mod.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/wrapper/mod.rs
@@ -277,7 +277,9 @@ extern \"C\" {
             // construct new callback
             Ok(CompilerCallbacks {
                 source: Source::new(Source::File { path: source_path }),
+                is_parsing: false,
                 functions: wrapped_functions,
+                ..callbacks
             })
         }
         Input::Str { name, input } => match name {
@@ -286,7 +288,9 @@ extern \"C\" {
                     name,
                     code: content + &input,
                 }),
+                is_parsing: false,
                 functions: wrapped_functions,
+                ..callbacks
             }),
             _ => {
                 unimplemented!()

--- a/source/scripts/rust/basic/source/basic.rs
+++ b/source/scripts/rust/basic/source/basic.rs
@@ -52,3 +52,28 @@ pub fn string_len(s: String) -> usize {
 pub fn new_string(idx: i32) -> String {
     format!("get number {idx}")
 }
+
+#[repr(C)]
+struct Book {
+    name: String,
+    price: u32,
+}
+
+impl Book {
+    fn new(name: String, price: u32) -> Self {
+        Self { name, price }
+    }
+    fn get_price(&self) -> u32 {
+        self.price
+    }
+}
+
+impl Drop for Book {
+    fn drop(&mut self) {}
+}
+trait BookTrait {
+    fn buy_book(&self, p: i32);
+}
+impl BookTrait for Book {
+    fn buy_book(&self, p: i32) {}
+}


### PR DESCRIPTION
# Description
When parsing HIR, the function signatures of `impl` blocks are missing. 
So we parse AST now.

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [x] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh build &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_SANITIZER` or `./docker-compose.sh test &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [x] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
