### PR TITLE
Add macos pipeline and scripts

### DIFF
--- a/.github/workflows/macos-test.yaml
+++ b/.github/workflows/macos-test.yaml
@@ -52,11 +52,12 @@ jobs:
           chmod +x ../tools/metacall-build.sh
           sh ../tools/metacall-configure.sh $METACALL_BUILD_OPTIONS
         env:
-          METACALL_BUILD_OPTIONS: ${{ matrix.buildtype }} scripts ports tests sanitizer #python nodejs #java sanitizer # ruby # netcore5 typescript file rpc wasm java c cobol rust examples dynamic install pack benchmarks # v8 coverage
+          METACALL_BUILD_OPTIONS: ${{ matrix.buildtype }} scripts ports tests sanitizer python #nodejs #java sanitizer # ruby # netcore5 typescript file rpc wasm java c cobol rust examples dynamic install pack benchmarks # v8 coverage
 
       - name: Build
         working-directory: ./build
         run: |
+          echo $BUILD_STRING
           cmake ..
           sudo HOME="$HOME" cmake --build . --target install
           ctest -j$(getconf _NPROCESSORS_ONLN) --timeout 5400 --output-on-failure --test-output-size-failed 3221000000 -C $BUILD_TYPE

--- a/.github/workflows/macos-test.yaml
+++ b/.github/workflows/macos-test.yaml
@@ -1,0 +1,66 @@
+name: MacOS Test
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    tags:
+      - 'v*.*.*'
+    branches:
+      - master
+      - develop
+
+jobs:
+  mac-test:
+    name: MacOS Clang Test
+    runs-on: macos-latest
+
+    strategy:
+      matrix:
+        buildtype: [debug] # TODO: Add release
+    
+    env:
+      LTTNG_UST_REGISTER_TIMEOUT:  0
+      NUGET_XMLDOC_MODE:           skip
+      DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+
+      - name: Configure Clang 
+        run: |
+          brew install llvm
+          brew install libomp
+          brew install cmake  git  wget  gnupg  ca-certificates 
+          brew install clang-format
+
+      - name: Set up the environment
+        run: sh ./tools/metacall-environment-macos.sh $METACALL_INSTALL_OPTIONS
+        env:
+          METACALL_INSTALL_OPTIONS: python nodejs  # ruby netcore5 typescript file rpc wasm java c cobol rust rapidjson funchook swig pack # clangformat v8rep51 coverage
+
+      - name: Configure
+        run: |
+          METACALL_PATH=$PWD
+          mkdir -p "$METACALL_PATH/build"
+          cd "$METACALL_PATH/build"
+          chmod +x ../tools/metacall-configure.sh
+          chmod +x ../tools/metacall-build.sh
+          sh ../tools/metacall-configure.sh $METACALL_BUILD_OPTIONS
+        env:
+          METACALL_BUILD_OPTIONS: ${{ matrix.buildtype }} scripts ports tests sanitizer #python nodejs #java sanitizer # ruby # netcore5 typescript file rpc wasm java c cobol rust examples dynamic install pack benchmarks # v8 coverage
+
+      - name: Build
+        working-directory: ./build
+        run: |
+          cmake ..
+          sudo HOME="$HOME" cmake --build . --target install
+          ctest -j$(getconf _NPROCESSORS_ONLN) --timeout 5400 --output-on-failure --test-output-size-failed 3221000000 -C $BUILD_TYPE
+        env:
+          METACALL_BUILD_OPTIONS: ${{ matrix.buildtype }} tests
+          BUILD_TYPE: Release
+         

--- a/.github/workflows/macos-test.yaml
+++ b/.github/workflows/macos-test.yaml
@@ -53,12 +53,11 @@ jobs:
           chmod +x ../tools/metacall-build.sh
           sh ../tools/metacall-configure.sh $METACALL_BUILD_OPTIONS
         env:
-          METACALL_BUILD_OPTIONS: ${{ matrix.buildtype }} scripts ports tests sanitizer python #nodejs #java sanitizer # ruby # netcore5 typescript file rpc wasm java c cobol rust examples dynamic install pack benchmarks # v8 coverage
+          METACALL_BUILD_OPTIONS: ${{ matrix.buildtype }} scripts ports tests sanitizer nodejs #python  #java sanitizer # ruby # netcore5 typescript file rpc wasm java c cobol rust examples dynamic install pack benchmarks # v8 coverage
 
       - name: Build
         working-directory: ./build
         run: |
-          echo $BUILD_STRING
           cmake ..
           sudo HOME="$HOME" cmake --build . --target install
           ctest -j$(getconf _NPROCESSORS_ONLN) --timeout 5400 --output-on-failure --test-output-size-failed 3221000000 -C $BUILD_TYPE

--- a/.github/workflows/macos-test.yaml
+++ b/.github/workflows/macos-test.yaml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - develop
+      - feat/macos-pipeline
 
 jobs:
   mac-test:

--- a/.github/workflows/macos-test.yaml
+++ b/.github/workflows/macos-test.yaml
@@ -9,7 +9,6 @@ on:
     branches:
       - master
       - develop
