### PR TITLE
runtimeLinkAdded

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -120,7 +120,7 @@ This section describes all programming languages that **METACALL** allows to loa
 | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | :--: |
 | [C++](http://www.cplusplus.com/)                                              | [Clang](https://clang.llvm.org/) - [LLVM](https://llvm.org/)                                           | cpp  |
 | [PHP](https://php.net/)                                                       | [Zend](https://www.php.net/manual/en/internals2.ze1.zendapi.php)                                       | php  |
-| [Go](https://golang.org/)                                                     | Go Runtime                                                                                             |  go  |
+| [Go](https://golang.org/)                                                     | [Go](https://pkg.go.dev/runtime)                                                                                             |  go  |
 | [Haskell](https://www.haskell.org/)                                           | [Haskell FFI](https://wiki.haskell.org/GHC/Using_the_FFI)                                              |  hs  |
 | [Crystal](https://crystal-lang.org/)                                          | [Crystal Compiler Internals](https://github.com/crystal-lang/crystal/wiki/Compiler-internals)          |  cr  |
 | [JavaScript](https://developer.mozilla.org/bm/docs/Web/JavaScript)            | [SpiderMonkey](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/JSAPI_reference) | jsm  |


### PR DESCRIPTION
# Description

While reading the documentation, in the Documentation - 2.1 Loaders, link to Go runtime package was not listed. So I added the link in that section (Under Loaders(Backends) *languages and runtimes under construction.


## Type of change

<!-- Please delete options that are not relevant. -->

- [o] Documentation update

# Checklist:

- [o] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [o] I have made corresponding changes to the documentation.
- [o] My changes generate no new warnings.
- [x] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [x] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [x] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test &> output` and attached the output.
- [x] I have tested my code with `OPTION_BUILD_SANITIZER` or `./docker-compose.sh test-sanitizer &> output` and `OPTION_TEST_MEMORYCHECK`.
- [x] I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer &> output`.
- [x] I have tested with `Helgrind` in case my code works with threading.
- [x] I have run `make clang-format in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
