### PR TITLE
[FIX] Running python on metacall windows works now

### DIFF
--- a/source/ports/py_port/metacall/module_win32.py
+++ b/source/ports/py_port/metacall/module_win32.py
@@ -67,6 +67,8 @@ def metacall_module_load():
 
 	for name in library_names:
 		runtime_module_handle = get_loaded_module(modules, os.path.join(os.path.sep, base_path, name + '.dll'))
+		if runtime_module_handle is None:
+			continue
 		runtime_module = ctypes.CDLL('', handle = runtime_module_handle) # cdecl calling convention
 
 		if runtime_module != None:


### PR DESCRIPTION
# Description

When `metacall main.py` used to be run, errors used to get caused as `ctypes` in `module_win32.py` used to try to load a dll which didnt exist, and used to crash immediately without trying all the alternatives. 

Added the check now

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
