### PR TITLE
Linux CI Repository Dispatch Test added

### DIFF
--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -46,4 +46,4 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           repository: metacall/distributable-linux
           event-type: test-trigger
-          ref: ${{ github.ref }}
+          client-payload: '{"ref": "${{ github.ref }}"}'

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Linux Repository Dispatch
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.ACCESS_TOKEN }}
+          token: ${{ secrets.G_PERSONAL_ACCESS_TOKEN }}
           repository: metacall/distributable-linux
           event-type: test-trigger
           client-payload: '{"ref": "${{ github.ref }}"}'

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -35,3 +35,15 @@ jobs:
         env:
           METACALL_BUILD_TYPE: ${{ matrix.build }}
           METACALL_BASE_IMAGE: ${{ matrix.image }}
+  trigger_dist_linux:
+    needs: linux-test
+    if: ${{ success() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Linux Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.ACCESS_TOKEN }}
+          repository: metacall/distributable-linux
+          event-type: test-trigger
+          ref: ${{ github.ref }}

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -35,6 +35,7 @@ jobs:
         env:
           METACALL_BUILD_TYPE: ${{ matrix.build }}
           METACALL_BASE_IMAGE: ${{ matrix.image }}
+
   trigger_dist_linux:
     needs: linux-test
     if: ${{ success() }}

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -95,3 +95,15 @@ jobs:
           bash ../tools/metacall-build.sh $METACALL_BUILD_OPTIONS
         env:
           METACALL_BUILD_OPTIONS: ${{ matrix.options.build }} tests
+  trigger_dist_macos:
+    needs: mac-test
+    if: ${{ success() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: MacOS Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.ACCESS_TOKEN }}
+          repository: metacall/distributable-macos
+          event-type: test-trigger
+          client-payload: '{"ref": "${{ github.ref }}"}'

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -95,6 +95,7 @@ jobs:
           bash ../tools/metacall-build.sh $METACALL_BUILD_OPTIONS
         env:
           METACALL_BUILD_OPTIONS: ${{ matrix.options.build }} tests
+
   trigger_dist_macos:
     needs: mac-test
     if: ${{ success() }}

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -104,7 +104,7 @@ jobs:
       - name: MacOS Repository Dispatch
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.ACCESS_TOKEN }}
+          token: ${{ secrets.G_PERSONAL_ACCESS_TOKEN }}
           repository: metacall/distributable-macos
           event-type: test-trigger
           client-payload: '{"ref": "${{ github.ref }}"}'

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Windows Repository Dispatch
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.ACCESS_TOKEN }}
+          token: ${{ secrets.G_PERSONAL_ACCESS_TOKEN }}
           repository: metacall/distributable-windows
           event-type: test-trigger
           client-payload: '{"ref": "${{ github.ref }}"}'

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -76,4 +76,4 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           repository: metacall/distributable-windows
           event-type: test-trigger
-          ref: ${{ github.ref }}
+          client-payload: '{"ref": "${{ github.ref }}"}'

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -74,6 +74,6 @@ jobs:
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.ACCESS_TOKEN }}
-          repository: shaggyyy2002/distributable-windows
+          repository: metacall/distributable-windows
           event-type: test-trigger
           ref: ${{ github.ref }}


### PR DESCRIPTION
# Description
In this I have added the repository dispatch so that it will trigger the linux-dist repo, only if it passes all the linux tests mentioned.

Fixes #505 Connect Core CI with Distributable's Repo

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [X] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test &> output` and attached the output.
- [ X I have tested my code with `OPTION_BUILD_ADDRESS_SANITIZER` or `./docker-compose.sh test-address-sanitizer &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ X I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer &> output`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [X] I have run `make clang-format` in order to format my code and my code follows the style guidelines.