### PR TITLE
Clear Error message when backtrace_plugin load fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           LTTNG_UST_REGISTER_TIMEOUT:  0
           NUGET_XMLDOC_MODE:           skip
           DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
-          METACALL_INSTALL_OPTIONS:    root base python ruby netcore5 nodejs typescript file rpc wasm java c cobol rust rapidjson funchook swig pack
+          METACALL_INSTALL_OPTIONS:    root base python ruby netcore5 nodejs typescript file rpc wasm java c cobol rust rapidjson funchook swig pack backtrace
 
       - name: Configure
         run: |

--- a/source/plugins/backtrace_plugin/source/backtrace_plugin.cpp
+++ b/source/plugins/backtrace_plugin/source/backtrace_plugin.cpp
@@ -22,6 +22,8 @@
 
 #include <backward.hpp>
 
+#include <log/log.h>
+
 static backward::SignalHandling signal_handling;
 
 int backtrace_plugin(void *loader, void *handle, void *context)
@@ -30,5 +32,10 @@ int backtrace_plugin(void *loader, void *handle, void *context)
 	(void)handle;
 	(void)context;
 
-	return signal_handling.loaded() == true ? 0 : 1;
+	if (signal_handling.loaded() == false)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Backtrace plugin failed to load, you need unwind/libunwind for stacktracing and libbfd/libdw/libdwarf for the debug information. Install the required libraries and recompile to utilise the backtrace plugin. For more information visit https://github.com/bombela/backward-cpp");
+		return 1;
+	}
+	return 0;
 }

--- a/tools/metacall-runtime.sh
+++ b/tools/metacall-runtime.sh
@@ -239,7 +239,7 @@ sub_cobol(){
 
 # Backtrace (this only improves stack traces verbosity but backtracing is enabled by default)
 sub_backtrace(){
-	echo "configure cobol"
+	echo "configure backtrace"
 
 	sub_apt_install_hold libdw1
 }


### PR DESCRIPTION
# Description

Added a Clear Error message when backtrace_plugin load fails

Other Minor fixes
 
* Replaced `echo "configure cobol"` with `echo "configure backtrace"` [here](https://github.com/metacall/core/blob/develop/tools/metacall-runtime.sh#L242)

* Added backtrace_plugin to test.yml


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh build &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_SANITIZER` or `./docker-compose.sh test &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
