### PR TITLE
ports/go: support buffer type

### DIFF
--- a/source/ports/go_port/source/go_port_test.go
+++ b/source/ports/go_port/source/go_port_test.go
@@ -1,6 +1,7 @@
 package metacall
 
 import (
+	"bytes"
 	"log"
 	"os"
 	"reflect"
@@ -153,6 +154,10 @@ func TestValues(t *testing.T) {
 		{"double_min", float64(2.3e-308), float64(2.3e-308)},
 		{"double_max", float64(1.7e+308), float64(1.7e+308)},
 		{"string", "hello", "hello"},
+		{"buffer_empty", *bytes.NewBuffer([]byte{}), *bytes.NewBuffer([]byte{})},
+		{"buffer_nil", *bytes.NewBuffer(nil), *bytes.NewBuffer([]byte{})}, // TODO(iyear): how to handle nil buffer?
+		{"buffer_ascii", *bytes.NewBuffer([]byte{'A', 'B', 'C'}), *bytes.NewBuffer([]byte{'A', 'B', 'C'})},
+		{"buffer_unicode", *bytes.NewBuffer([]byte("\u00A9\u00A9\u00A9")), *bytes.NewBuffer([]byte("\u00A9\u00A9\u00A9"))},
 		{"array", [3]interface{}{1, 2, 3}, []interface{}{1, 2, 3}},
 		{"array_bool", [3]bool{true, false, true}, []interface{}{true, false, true}},
 		{"array_char", [3]byte{'1', '2', '3'}, []interface{}{byte('1'), byte('2'), byte('3')}},


### PR DESCRIPTION
# Description

Support buffer type for go port.

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_SANITIZER` or `./docker-compose.sh test-sanitizer &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer &> output`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
