### PR TITLE
Rs Loader: Move artifacts to temp folder.

### DIFF
--- a/source/loaders/rs_loader/rust/compiler/src/lib.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/lib.rs
@@ -119,11 +119,11 @@ impl Source {
                     path.file_name()
                         .expect(format!("Unable to get the filename of {:?}", path).as_str()),
                 );
-
+                let temp_dir = std::env::temp_dir();
                 SourceImpl {
                     input: SourceInput(config::Input::File(path.clone())),
                     input_path: input_path(&dir, &name),
-                    output: output_path(&dir, &name),
+                    output: output_path(&temp_dir, &name),
                     source,
                 }
             }
@@ -151,11 +151,11 @@ impl Source {
                     path.file_name()
                         .expect(format!("Unable to get the filename of {:?}", path).as_str()),
                 );
-
+                let temp_dir = std::env::temp_dir();
                 SourceImpl {
                     input: SourceInput(config::Input::File(path.clone())),
                     input_path: input_path(&dir, &name),
-                    output: output_path(&dir, &name),
+                    output: output_path(&temp_dir, &name),
                     source,
                 }
             }
@@ -563,13 +563,7 @@ impl rustc_driver::Callbacks for CompilerCallbacks {
                 ErrorOutputType::default(),
             ));
             // Set up inputs
-            let wrapped_script_path = self
-                .source
-                .input_path
-                .clone()
-                .parent()
-                .expect("input path has no parent")
-                .join("metacall_wrapped_package.rs");
+            let wrapped_script_path = std::env::temp_dir().join("metacall_wrapped_package.rs");
             if self.is_parsing {
                 let mut wrapped_script = std::fs::File::create(&wrapped_script_path)
                     .expect("unable to create wrapped script");

--- a/source/loaders/rs_loader/rust/compiler/src/wrapper/mod.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/wrapper/mod.rs
@@ -137,17 +137,18 @@ pub fn generate_wrapper(callbacks: CompilerCallbacks) -> std::io::Result<Compile
                 generate_class_wrapper_for_package(&callbacks.classes.iter().collect());
             content.push_str(&class_wrapper);
 
-            let source_dir = path.parent().expect("input path has no parent");
+            // use temp_dir instead.
+            let temp_dir = std::env::temp_dir();
 
             // create metacall_class file
             // println!("create: {:?}", source_dir.join("metacall_class.rs"));
-            let mut class_file = File::create(source_dir.join("metacall_class.rs"))?;
+            let mut class_file = File::create(temp_dir.join("metacall_class.rs"))?;
             let bytes = include_bytes!("class.rs");
             class_file.write_all(bytes)?;
             // println!("open: {:?}", source_dir.join("metacall_wrapped_package.rs"));
             let mut wrapper_file = std::fs::OpenOptions::new()
                 .append(true)
-                .open(source_dir.join("metacall_wrapped_package.rs"))?;
+                .open(temp_dir.join("metacall_wrapped_package.rs"))?;
             // include class module
             wrapper_file.write_all(b"mod metacall_class;\nuse metacall_class::*;\n")?;
             wrapper_file.write_all(content.as_bytes())?;
@@ -172,29 +173,30 @@ pub fn generate_wrapper(callbacks: CompilerCallbacks) -> std::io::Result<Compile
 
             match callbacks.source.input.0 {
                 Input::File(input_path) => {
+                    let temp_dir = std::env::temp_dir();
                     // generate wrappers to a file source_wrapper.rs
-                    let mut source_path = input_path.clone();
-                    let source_file = source_path
+                    let source_file = input_path
                         .file_name()
                         .expect("not a file")
                         .to_str()
                         .expect("Unable to cast OsStr to str")
                         .to_owned();
-                    let _ = source_path.pop();
 
                     // create metacall_class file
-                    let mut class_file = File::create(source_path.join("metacall_class.rs"))?;
+                    let mut class_file = File::create(temp_dir.join("metacall_class.rs"))?;
                     let bytes = include_bytes!("class.rs");
                     class_file.write_all(bytes)?;
 
-                    source_path.push("wrapped_".to_owned() + &source_file);
-                    let mut wrapper_file = File::create(&source_path)?;
+                    let mut wrapper_file =
+                        File::create(&temp_dir.join("wrapped_".to_owned() + &source_file))?;
                     // include class module
                     wrapper_file.write_all(b"mod metacall_class;\nuse metacall_class::*;\n")?;
                     wrapper_file.write_all(content.as_bytes())?;
-                    let dst = format!("include!({:?});", callbacks.source.input_path.clone());
+                    let dst = format!("include!({:?});", callbacks.source.input_path);
                     wrapper_file.write_all(dst.as_bytes())?;
-                    let mut source = Source::new(Source::File { path: source_path });
+                    let mut source = Source::new(Source::File {
+                        path: temp_dir.join("wrapped_".to_owned() + &source_file),
+                    });
                     source.output = callbacks.source.output;
                     // construct new callback
                     Ok(CompilerCallbacks {


### PR DESCRIPTION
Signed-off-by: Tricster <mediosrity@gmail.com>

# Description
We used to generate intermediate artifacts in the same of folder of source files, now move the artifacts to temp folder.

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [x] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [x] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh build &> output` and attached the output.
- [x] I have tested my code with `OPTION_BUILD_SANITIZER` or `./docker-compose.sh test &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
