### PR TITLE
Make the C loader independent from its libclang version

### DIFF
--- a/source/loaders/c_loader/CMakeLists.txt
+++ b/source/loaders/c_loader/CMakeLists.txt
@@ -25,7 +25,7 @@ if(NOT LIBTCC_FOUND)
 	endif()
 endif()
 
-find_package(LibClang 11)
+find_package(LibClang)
 
 if(NOT LibClang_FOUND)
 	message(SEND_ERROR "Clang C API library not found")

--- a/source/ports/rs_port/Dockerfile
+++ b/source/ports/rs_port/Dockerfile
@@ -6,7 +6,7 @@ FROM metacall/core:dev AS develop
 # Install dependencies
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
-		clang-11 clang-format-11 libclang-11-dev libtcc-dev valgrind libdw-dev libbfd-dev libdwarf-dev libffi-dev \
+	clang-16 clang-format-16 libclang-16-dev libtcc-dev valgrind libdw-dev libbfd-dev libdwarf-dev libffi-dev \
 	&& curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
 	&& . "/root/.cargo/env" \
 	&& rustup component add rustfmt \
@@ -17,17 +17,17 @@ ENV PATH="${PATH}:/root/.cargo/bin"
 
 RUN cd build \
 	&& cmake \
-		-DCMAKE_BUILD_TYPE=Debug \
-		-DOPTION_BUILD_DETOURS=Off \
-		-DOPTION_BUILD_EXAMPLES=Off \
-		-DOPTION_BUILD_LOADERS_C=On \
-		-DOPTION_BUILD_LOADERS_NODE=On \
-		-DOPTION_BUILD_LOADERS_PY=On \
-		-DOPTION_BUILD_LOADERS_TS=On \
-		-DOPTION_BUILD_SCRIPTS=Off \
-		-DOPTION_BUILD_SERIALS_RAPID_JSON=On \
-		-DOPTION_BUILD_TESTS=Off \
-		.. \
+	-DCMAKE_BUILD_TYPE=Debug \
+	-DOPTION_BUILD_DETOURS=Off \
+	-DOPTION_BUILD_EXAMPLES=Off \
+	-DOPTION_BUILD_LOADERS_C=On \
+	-DOPTION_BUILD_LOADERS_NODE=On \
+	-DOPTION_BUILD_LOADERS_PY=On \
+	-DOPTION_BUILD_LOADERS_TS=On \
+	-DOPTION_BUILD_SCRIPTS=Off \
+	-DOPTION_BUILD_SERIALS_RAPID_JSON=On \
+	-DOPTION_BUILD_TESTS=Off \
+	.. \
 	&& cmake --build . --target install \
 	&& cd /usr/local/lib \
 	&& ldconfig


### PR DESCRIPTION
# Description

Make the C loader independent from its libclang version. The Ubuntu docker image no longer distributes clang-11. So we tried to upgrade it to clang-16 and realized we didn't need to change a single line of code. For that reason, we decided to make the C loader independent from the libclang version.