### PR TITLE
CMake add compilation flag for Ruby support in Homebrew OSX fix

### DIFF
--- a/source/loaders/rb_loader/CMakeLists.txt
+++ b/source/loaders/rb_loader/CMakeLists.txt
@@ -188,6 +188,17 @@ target_compile_options(${target}
 	INTERFACE
 )
 
+# Fix Ruby MacOSX LLVM bug 
+# '__declspec' attributes are not enabled; use '-fdeclspec' or '-fms-extensions' to enable support for __declspec attributes
+
+include(Portability)
+if("${PROJECT_OS_FAMILY}" STREQUAL "macos" )
+	if("${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+		target_compile_options(${target} PRIVATE "-fdeclspec")
+	endif()
+endif()
+
+
 #
 # Linker options
 #


### PR DESCRIPTION
# Description

Due to an LLVM bug in AppleClang a flag has to be passed to the compiler in order to fix Ruby building, for reference see : https://github.com/nginx/unit/issues/653#issuecomment-1063524279

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh build &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_SANITIZER` or `./docker-compose.sh test &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

@giarve could you please merge this PR, it was tested and worked under KVM-OSX and worked as a fix.
