### PR TITLE
[Rust]: Move build artifacts into unique folder.

### DIFF
--- a/source/loaders/rs_loader/rust/compiler/src/memory.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/memory.rs
@@ -28,14 +28,10 @@ impl MemoryRegistration {
             Ok(instance) => instance,
             Err(error) => return Err(RegistrationError::DlopenError(error)),
         };
-        // delete temporary files
-        let tmp_dir = std::env::temp_dir();
-        fs::remove_file(tmp_dir.join("script.rs")).expect("unable to delete source script");
-        fs::remove_file(tmp_dir.join("wrapped_script.rs"))
-            .expect("unable to delete wrapped script");
-        fs::remove_file(tmp_dir.join("metacall_class.rs"))
-            .expect("unable to delete metacall class");
-        fs::remove_file(&state.output).expect("unable to delete compiled library");
+        // cleanup temp dir
+        let mut destination = state.output.clone();
+        destination.pop();
+        std::fs::remove_dir_all(destination).expect("Unable to cleanup tempdir");
 
         Ok(MemoryRegistration {
             name,

--- a/source/loaders/rs_loader/rust/compiler/src/wrapper/mod.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/wrapper/mod.rs
@@ -138,7 +138,7 @@ pub fn generate_wrapper(callbacks: CompilerCallbacks) -> std::io::Result<Compile
             content.push_str(&class_wrapper);
 
             // use temp_dir instead.
-            let temp_dir = std::env::temp_dir();
+            let temp_dir = callbacks.destination.clone();
 
             // create metacall_class file
             // println!("create: {:?}", source_dir.join("metacall_class.rs"));
@@ -173,7 +173,7 @@ pub fn generate_wrapper(callbacks: CompilerCallbacks) -> std::io::Result<Compile
 
             match callbacks.source.input.0 {
                 Input::File(input_path) => {
-                    let temp_dir = std::env::temp_dir();
+                    let temp_dir = callbacks.destination.clone();
                     // generate wrappers to a file source_wrapper.rs
                     let source_file = input_path
                         .file_name()
@@ -207,7 +207,7 @@ pub fn generate_wrapper(callbacks: CompilerCallbacks) -> std::io::Result<Compile
                 }
                 Input::Str { name, input } => match name {
                     Custom(_name) => {
-                        let source_path = std::env::temp_dir();
+                        let source_path = callbacks.destination.clone();
                         // write code to script
                         let mut source_file = File::create(source_path.join("script.rs"))?;
                         source_file.write_all(input.as_bytes())?;

--- a/source/tests/sanitizer/tsan.supp
+++ b/source/tests/sanitizer/tsan.supp
@@ -41,6 +41,6 @@ mutex:libclang-11*
 #
 # Rust
 #
-called_from_lib:libLLVM*
-called_from_lib:librustc_driver-*
-called_from_lib:libstd-*
+race:libLLVM*
+race:librustc_driver-*
+race:libstd-*


### PR DESCRIPTION
Signed-off-by: Tricster <mediosrity@gmail.com>

# Description

Move build artifacts of every loaded package into a unique folder to avoid collision when running in parallel.

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [x] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [x] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh build &> output` and attached the output.
- [x] I have tested my code with `OPTION_BUILD_SANITIZER` or `./docker-compose.sh test &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [x] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