-      - feat/macos-pipeline
 
 jobs:
   mac-test:
@@ -53,7 +52,7 @@ jobs:
           chmod +x ../tools/metacall-build.sh
           sh ../tools/metacall-configure.sh $METACALL_BUILD_OPTIONS
         env:
-          METACALL_BUILD_OPTIONS: ${{ matrix.buildtype }} scripts ports tests sanitizer nodejs #python  #java sanitizer # ruby # netcore5 typescript file rpc wasm java c cobol rust examples dynamic install pack benchmarks # v8 coverage
+          METACALL_BUILD_OPTIONS: ${{ matrix.buildtype }} scripts ports tests sanitizer #nodejs #python  #java sanitizer # ruby # netcore5 typescript file rpc wasm java c cobol rust examples dynamic install pack benchmarks # v8 coverage
 
       - name: Build
         working-directory: ./build

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -92,7 +92,12 @@ elseif(OPTION_BUILD_UB_SANITIZER AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" 
 		"__UB_SANITIZER__=1"
 	)
 elseif(OPTION_BUILD_SANITIZER AND (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"))
-	set(SANITIZER_LIBRARIES -lasan -lubsan)
+	# check if compiler is clang 
+	if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+		set(SANITIZER_LIBRARIES -fsanitize=address)
+	else()
+		set(SANITIZER_LIBRARIES -lasan -lubsan)
+	endif()
 	set(TESTS_SANITIZER_ENVIRONMENT_VARIABLES
 		"LSAN_OPTIONS=verbosity=1:log_threads=1:print_suppressions=false:suppressions=${CMAKE_SOURCE_DIR}/source/tests/sanitizer/lsan.supp"
 

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -92,12 +92,7 @@ elseif(OPTION_BUILD_UB_SANITIZER AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" 
 		"__UB_SANITIZER__=1"
 	)
 elseif(OPTION_BUILD_SANITIZER AND (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"))
-	# check if compiler is clang 
-	if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-		set(SANITIZER_LIBRARIES -fsanitize=address)
-	else()
-		set(SANITIZER_LIBRARIES -lasan -lubsan)
-	endif()
+	set(SANITIZER_LIBRARIES -lasan -lubsan)
 	set(TESTS_SANITIZER_ENVIRONMENT_VARIABLES
 		"LSAN_OPTIONS=verbosity=1:log_threads=1:print_suppressions=false:suppressions=${CMAKE_SOURCE_DIR}/source/tests/sanitizer/lsan.supp"
 

--- a/tools/metacall-environment-macos.sh
+++ b/tools/metacall-environment-macos.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+
+#	MetaCall Configuration Environment Bash Script by Parra Studios
+#   This script only installs python and nodejs for now.
+#   It will be updated to install all the dependencies for all the languages.
+
+INSTALL_PYTHON=0
+INSTALL_RUBY=0
+INSTALL_RUST=0
+INSTALL_RAPIDJSON=0
+INSTALL_FUNCHOOK=0
+INSTALL_NETCORE=0
+INSTALL_NETCORE2=0
+INSTALL_NETCORE5=0
+INSTALL_NETCORE7=0
+INSTALL_V8=0
+INSTALL_V8REPO=0
+INSTALL_V8REPO58=0
+INSTALL_V8REPO57=0
+INSTALL_V8REPO54=0
+INSTALL_V8REPO52=0
+INSTALL_V8REPO51=0
+INSTALL_NODEJS=0
+INSTALL_TYPESCRIPT=0
+INSTALL_FILE=0
+INSTALL_RPC=0
+INSTALL_WASM=0
+INSTALL_JAVA=0
+INSTALL_C=0
+INSTALL_COBOL=0
+INSTALL_SWIG=0
+INSTALL_METACALL=0
+INSTALL_PACK=0
+INSTALL_COVERAGE=0
+INSTALL_CLANGFORMAT=0
+INSTALL_BACKTRACE=0
+SHOW_HELP=0
+PROGNAME=$(basename $0)
+
+# Swig
+sub_swig() {
+    brew install swig
+}
+
+# Python
+sub_python() {
+    echo "configuring python"
+    brew install python3 python3-pip
+    pip3 install requests
+    pip3 install setuptools
+    pip3 install wheel
+    pip3 install rsa
+    pip3 install scipy
+    pip3 install numpy
+    pip3 install joblib
+    pip3 install scikit-learn
+}
+
+# NodeJS
+sub_nodejs(){
+    echo "configuring nodejs"
+	npm uninstall npm -g
+	rm -rf /usr/local/lib/node_modules/npm
+    brew install node make npm curl python3
+}
+
+
+sub_install()
+{
+	if [ $INSTALL_PYTHON = 1 ]; then
+		sub_python
+	fi
+    if [ $INSTALL_NODEJS = 1 ]; then
+        sub_nodejs
+    fi
+}
+
+sub_options(){
+	for var in "$@"
+	do
+		if [ "$var" = 'cache' ]; then
+			echo "apt caching selected"
+			APT_CACHE=1
+		fi
+		if [ "$var" = 'base' ]; then
+			echo "apt selected"
+			INSTALL_APT=1
+		fi
+		if [ "$var" = 'python' ]; then
+			echo "python selected"
+			INSTALL_PYTHON=1
+		fi
+		if [ "$var" = 'ruby' ]; then
+			echo "ruby selected"
+			INSTALL_RUBY=1
+		fi
+		if [ "$var" = 'rust' ]; then
+			echo "rust selected"
+			INSTALL_RUST=1
+		fi
+		if [ "$var" = 'netcore' ]; then
+			echo "netcore selected"
+			INSTALL_NETCORE=1
+		fi
+		if [ "$var" = 'netcore2' ]; then
+			echo "netcore 2 selected"
+			INSTALL_NETCORE2=1
+		fi
+		if [ "$var" = 'netcore5' ]; then
+			echo "netcore 5 selected"
+			INSTALL_NETCORE5=1
+		fi
+		if [ "$var" = 'netcore7' ]; then
+			echo "netcore 7 selected"
+			INSTALL_NETCORE7=1
+		fi
+		if [ "$var" = 'rapidjson' ]; then
+			echo "rapidjson selected"
+			INSTALL_RAPIDJSON=1
+		fi
+		if [ "$var" = 'funchook' ]; then
+			echo "funchook selected"
+			INSTALL_FUNCHOOK=1
+		fi
+		if [ "$var" = 'v8' ] || [ "$var" = 'v8rep54' ]; then
+			echo "v8 selected"
+			INSTALL_V8REPO=1
+			INSTALL_V8REPO54=1
+		fi
+		if [ "$var" = 'v8rep57' ]; then
+			echo "v8 selected"
+			INSTALL_V8REPO=1
+			INSTALL_V8REPO57=1
+		fi
+		if [ "$var" = 'v8rep58' ]; then
+			echo "v8 selected"
+			INSTALL_V8REPO=1
+			INSTALL_V8REPO58=1
+		fi
+		if [ "$var" = 'v8rep52' ]; then
+			echo "v8 selected"
+			INSTALL_V8REPO=1
+			INSTALL_V8REPO52=1
+		fi
+		if [ "$var" = 'v8rep51' ]; then
+			echo "v8 selected"
+			INSTALL_V8REPO=1
+			INSTALL_V8REPO51=1
+		fi
+		if [ "$var" = 'nodejs' ]; then
+			echo "nodejs selected"
+			INSTALL_NODEJS=1
+		fi
+		if [ "$var" = 'typescript' ]; then
+			echo "typescript selected"
+			INSTALL_TYPESCRIPT=1
+		fi
+		if [ "$var" = 'file' ]; then
+			echo "file selected"
+			INSTALL_FILE=1
+		fi
+		if [ "$var" = 'rpc' ]; then
+			echo "rpc selected"
+			INSTALL_RPC=1
+		fi
+		if [ "$var" = 'wasm' ]; then
+			echo "wasm selected"
+			INSTALL_WASM=1
+		fi
+		if [ "$var" = 'java' ]; then
+			echo "java selected"
+			INSTALL_JAVA=1
+		fi
+		if [ "$var" = 'c' ]; then
+			echo "c selected"
+			INSTALL_C=1
+		fi
+		if [ "$var" = 'cobol' ]; then
+			echo "cobol selected"
+			INSTALL_COBOL=1
+		fi
+		if [ "$var" = 'swig' ]; then
+			echo "swig selected"
+			INSTALL_SWIG=1
+		fi
+		if [ "$var" = 'metacall' ]; then
+			echo "metacall selected"
+			INSTALL_METACALL=1
+		fi
+		if [ "$var" = 'pack' ]; then
+			echo "pack selected"
+			INSTALL_PACK=1
+		fi
+		if [ "$var" = 'coverage' ]; then
+			echo "coverage selected"
+			INSTALL_COVERAGE=1
+		fi
+		if [ "$var" = 'clangformat' ]; then
+			echo "clangformat selected"
+			INSTALL_CLANGFORMAT=1
+		fi
+		if [ "$var" = 'backtrace' ]; then
+			echo "backtrace selected"
+			INSTALL_BACKTRACE=1
+		fi
+	done
+}
+
+case "$#" in
+	0)
+		sub_help
+		;;
+	*)
+		sub_options $@
+		sub_install
+		;;
+esac


### PR DESCRIPTION
# Description

According to this [PR](https://github.com/metacall/core/pull/248) the only thing that was not completed is the macOS pipeline, so I created the pipeline for it.
It is just running tests, for now, it does not support any language yet.


Fixes #(issue_no)

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [x] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [x] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test &> output` and attached the 

# Note:
The ci for macOS is falling at three test cases which are:

-  15- detour-test
-  4 - log-custom-test (Subprocess aborted)
-  35 - metacall-dynlink-path-test

you can view full logs from [here ](https://github.com/ahmedihabb2/core/actions/runs/4129078853/jobs/7134289663)