### PR TITLE
Update Benchmark CI to use another repo

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -74,11 +74,11 @@ jobs:
             tool: 'googlecpp'
             output-file-path: ./build/benchmarks/metacall-benchmarks.json
             # Access token to deploy GitHub Pages branch
-            github-token: ${{ secrets.PUSH_TOKEN }}
+            github-token: ${{ secrets.BENCHMARKS_PUSH_TOKEN }}
             # Disable push and deploy GitHub pages branch automatically
             auto-push: false
             # Github Pages repository name
-            gh-repository: github.com/ahmedihabb2/benchmarks
+            gh-repository: github.com/metacall/core-benchmarks
             # Github Pages branch name
             gh-pages-branch: main
             # Output directory
@@ -88,9 +88,9 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         run: |
           cd  benchmark-data-repository
-          git push https://$REPO_KEY@github.com/ahmedihabb2/benchmarks.git
+          git push https://$REPO_KEY@github.com/metacall/core-benchmarks.git
         env:
-          REPO_KEY: ${{secrets.PUSH_TOKEN}}
+          REPO_KEY: ${{secrets.BENCHMARKS_PUSH_TOKEN}}
 
   benchmark-windows:
     runs-on: ${{ matrix.os }}
@@ -149,11 +149,11 @@ jobs:
             tool: 'googlecpp'
             output-file-path: ./build/benchmarks/metacall-benchmarks.json
             # Access token to deploy GitHub Pages branch
-            github-token: ${{ secrets.PUSH_TOKEN }}
+            github-token: ${{ secrets.BENCHMARKS_PUSH_TOKEN }}
             # Disable push and deploy GitHub pages branch automatically
             auto-push: false
             # Github Pages repository name
-            gh-repository: github.com/ahmedihabb2/benchmarks
+            gh-repository: github.com/metacall/core-benchmarks
             # Github Pages branch name
             gh-pages-branch: main
             # Output directory
@@ -165,4 +165,4 @@ jobs:
           cd  benchmark-data-repository
           git push https://${REPO_KEY}@github.com/metacall/core-benchmarks.git
         env:
-          REPO_KEY: ${{secrets.PUSH_TOKEN}}
+          REPO_KEY: ${{secrets.BENCHMARKS_PUSH_TOKEN}}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -66,14 +66,6 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         run: python3 ./tools/metacall-benchmarks-merge.py ./build/benchmarks
 
-      # Download previous benchmark result from cache (if exists)
-      - name: Download previous benchmark data
-        uses: actions/cache@v1
-        if: ${{ github.event_name != 'pull_request' }}
-        with:
-          path: ./cache
-          key: ${{ matrix.os }}-benchmark
-
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -163,6 +163,6 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         run: |     
           cd  benchmark-data-repository
-          git push https://${REPO_KEY}@github.com/ahmedihabb2/benchmarks.git
+          git push https://${REPO_KEY}@github.com/metacall/core-benchmarks.git
         env:
           REPO_KEY: ${{secrets.PUSH_TOKEN}}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -82,7 +82,7 @@ jobs:
             tool: 'googlecpp'
             output-file-path: ./build/benchmarks/metacall-benchmarks.json
             # Access token to deploy GitHub Pages branch
-            github-token: ${{ secrets.GITHUB_TOKEN }}
+            github-token: ${{ secrets.PUSH_TOKEN }}
             # Disable push and deploy GitHub pages branch automatically
             auto-push: false
             # Github Pages repository name

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -82,24 +82,23 @@ jobs:
             tool: 'googlecpp'
             output-file-path: ./build/benchmarks/metacall-benchmarks.json
             # Access token to deploy GitHub Pages branch
-            github-token: ""
+            github-token: ${{ secrets.GITHUB_TOKEN }}
             # Disable push and deploy GitHub pages branch automatically
             auto-push: false
-            skip-fetch-gh-pages: true
+            # Github Pages repository name
+            gh-repository: github.com/ahmedihabb2/benchmarks
             # Github Pages branch name
-            gh-pages-branch: ${{ github.head_ref || github.ref_name }}
+            gh-pages-branch: main
             # Output directory
-            benchmark-data-dir-path: bench/${{ matrix.os }}
-            # Where the previous data file is stored
-            external-data-json-path: ./cache/metacall-benchmarks.json
+            benchmark-data-dir-path: ./${{ matrix.os }}
 
-      # Upload benchmark artifacts
-      - name: Upload benchmark artifact
-        uses: actions/upload-artifact@master
+      - name:  Push benchmark result
         if: ${{ github.event_name != 'pull_request' }}
-        with:
-          name: ${{ matrix.os }}-benchmark
-          path: ./bench/
+        run: |
+          cd  benchmark-data-repository
+          git push https://$REPO_KEY@github.com/ahmedihabb2/benchmarks.git
+        env:
+          REPO_KEY: ${{secrets.PUSH_TOKEN}}
 
   benchmark-windows:
     runs-on: ${{ matrix.os }}
