### PR TITLE
Metacall MacOS app bundle remove

### DIFF
--- a/source/cli/metacallcli/CMakeLists.txt
+++ b/source/cli/metacallcli/CMakeLists.txt
@@ -51,7 +51,6 @@ set(sources
 
 # Build executable
 add_executable(${target}
-	#MACOSX_BUNDLE
 	${sources}
 )
 

--- a/source/cli/metacallcli/CMakeLists.txt
+++ b/source/cli/metacallcli/CMakeLists.txt
@@ -162,9 +162,10 @@ target_link_libraries(${target}
 #
 
 # Executable
+message("${INSTALL_BIN}")
 install(TARGETS ${target}
 	RUNTIME DESTINATION ${INSTALL_BIN} COMPONENT cli
-	BUNDLE  DESTINATION ${INSTALL_BIN} COMPONENT cli
+	BUNDLE  DESTINATION ${INSTALL_BIN}/.. COMPONENT cli
 )
 
 #

--- a/source/cli/metacallcli/CMakeLists.txt
+++ b/source/cli/metacallcli/CMakeLists.txt
@@ -51,7 +51,7 @@ set(sources
 
 # Build executable
 add_executable(${target}
-	MACOSX_BUNDLE
+	#MACOSX_BUNDLE
 	${sources}
 )
 
@@ -162,7 +162,6 @@ target_link_libraries(${target}
 #
 
 # Executable
-message("${INSTALL_BIN}")
 install(TARGETS ${target}
 	RUNTIME DESTINATION ${INSTALL_BIN} COMPONENT cli
 	BUNDLE  DESTINATION ${INSTALL_BIN}/.. COMPONENT cli

--- a/source/cli/metacallcli/CMakeLists.txt
+++ b/source/cli/metacallcli/CMakeLists.txt
@@ -51,7 +51,7 @@ set(sources
 
 # Build executable
 add_executable(${target}
-	MACOSX_BUNDLE
+	#MACOSX_BUNDLE
 	${sources}
 )
 

--- a/source/cli/metacallcli/CMakeLists.txt
+++ b/source/cli/metacallcli/CMakeLists.txt
@@ -51,7 +51,7 @@ set(sources
 
 # Build executable
 add_executable(${target}
-	#MACOSX_BUNDLE
+	MACOSX_BUNDLE
 	${sources}
 )
 

--- a/source/extensions/plugin_extension/CMakeLists.txt
+++ b/source/extensions/plugin_extension/CMakeLists.txt
@@ -192,14 +192,3 @@ target_link_libraries(${target}
 	INTERFACE
 )
 
-#
-# Deployment
-#
-
-# Library
-install(TARGETS ${target}
-	EXPORT  "${target}-export"				COMPONENT dev
-	RUNTIME DESTINATION ${INSTALL_BIN}		COMPONENT runtime
-	LIBRARY DESTINATION ${INSTALL_SHARED}	COMPONENT runtime
-	ARCHIVE DESTINATION ${INSTALL_LIB}		COMPONENT dev
-)


### PR DESCRIPTION
# Description

Remove MacOS BUNDLE from cmake, to prevent metacallcli.app folder being created in order to be more compliant towards brew. 

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh build &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_SANITIZER` or `./docker-compose.sh test &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
