### PR TITLE
fix: incorrectly calculating the size of script that is loaded from memory

### DIFF
--- a/source/ports/rs_port/src/loaders.rs
+++ b/source/ports/rs_port/src/loaders.rs
@@ -82,7 +82,7 @@ pub fn from_memory(tag: impl ToString, script: impl ToString) -> Result<(), Meta
         metacall_load_from_memory(
             c_tag.as_ptr(),
             c_script.as_ptr(),
-            script.len(),
+            script.len() + 1,
             ptr::null_mut(),
         )
     } != 0

--- a/source/ports/rs_port/tests/inlines_test.rs
+++ b/source/ports/rs_port/tests/inlines_test.rs
@@ -12,16 +12,25 @@ fn inlines() {
             print("hello world")
         }
     }
+    if loaders::from_memory("py", "").is_ok() {
+        py! {print("hello world")}
+    }
 
     if loaders::from_memory("node", "").is_ok() {
         node! {
             console.log("hello world");
         }
     }
+    if loaders::from_memory("node", "").is_ok() {
+        node! {console.log("hello world")}
+    }
 
     if loaders::from_memory("ts", "").is_ok() {
         ts! {
             console.log("hello world");
         }
+    }
+    if loaders::from_memory("ts", "").is_ok() {
+        ts! {console.log("hello world")}
     }
 }

--- a/source/ports/rs_port/tests/loaders_test.rs
+++ b/source/ports/rs_port/tests/loaders_test.rs
@@ -8,9 +8,9 @@ use std::{
 
 // Two different names to avoid conflicts when testing both load_from_memory and load_from_files
 // in a single test.
-const SCRIPT1: &str = "function greet1() { return 'hi there!' } \nmodule.exports = { greet1 };";
+const SCRIPT1: &str = "function greet1() { return 'hi there!' } \nmodule.exports = { greet1 }";
 const SCRIPT2: &str = "function greet2() { return 'hi there!' } \nmodule.exports = { greet2 };";
-
+const SCRIPT3: &str = "console.log('Hello world')";
 fn call_greet(test: &str, num: u32) {
     let out = metacall_no_arg::<String>(format!("greet{}", num)).unwrap();
     if out.as_str() == "hi there!" {
@@ -25,8 +25,9 @@ fn call_greet(test: &str, num: u32) {
 
 fn load_from_memory_test() {
     loaders::from_memory("node", SCRIPT1).unwrap();
-
     call_greet("load_from_memory", 1);
+
+    loaders::from_memory("node", SCRIPT3).unwrap();
 }
 
 fn load_from_file_test() {
@@ -51,7 +52,6 @@ fn load_from_file_test() {
 #[test]
 fn loaders() {
     let _d = switch::initialize().unwrap();
-
     // Testing load_from_memory
     load_from_memory_test();
 


### PR DESCRIPTION
# Description

Fixes #513 

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [x] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_ADDRESS_SANITIZER` or `./docker-compose.sh test-address-sanitizer &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer &> output`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
