### PR TITLE
Fix rs_loader leaks.

### DIFF
--- a/source/loaders/rs_loader/rust/compiler/src/api/class.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/api/class.rs
@@ -119,11 +119,12 @@ extern "C" fn class_singleton_static_await(
 
 #[no_mangle]
 extern "C" fn class_singleton_destroy(_klass: OpaqueType, class_impl: OpaqueType) {
-    // unsafe {
-    //     let class_impl_ptr = class_impl as *mut class::Class;
-    //     let class = Box::from_raw(class_impl_ptr);
-    //     drop(class);
-    // }
+    if !class_impl.is_null() {
+        unsafe {
+            let class = Box::from_raw(class_impl as *mut class::Class);
+            drop(class);
+        }
+    }
     println!("class destroy");
 }
 

--- a/source/loaders/rs_loader/rust/compiler/src/api/class.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/api/class.rs
@@ -240,6 +240,17 @@ pub fn register_class(class_registration: ClassRegistration) {
                 );
             };
         }
+        else {
+            let ret = CString::new("Null")
+            .expect("Failed to convert return type to C string");
+
+            unsafe {
+                signature_set_return(
+                    s,
+                    loader_impl_type(class_registration.loader_impl, ret.as_ptr()),
+                );
+            };
+        }
         for (idx, param) in method.args.iter().enumerate() {
             let name = CString::new(param.name.clone())
                 .expect("Failed to convert function parameter name to C string");
@@ -276,6 +287,17 @@ pub fn register_class(class_registration: ClassRegistration) {
         if let Some(ret) = &method.ret {
             let ret = CString::new(ret.ty.to_string())
                 .expect("Failed to convert return type to C string");
+
+            unsafe {
+                signature_set_return(
+                    s,
+                    loader_impl_type(class_registration.loader_impl, ret.as_ptr()),
+                );
+            };
+        }
+        else {
+            let ret = CString::new("Null")
+            .expect("Failed to convert return type to C string");
 
             unsafe {
                 signature_set_return(

--- a/source/loaders/rs_loader/rust/compiler/src/api/function.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/api/function.rs
@@ -118,6 +118,16 @@ pub fn register_function(function_registration: FunctionRegistration) {
                 loader_impl_type(function_registration.loader_impl, ret.as_ptr()),
             );
         };
+    } 
+    else {
+        let ret = CString::new("Null").expect("Failed to convert return type to C string");
+
+        unsafe {
+            signature_set_return(
+                s,
+                loader_impl_type(function_registration.loader_impl, ret.as_ptr()),
+            );
+        };
     }
 
     for (index, param) in function_registration.input.iter().enumerate() {

--- a/source/loaders/rs_loader/rust/compiler/src/api/function.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/api/function.rs
@@ -31,11 +31,6 @@ extern "C" fn function_singleton_invoke(
     size: usize,
 ) -> OpaqueType {
     unsafe {
-        // let func_ptr = Box::from_raw(func_impl as *mut unsafe fn());
-        // let func: fn(OpaqueTypeList, usize) -> OpaqueType = std::mem::transmute_copy(&*func_ptr);
-        // let result = func(args_p, size);
-        // std::mem::forget(func_ptr);
-        // result
         let args = std::slice::from_raw_parts(args_p, size).to_vec();
         let nf = Box::from_raw(func_impl as *mut class::NormalFunction);
         let res = nf.invoke(args).unwrap();
@@ -62,10 +57,12 @@ extern "C" fn function_singleton_await(
 #[no_mangle]
 extern "C" fn function_singleton_destroy(_func: OpaqueType, func_impl: OpaqueType) {
     // comment out this due to the seg fault
-    // unsafe {
-    //     let func_ptr = Box::from_raw(func_impl as *mut class::NormalFunction);
-    //     drop(func_ptr);
-    // }
+    if !func_impl.is_null() {
+        unsafe {
+            let func_ptr = Box::from_raw(func_impl as *mut class::NormalFunction);
+            drop(func_ptr);
+        }
+    }
 }
 
 #[no_mangle]

--- a/source/loaders/rs_loader/rust/compiler/src/api/mod.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/api/mod.rs
@@ -17,10 +17,14 @@ pub use class::{class_singleton, register_class, ClassCreate, ClassRegistration}
 
 pub struct LoaderLifecycleState {
     pub execution_paths: Vec<PathBuf>,
+    pub destroy_list: Vec<super::DlopenLibrary>,
 }
 impl LoaderLifecycleState {
     pub fn new(execution_paths: Vec<PathBuf>) -> LoaderLifecycleState {
-        LoaderLifecycleState { execution_paths }
+        LoaderLifecycleState {
+            execution_paths,
+            destroy_list: vec![],
+        }
     }
 }
 extern "C" {

--- a/source/loaders/rs_loader/rust/compiler/src/api/object.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/api/object.rs
@@ -123,11 +123,12 @@ extern "C" fn object_singleton_method_await(
 }
 #[no_mangle]
 extern "C" fn object_singleton_destructor(_object: OpaqueType, object_impl: OpaqueType) -> c_int {
-    // unsafe {
-    //     let object_impl_ptr = object_impl as *mut Object;
-    //     let object = Box::from_raw(object_impl_ptr);
-    //     drop(object);
-    // }
+    if !object_impl.is_null() {
+        unsafe {
+            let object = Box::from_raw(object_impl as *mut Object);
+            drop(object);
+        }
+    }
     println!("destruct object");
     0
 }

--- a/source/loaders/rs_loader/rust/compiler/src/file.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/file.rs
@@ -8,7 +8,7 @@ use crate::{registrator, DlopenLibrary};
 pub struct FileRegistration {
     pub path_to_file: PathBuf,
     pub state: CompilerState,
-    pub dlopen: DlopenLibrary,
+    pub dlopen: Option<DlopenLibrary>,
 }
 impl FileRegistration {
     pub fn new(path_to_file: PathBuf) -> Result<FileRegistration, RegistrationError> {
@@ -31,13 +31,17 @@ impl FileRegistration {
         Ok(FileRegistration {
             path_to_file,
             state,
-            dlopen,
+            dlopen: Some(dlopen),
         })
     }
 
     pub fn discover(&self, loader_impl: *mut c_void, ctx: *mut c_void) -> Result<(), String> {
-        registrator::register(&self.state, &self.dlopen, loader_impl, ctx);
-
-        Ok(())
+        match &self.dlopen {
+            Some(dl) => {
+                registrator::register(&self.state, &dl, loader_impl, ctx);
+                Ok(())
+            }
+            None => Err(String::from("")),
+        }
     }
 }

--- a/source/loaders/rs_loader/rust/compiler/src/file.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/file.rs
@@ -41,7 +41,7 @@ impl FileRegistration {
                 registrator::register(&self.state, &dl, loader_impl, ctx);
                 Ok(())
             }
-            None => Err(String::from("")),
+            None => Err(String::from("The dlopen_lib is None")),
         }
     }
 }

--- a/source/loaders/rs_loader/rust/compiler/src/memory.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/memory.rs
@@ -50,7 +50,7 @@ impl MemoryRegistration {
                 registrator::register(&self.state, &dl, loader_impl, ctx);
                 Ok(())
             }
-            None => Err(String::from("")),
+            None => Err(String::from("The dlopen_lib is None")),
         }
     }
 }

--- a/source/loaders/rs_loader/rust/compiler/src/memory.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/memory.rs
@@ -8,7 +8,7 @@ use crate::{registrator, DlopenLibrary};
 pub struct MemoryRegistration {
     pub name: String,
     pub state: CompilerState,
-    pub dlopen: DlopenLibrary,
+    pub dlopen: Option<DlopenLibrary>,
 }
 impl MemoryRegistration {
     pub fn new(name: String, code: String) -> Result<MemoryRegistration, RegistrationError> {
@@ -40,13 +40,17 @@ impl MemoryRegistration {
         Ok(MemoryRegistration {
             name,
             state,
-            dlopen,
+            dlopen: Some(dlopen),
         })
     }
 
     pub fn discover(&self, loader_impl: *mut c_void, ctx: *mut c_void) -> Result<(), String> {
-        registrator::register(&self.state, &self.dlopen, loader_impl, ctx);
-
-        Ok(())
+        match &self.dlopen {
+            Some(dl) => {
+                registrator::register(&self.state, &dl, loader_impl, ctx);
+                Ok(())
+            }
+            None => Err(String::from("")),
+        }
     }
 }

--- a/source/loaders/rs_loader/rust/compiler/src/package.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/package.rs
@@ -40,7 +40,7 @@ impl PackageRegistration {
                 registrator::register(&self.state, &dl, loader_impl, ctx);
                 Ok(())
             }
-            None => Err(String::from("")),
+            None => Err(String::from("The dlopen_lib is None")),
         }
     }
 }

--- a/source/loaders/rs_loader/rust/compiler/src/package.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/package.rs
@@ -6,7 +6,7 @@ use std::{ffi::c_void, path::PathBuf};
 pub struct PackageRegistration {
     pub path_to_file: PathBuf,
     pub state: CompilerState,
-    pub dlopen: DlopenLibrary,
+    pub dlopen: Option<DlopenLibrary>,
 }
 
 impl PackageRegistration {
@@ -30,13 +30,17 @@ impl PackageRegistration {
         Ok(PackageRegistration {
             path_to_file,
             state,
-            dlopen,
+            dlopen: Some(dlopen),
         })
     }
 
     pub fn discover(&self, loader_impl: *mut c_void, ctx: *mut c_void) -> Result<(), String> {
-        registrator::register(&self.state, &self.dlopen, loader_impl, ctx);
-
-        Ok(())
+        match &self.dlopen {
+            Some(dl) => {
+                registrator::register(&self.state, &dl, loader_impl, ctx);
+                Ok(())
+            }
+            None => Err(String::from("")),
+        }
     }
 }

--- a/source/loaders/rs_loader/rust/compiler/src/wrapper/class.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/wrapper/class.rs
@@ -35,6 +35,7 @@ extern "C" {
     fn metacall_value_create_string(st: *const c_char, ln: usize) -> *mut c_void;
     fn metacall_value_create_array(values: *const *mut c_void, size: usize) -> *mut c_void;
     fn metacall_value_create_map(tuples: *const *mut c_void, size: usize) -> *mut c_void;
+    fn metacall_value_create_null() -> *mut c_void;
 }
 
 type Attributes = HashMap<&'static str, AttributeGetter>;
@@ -454,7 +455,7 @@ pub trait ToMetaResult {
 
 impl ToMetaResult for () {
     fn to_meta_result(self) -> Result<MetacallValue> {
-        Ok(unsafe { metacall_value_create_int(0) })
+        Ok(unsafe { metacall_value_create_null() })
     }
 }
 

--- a/source/loaders/rs_loader/rust/src/lifecycle/clear.rs
+++ b/source/loaders/rs_loader/rust/src/lifecycle/clear.rs
@@ -1,9 +1,29 @@
-use crate::{c_int, c_void};
 use super::loader::LoadingMethod;
+use crate::{c_int, c_void};
+
+use compiler::api;
 
 #[no_mangle]
-pub extern "C" fn rs_loader_impl_clear(_loader_impl: *mut c_void, handle: *mut c_void) -> c_int {
-    let handle_shared_objects = unsafe { Box::from_raw(handle as *mut Vec<LoadingMethod>) };
-    drop(handle_shared_objects);
+pub extern "C" fn rs_loader_impl_clear(loader_impl: *mut c_void, handle: *mut c_void) -> c_int {
+    let loader_lifecycle_state = unsafe {
+        api::get_loader_lifecycle_state(loader_impl)
+            .as_mut()
+            .expect("Unable to get loader state")
+    };
+    unsafe {
+        let methods = Box::from_raw(handle as *mut Vec<LoadingMethod>);
+        for loading_method in *methods {
+            match loading_method.consume_dlib() {
+                Ok(lib) => {
+                    // extend the lifetime of library
+                    loader_lifecycle_state.destroy_list.push(lib);
+                }
+                Err(err) => {
+                    eprintln!("{}", err);
+                    return 1 as c_int;
+                }
+            }
+        }
+    }
     0 as c_int
 }

--- a/source/loaders/rs_loader/rust/src/lifecycle/destroy.rs
+++ b/source/loaders/rs_loader/rust/src/lifecycle/destroy.rs
@@ -9,7 +9,9 @@ pub extern "C" fn rs_loader_impl_destroy(loader_impl: *mut c_void) -> c_int {
     api::loader_lifecycle_unload_children(loader_impl);
 
     unsafe {
-        loader_lifecycle_state.drop_in_place();
+        let state = Box::from_raw(loader_lifecycle_state);
+        // drop the state, including dlibs.
+        drop(state);
     }
 
     0 as c_int

--- a/source/loaders/rs_loader/rust/src/lifecycle/initialize.rs
+++ b/source/loaders/rs_loader/rust/src/lifecycle/initialize.rs
@@ -114,6 +114,13 @@ pub extern "C" fn rs_loader_impl_initialize(
         0 as c_int as *mut c_void,
         0 as c_int as *mut c_void,
     );
+    api::define_type(
+        loader_impl,
+        "Null",
+        PrimitiveMetacallProtocolTypes::Null,
+        0 as c_int as *mut c_void,
+        0 as c_int as *mut c_void,
+    );
     // Register initialization
     api::loader_lifecycle_register(loader_impl);
 

--- a/source/loaders/rs_loader/rust/src/lifecycle/loader.rs
+++ b/source/loaders/rs_loader/rust/src/lifecycle/loader.rs
@@ -23,21 +23,21 @@ impl LoadingMethod {
                     let dl = std::mem::replace(&mut dlopen, None);
                     Ok(dl.expect("Unexpected: dlopen is None"))
                 }
-                None => Err(String::from("DlopenLibrary is None")),
+                None => Err(String::from("consume_dlib was called more than once")),
             },
             Self::Package(PackageRegistration { mut dlopen, .. }) => match dlopen {
                 Some(_) => {
                     let dl = std::mem::replace(&mut dlopen, None);
                     Ok(dl.expect("Unexpected: dlopen is None"))
                 }
-                None => Err(String::from("DlopenLibrary is None")),
+                None => Err(String::from("consume_dlib was called more than once")),
             },
             Self::Memory(MemoryRegistration { mut dlopen, .. }) => match dlopen {
                 Some(_) => {
                     let dl = std::mem::replace(&mut dlopen, None);
                     Ok(dl.expect("Unexpected: dlopen is None"))
                 }
-                None => Err(String::from("DlopenLibrary is None")),
+                None => Err(String::from("consume_dlib was called more than once")),
             },
         }
     }

--- a/source/loaders/rs_loader/rust/src/lifecycle/loader.rs
+++ b/source/loaders/rs_loader/rust/src/lifecycle/loader.rs
@@ -15,6 +15,34 @@ pub enum LoadingMethod {
     Memory(MemoryRegistration),
 }
 
+impl LoadingMethod {
+    pub fn consume_dlib(self) -> Result<compiler::DlopenLibrary, String> {
+        match self {
+            Self::File(FileRegistration { mut dlopen, .. }) => match dlopen {
+                Some(_) => {
+                    let dl = std::mem::replace(&mut dlopen, None);
+                    Ok(dl.expect("Unexpected: dlopen is None"))
+                }
+                None => Err(String::from("DlopenLibrary is None")),
+            },
+            Self::Package(PackageRegistration { mut dlopen, .. }) => match dlopen {
+                Some(_) => {
+                    let dl = std::mem::replace(&mut dlopen, None);
+                    Ok(dl.expect("Unexpected: dlopen is None"))
+                }
+                None => Err(String::from("DlopenLibrary is None")),
+            },
+            Self::Memory(MemoryRegistration { mut dlopen, .. }) => match dlopen {
+                Some(_) => {
+                    let dl = std::mem::replace(&mut dlopen, None);
+                    Ok(dl.expect("Unexpected: dlopen is None"))
+                }
+                None => Err(String::from("DlopenLibrary is None")),
+            },
+        }
+    }
+}
+
 // Trait aliasing
 pub trait OnPathBufClosure:
     Fn(PathBuf, fn(error: String) -> *mut c_void) -> Result<LoadingMethod, *mut c_void>

--- a/source/scripts/rust/basic/source/basic.rs
+++ b/source/scripts/rust/basic/source/basic.rs
@@ -1,4 +1,7 @@
 use std::collections::HashMap;
+use std::fs::File;
+use std::io::Write;
+use std::env;
 
 pub fn add(num_1: i32, num_2: i32) -> i32 {
     num_1 + num_2
@@ -13,7 +16,9 @@ pub fn add_float(num_1: f32, num_2: f32) -> f32 {
 }
 
 pub fn run() {
-    println!("Hello World")
+    let dir = env::temp_dir();
+    let mut f = File::create(dir.join("hello.txt")).unwrap();
+    f.write(b"Hello metacall");
 }
 
 // pub fn add_vec(vec: &mut Vec<i32>) -> i32 {

--- a/source/tests/metacall_rust_load_from_package_test/source/metacall_rust_load_from_package_test.cpp
+++ b/source/tests/metacall_rust_load_from_package_test/source/metacall_rust_load_from_package_test.cpp
@@ -78,9 +78,11 @@ TEST_F(metacall_rust_load_from_mem_test, DefaultConstructor)
 	}
 
 	{
-		void *ret = metacall("run");
-		EXPECT_EQ((int)0, (int)metacall_value_to_int(ret));
-		metacall_value_destroy(ret);
+		// this causes a leak
+		// TODO: we don't support function that returns nothing yet
+		// void *ret = metacall("run");
+		// EXPECT_EQ((void *)NULL, (void *)metacall_value_to_null(ret));
+		// metacall_value_destroy(ret);
 	}
 
 	{

--- a/source/tests/metacall_rust_load_from_package_test/source/metacall_rust_load_from_package_test.cpp
+++ b/source/tests/metacall_rust_load_from_package_test/source/metacall_rust_load_from_package_test.cpp
@@ -78,11 +78,9 @@ TEST_F(metacall_rust_load_from_mem_test, DefaultConstructor)
 	}
 
 	{
-		// this causes a leak
-		// TODO: we don't support function that returns nothing yet
-		// void *ret = metacall("run");
-		// EXPECT_EQ((void *)NULL, (void *)metacall_value_to_null(ret));
-		// metacall_value_destroy(ret);
+		void *ret = metacall("run");
+		EXPECT_EQ((void *)NULL, (void *)metacall_value_to_null(ret));
+		metacall_value_destroy(ret);
 	}
 
 	{

--- a/source/tests/metacall_rust_test/source/metacall_rust_test.cpp
+++ b/source/tests/metacall_rust_test/source/metacall_rust_test.cpp
@@ -79,9 +79,11 @@ TEST_F(metacall_rust_test, DefaultConstructor)
 	}
 
 	{
-		void *ret = metacall("run");
-		EXPECT_EQ((int)0, (int)metacall_value_to_int(ret));
-		metacall_value_destroy(ret);
+		// this causes a leak
+		// TODO: we don't support function that returns nothing yet
+		// void *ret = metacall("run");
+		// EXPECT_EQ((void *)NULL, (void *)metacall_value_to_null(ret));
+		// metacall_value_destroy(ret);
 	}
 
 	{

--- a/source/tests/metacall_rust_test/source/metacall_rust_test.cpp
+++ b/source/tests/metacall_rust_test/source/metacall_rust_test.cpp
@@ -79,11 +79,9 @@ TEST_F(metacall_rust_test, DefaultConstructor)
 	}
 
 	{
-		// this causes a leak
-		// TODO: we don't support function that returns nothing yet
-		// void *ret = metacall("run");
-		// EXPECT_EQ((void *)NULL, (void *)metacall_value_to_null(ret));
-		// metacall_value_destroy(ret);
+		void *ret = metacall("run");
+		EXPECT_EQ((void *)NULL, (void *)metacall_value_to_null(ret));
+		metacall_value_destroy(ret);
 	}
 
 	{

--- a/source/tests/sanitizer/lsan.supp
+++ b/source/tests/sanitizer/lsan.supp
@@ -34,3 +34,7 @@ leak:libruby*
 #
 leak:libcoreclr*
 leak:libicuuc*
+#
+# Rust
+#
+leak:libLLVM*


### PR DESCRIPTION
Signed-off-by: Tricster <mediosrity@gmail.com>
# Description

Fix rs_loader leaks by delaying the destruction of loaded libraries.

Fixes #301 

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [x] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [x] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh build &> output` and attached the output.
- [x] I have tested my code with `OPTION_BUILD_SANITIZER` or `./docker-compose.sh test &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
