### PR TITLE
move file protocol outside Paths.get

### DIFF
--- a/source/loaders/java_loader/bootstrap/lib/bootstrap.java
+++ b/source/loaders/java_loader/bootstrap/lib/bootstrap.java
@@ -143,8 +143,8 @@ public class bootstrap {
             JarFile jarFile = new JarFile(curJarPath.toString());
             Enumeration<JarEntry> e = jarFile.entries();
 
-            Path jpath = Paths.get("jar:file:", curExecPath, path);
-            String jarPath = jpath.toString() + "!/";
+            Path jpath = Paths.get(curExecPath, path);
+            String jarPath = "jar:file:" + jpath.toString() + "!/";
 
             Path epath = Paths.get(curExecPath, path);
             executionPath.add(epath.toString());


### PR DESCRIPTION
# Description

Fix error in java test
```
EXCEPTION java.nio.file.InvalidPathException: Illegal char <:> at index 3: jar:file:\D:/a/core/core/build/scripts/\JarTest.jar
```