### PR TITLE
Made workflow step fail if any step fails

### DIFF
--- a/tools/metacall-build.ps1
+++ b/tools/metacall-build.ps1
@@ -44,7 +44,10 @@ function sub-build {
 	cmake --build . "-j$((Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors)"
 
 	if ( -not $? ) {
-		$Global:ExitCode = $LASTEXITCODE
+		$RecentExitCode = $LASTEXITCODE
+		echo "Failure in build with exit code: $RecentExitCode"
+
+		$Global:ExitCode = $RecentExitCode
 	}
 
 	# Tests (coverage needs to run the tests)
@@ -68,7 +71,10 @@ function sub-build {
 		ctest "-j$((Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors)" --output-on-failure -C $BUILD_TYPE
 
 		if ( -not $? ) {
-			$Global:ExitCode = $LASTEXITCODE
+			$RecentExitCode = $LASTEXITCODE
+			echo "Failure in tests with exit code: $RecentExitCode"
+
+			$Global:ExitCode = $RecentExitCode
 		}
 	}
 
@@ -82,7 +88,10 @@ function sub-build {
 		make -k lcov-genhtml
 
 		if ( -not $? ) {
-			$Global:ExitCode = $LASTEXITCODE
+			$RecentExitCode = $LASTEXITCODE
+			echo "Failure in coverage with exit code: $RecentExitCode"
+
+			$Global:ExitCode = $RecentExitCode
 		}
 	} #>
 
@@ -92,7 +101,10 @@ function sub-build {
 		cmake --build . --target install
 
 		if ( -not $? ) {
-			$Global:ExitCode = $LASTEXITCODE
+			$RecentExitCode = $LASTEXITCODE
+			echo "Failure in install with exit code: $RecentExitCode"
+
+			$Global:ExitCode = $RecentExitCode
 		}
 	}
 

--- a/tools/metacall-build.ps1
+++ b/tools/metacall-build.ps1
@@ -37,10 +37,15 @@ function sub-options {
 }
 
 function sub-build {
+	$Global:ExitCode = 0
 
 	# Build the project
 	echo "Building MetaCall..."
 	cmake --build . "-j$((Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors)"
+
+	if ( -not $? ) {
+		$Global:ExitCode = 1
+	}
 
 	# Tests (coverage needs to run the tests)
 	if ( ($BUILD_TESTS -eq 1) -or ($BUILD_COVERAGE -eq 1) ) {
@@ -61,6 +66,10 @@ function sub-build {
 		}
 
 		ctest "-j$((Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors)" --output-on-failure -C $BUILD_TYPE
+
+		if ( -not $? ) {
+			$Global:ExitCode = 1
+		}
 	}
 
 	# Coverage
@@ -71,13 +80,23 @@ function sub-build {
 		make -k gcov
 		make -k lcov
 		make -k lcov-genhtml
+
+		if ( -not $? ) {
+			$Global:ExitCode = 1
+		}
 	} #>
 
 	# Install
 	if ( $BUILD_INSTALL -eq 1 ) {
 		echo "Building and installing MetaCall..."
 		cmake --build . --target install
+
+		if ( -not $? ) {
+			$Global:ExitCode = 1
+		}
 	}
+
+	Exit $ExitCode
 }
 
 function sub-help {

--- a/tools/metacall-build.ps1
+++ b/tools/metacall-build.ps1
@@ -44,7 +44,7 @@ function sub-build {
 	cmake --build . "-j$((Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors)"
 
 	if ( -not $? ) {
-		$Global:ExitCode = 1
+		$Global:ExitCode = $LASTEXITCODE
 	}
 
 	# Tests (coverage needs to run the tests)
@@ -68,7 +68,7 @@ function sub-build {
 		ctest "-j$((Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors)" --output-on-failure -C $BUILD_TYPE
 
 		if ( -not $? ) {
-			$Global:ExitCode = 1
+			$Global:ExitCode = $LASTEXITCODE
 		}
 	}
 
@@ -82,7 +82,7 @@ function sub-build {
 		make -k lcov-genhtml
 
 		if ( -not $? ) {
-			$Global:ExitCode = 1
+			$Global:ExitCode = $LASTEXITCODE
 		}
 	} #>
 
@@ -92,7 +92,7 @@ function sub-build {
 		cmake --build . --target install
 
 		if ( -not $? ) {
-			$Global:ExitCode = 1
+			$Global:ExitCode = $LASTEXITCODE
 		}
 	}
 


### PR DESCRIPTION
# Made workflow step fail if any step fails

# Description

This PR makes sure the step fails even if any of build, test, or install fail in the final build step for Windows.

CC: @viferga 

<!-- Fixes #(issue_no) -->

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh build &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_SANITIZER` or `./docker-compose.sh test &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