@@ -150,14 +149,6 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         run: python3 ./tools/metacall-benchmarks-merge.py ./build/benchmarks
 
-      # Download previous benchmark result from cache (if exists)
-      - name: Download previous benchmark data
-        uses: actions/cache@v1
-        if: ${{ github.event_name != 'pull_request' }}
-        with:
-          path: ./cache
-          key: ${{ matrix.os }}-benchmark
-
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         if: ${{ github.event_name != 'pull_request' }}
@@ -166,70 +157,20 @@ jobs:
             tool: 'googlecpp'
             output-file-path: ./build/benchmarks/metacall-benchmarks.json
             # Access token to deploy GitHub Pages branch
-            github-token: ""
+            github-token: ${{ secrets.PUSH_TOKEN }}
             # Disable push and deploy GitHub pages branch automatically
             auto-push: false
-            skip-fetch-gh-pages: true
+            # Github Pages repository name
+            gh-repository: github.com/ahmedihabb2/benchmarks
             # Github Pages branch name
-            gh-pages-branch: ${{ github.head_ref || github.ref_name }}
+            gh-pages-branch: main
             # Output directory
-            benchmark-data-dir-path: bench/${{ matrix.os }}
-            # Where the previous data file is stored
-            external-data-json-path: ./cache/metacall-benchmarks.json
+            benchmark-data-dir-path: ./${{ matrix.os }}
 
-      # Upload benchmark artifacts
-      - name: Upload benchmark artifact
-        uses: actions/upload-artifact@master
+      - name:  Push benchmark result
         if: ${{ github.event_name != 'pull_request' }}
-        with:
-          name: ${{ matrix.os }}-benchmark
-          path: ./bench/
-
-  # This job will merge all benchmarks into one artifact
-  benchmark-upload:
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: [benchmark-unix, benchmark-windows]
-    steps:
-      # Ubuntu
-      - uses: actions/download-artifact@master
-        with:
-          name: ubuntu-latest-benchmark
-          path: ./bench/
-
-      # MacOS
-      - uses: actions/download-artifact@master
-        with:
-          name: macos-latest-benchmark
-          path: ./bench/
-
-      # Windows
-      - uses: actions/download-artifact@master
-        with:
-          name: windows-2019-benchmark
-          path: ./bench/
-
-      # Upload benchmark website artifacts
-      - name: Upload benchmark artifact
-        uses: actions/upload-pages-artifact@v2
-        with:
-          path: ./bench/
-          name: benchmarks
-
-  benchmark-deploy:
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: [benchmark-upload]
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
-        with:
-          artifact_name: benchmarks
+        run: |     
+          cd  benchmark-data-repository
+          git push https://${REPO_KEY}@github.com/ahmedihabb2/benchmarks.git
+        env:
+          REPO_KEY: ${{secrets.PUSH_TOKEN}}


### PR DESCRIPTION
# Description

Now benchmark CI pushes the results to another repo to keep track of benchmark history and to keep the main repo clean

# Changelog

- [Download the previous benchmark results](https://github.com/metacall/core/blob/1aeaede8ad542bac27ebd934bbc0220fc1c9c813/.github/workflows/benchmark.yml#L69C1-L76C1) removed as we do not need cache anymore as we compare with previous results from the other repo

- [Output directory changed](https://github.com/metacall/core/blob/1aeaede8ad542bac27ebd934bbc0220fc1c9c813/.github/workflows/benchmark.yml#L92C13-L92C60) as when it was /bench/matrix.os, the benchmark action will search for previous results in /bench directory, although we store them directly on the repo using matrix.os in order to access them using metacall.github.io/benchmarks/ubuntu-latest not metacall.github.io/benchmarks/bench/ubuntu-latest 

- [Add github-token](https://github.com/metacall/core/blob/1aeaede8ad542bac27ebd934bbc0220fc1c9c813/.github/workflows/benchmark.yml#L85) to allow the action pull the specified repo

-  [ Remove skip-fetch-gh-pages](https://github.com/metacall/core/blob/1aeaede8ad542bac27ebd934bbc0220fc1c9c813/.github/workflows/benchmark.yml#L88) to allow the action fetching the specified repo and compare with the previous results

- You will need to replace any occurrence of ahmedihabb2/benchmarks with the Metacall benchmarks repo that we will store benchmarks results in it.

## Create Private Access token

- Click on your profile pic in the top right corner
- Choose settings
- Scroll down and choose developer settings from the right menu
- Choose Personal access token and click on Tokens (Classic)
- Click on Generate new token
- Specify expiration and select the repo option and this will give the token read and write access to repos
![image](https://github.com/metacall/core/assets/57008633/27a1b205-5f0f-4833-a5e4-f37058124c75)
- Copy the token then go to the repo setting and create a secret called PUSH_TOKEN and put the copied token as a value for the secret
- Now everything should work fine 

