### PR TITLE
remove unnecessary import of 'ctypes'

### DIFF
--- a/source/ports/py_port/metacall/module_win32.py
+++ b/source/ports/py_port/metacall/module_win32.py
@@ -18,7 +18,6 @@
 #	limitations under the License.
 
 import os
-import ctypes
 from ctypes import wintypes, windll
 
 def metacall_module_load():


### PR DESCRIPTION

# Description

Remove unnecessary import of ctypes from module_win32.py file


## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Delete a line to optimize the code

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

