### PR TITLE
Updated CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,6 @@ set(WriterCompilerDetectionHeaderFound NOTFOUND)
 
 include(ExternalProject)
 
-# This module is only available with CMake >=3.1, so check whether it could be found
-include(WriteCompilerDetectionHeader OPTIONAL RESULT_VARIABLE WriterCompilerDetectionHeaderFound)
-
 include(GetGitRevisionDescription)
 include(Custom)
 


### PR DESCRIPTION
Build error:-

The WriteCompilerDetectionHeader module will be removed by policy CMP0120.
 CMakeLists.txt:35 (include)

# Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.

Fixes #(241)

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code.


If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
