### PR TITLE
Add Digest Export and Manifest Creation for Multi-Arch Docker Builds

### DIFF
--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE_NAME: index.docker.io/metacall/coree
+  IMAGE_NAME: index.docker.io/metacall/core
 
 jobs:
   build:

--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
       - develop
-      - feature/** # Added to run on feature branches
+      - feature/**
     tags:
       - 'v*.*.*'
 
@@ -29,7 +29,6 @@ jobs:
           - linux/arm64
           - linux/arm/v6
           - linux/arm/v7
-
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
@@ -74,7 +73,7 @@ jobs:
       - name: Upload Digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ steps.define-platform.outputs.platform_safe }}-${{ github.run_id }}  # Adding run_id for uniqueness
+          name: digests-${{ env.METACALL_PLATFORM_PAIR }}
           path: /tmp/digests/*
           retention-days: 1
 
@@ -85,8 +84,9 @@ jobs:
       - name: Download all digests
         uses: actions/download-artifact@v4
         with:
-          name: digests-${{ github.run_id }}  # Use run_id here as well for consistency
+          pattern: digests-*
           path: /tmp/digests
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -1,24 +1,17 @@
 name: Build and Push Docker Image for Multiple Architectures
-
 on:
-  # To enable manual triggering of this workflow
   workflow_dispatch:
-
-  # Trigger for pushes to master and tags
   push:
     branches:
       - master
       - develop # TODO: Remove this
     tags:
       - 'v*.*.*'
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-
 env:
   IMAGE_NAME: index.docker.io/metacall/core
-
 jobs:
   build:
     name: Build
@@ -36,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
+      
       - name: Define Platform
         run: |
           PLATFORM=${{ matrix.platform }}
@@ -54,78 +47,86 @@ jobs:
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
+      
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
-      - name: Build MetaCall Docker Images
-        run: bash ./docker-compose.sh platform
-
-      # # TODO: Build with alpine and provide multiple tags (debian & alpine) once all tests pass
-      # - name: Push MetaCall Docker Image to DockerHub
-      #   run: |
-      #     if [[ "${{ github.ref == 'refs/heads/master' }}" = true ]]; then
-      #       bash ./docker-compose.sh push
-      #     elif [[ "${{ contains(github.ref, 'refs/tags/') }}" = true ]]; then
-      #       bash ./docker-compose.sh version
-      #     else
-      #       echo "Failed to push the docker images"
-      #       exit 1
-      #     fi
-
-      # - name: Export Digest
-      #   run: |
-      #     mkdir -p /tmp/digests
-      #     digest="${{ steps.build.outputs.digest }}"
-      #     touch "/tmp/digests/${digest#sha256:}"          
       
-      # - name: Upload Digest
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: digests-${{ env.METACALL_PLATFORM_PAIR }}
-      #     path: /tmp/digests/*
-      #     if-no-files-found: error
-      #     retention-days: 1
-
+      - name: Build and Push MetaCall Docker Images
+        id: build_and_push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      - name: Export Digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build_and_push.outputs.digest }}"
+          touch "/tmp/digests/${METACALL_PLATFORM_PAIR}_${digest#sha256:}"
+      
+      - name: Upload Digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+      
       - name: Logout from DockerHub
+        if: always()
         run: docker logout
 
-  # merge:
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - build
-  #   steps:
-  #     - name: Download Digests
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         path: /tmp/digests
-  #         pattern: digests-*
-  #         merge-multiple: true
+  merge:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Digests
+        uses: actions/download-artifact@v4
+        with:
+          name: digests
+          path: /tmp/digests
       
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       
-  #     - name: Docker Metadata
-  #       id: meta
-  #       uses: docker/metadata-action@v5
-  #       with:
-  #         images: ${{ env.IMAGE_NAME }}
+      - name: Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
       
-  #     - name: Login to DockerHub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_HUB_USERNAME }}
-  #         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       
-  #     - name: Create manifest list and push
-  #       working-directory: /tmp/digests
-  #       run: |
-  #         docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-  #           $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+      - name: Create and Push Manifest List
+        run: |
+          platforms=("linux-amd64" "linux-arm64" "linux-arm-v6" "linux-arm-v7")
+          manifests=""
+          for platform in "${platforms[@]}"; do
+            digest=$(cat /tmp/digests/${platform}_*)
+            manifests="${manifests} ${IMAGE_NAME}@${digest}"
+          done
+          docker buildx imagetools create -t ${IMAGE_NAME}:${{ steps.meta.outputs.version }} ${manifests}
+          docker buildx imagetools create -t ${IMAGE_NAME}:latest ${manifests}
       
-  #     - name: Inspect image
-  #       run: |
-  #         docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+      - name: Inspect Image
+        run: |
+          docker buildx imagetools inspect ${IMAGE_NAME}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${IMAGE_NAME}:latest
+      
+      - name: Logout from DockerHub
+        if: always()
+        run: docker logout

--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Upload Digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ github.run_id }}-${{ github.job }} # Ensure unique artifact name
+          name: digests-${{ github.run_id }}-${{ github.job }}-${{ github.run_attempt }}-${{ runner.os }}-${{ matrix.platform }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - develop # TODO: Remove this
+      - feature/**
     tags:
       - 'v*.*.*'
 concurrency:

--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - master
       - develop
-      - feature/**
     tags:
       - 'v*.*.*'
 

--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Upload Digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ steps.define-platform.outputs.platform_safe }} # Using output from Define Platform step
+          name: digests-${{ steps.define-platform.outputs.platform_safe }}-${{ github.run_id }}  # Adding run_id for uniqueness
           path: /tmp/digests/*
           retention-days: 1
 
@@ -85,7 +85,7 @@ jobs:
       - name: Download all digests
         uses: actions/download-artifact@v4
         with:
-          name: digests-linux-amd64 # Adjust as needed for each platform
+          name: digests-${{ github.run_id }}  # Use run_id here as well for consistency
           path: /tmp/digests
 
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -37,6 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Define Platform
+        id: define-platform
         run: |
           PLATFORM=${{ matrix.platform }}
           PLATFORM_SAFE=${PLATFORM//\//-} # Replace slashes with dashes
@@ -73,7 +74,7 @@ jobs:
       - name: Upload Digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.platform //\//- }} # Replaced slashes with dashes
+          name: digests-${{ steps.define-platform.outputs.platform_safe }} # Using output from Define Platform step
           path: /tmp/digests/*
           retention-days: 1
 

--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -1,4 +1,5 @@
 name: Build and Push Docker Image for Multiple Architectures
+
 on:
   workflow_dispatch:
   push:
@@ -8,11 +9,14 @@ on:
       - feature/** # Added to run on feature branches
     tags:
       - 'v*.*.*'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
 env:
   IMAGE_NAME: index.docker.io/metacall/core
+
 jobs:
   build:
     name: Build
@@ -25,36 +29,46 @@ jobs:
           - linux/arm64
           - linux/arm/v6
           - linux/arm/v7
+
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Define Platform
         run: |
           PLATFORM=${{ matrix.platform }}
           echo "METACALL_PLATFORM=${PLATFORM}" >> $GITHUB_ENV
           echo "METACALL_PLATFORM_PAIR=${PLATFORM//\//-}" >> $GITHUB_ENV
-      
+
       - name: Docker Metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
-      
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
+      # Uncomment this section if you plan to log in to DockerHub
       # - name: Login to DockerHub
       #   uses: docker/login-action@v3
       #   with:
       #     username: ${{ secrets.DOCKER_HUB_USERNAME }}
       #     password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-      
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Build MetaCall Docker Images
         id: build_image
         uses: docker/build-push-action@v5
@@ -65,21 +79,24 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
       - name: Export Digest
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build_image.outputs.digest }}"
           touch "/tmp/digests/${METACALL_PLATFORM_PAIR}_${digest#sha256:}"
-      
+
       - name: Upload Digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests
+          name: digests-${{ github.run_id }}-${{ github.job }} # Ensure unique artifact name
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
-      
+
+      # Uncomment this section if you plan to log out from DockerHub
       # - name: Logout from DockerHub
       #   if: always()
       #   run: docker logout
@@ -91,25 +108,26 @@ jobs:
       - name: Download Digests
         uses: actions/download-artifact@v4
         with:
-          name: digests
+          name: digests-${{ github.run_id }}-${{ github.job }} # Match the uploaded artifact name
           path: /tmp/digests
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Docker Metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
-      
+
+      # Uncomment this section if you plan to log in to DockerHub
       # - name: Login to DockerHub
       #   uses: docker/login-action@v3
       #   with:
       #     username: ${{ secrets.DOCKER_HUB_USERNAME }}
       #     password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-      
-      - name: Create Manifest List (without pushing)
+
+      - name: Create and Push Manifest List
         run: |
           platforms=("linux-amd64" "linux-arm64" "linux-arm-v6" "linux-arm-v7")
           manifests=""
@@ -117,14 +135,16 @@ jobs:
             digest=$(cat /tmp/digests/${platform}_*)
             manifests="${manifests} ${IMAGE_NAME}@${digest}"
           done
-          echo "Would create manifest list with: ${manifests}"
-          echo "Would tag as: ${IMAGE_NAME}:${{ steps.meta.outputs.version }} and ${IMAGE_NAME}:latest"
-      
-      - name: Simulate Image Inspection
+          docker manifest create ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }} ${manifests}
+          docker manifest push ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          docker manifest push ${{ env.IMAGE_NAME }}:latest
+
+      - name: Inspect Images
         run: |
-          echo "Would inspect: ${IMAGE_NAME}:${{ steps.meta.outputs.version }}"
-          echo "Would inspect: ${IMAGE_NAME}:latest"
-      
+          docker manifest inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          docker manifest inspect ${{ env.IMAGE_NAME }}:latest
+
+      # Uncomment this section if you plan to log out from DockerHub
       # - name: Logout from DockerHub
       #   if: always()
       #   run: docker logout

--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Upload Digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.platform }}
+          name: digests-${{ matrix.platform //\//- }} # Replaced slashes with dashes
           path: /tmp/digests/*
           retention-days: 1
 
@@ -83,7 +83,7 @@ jobs:
       - name: Download all digests
         uses: actions/download-artifact@v4
         with:
-          name: digests-*
+          name: digests-linux-amd64 # Update this for each platform as needed
           path: /tmp/digests
 
       - name: Set up Docker Buildx
@@ -94,12 +94,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
-
-      # - name: Login to DockerHub
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ secrets.DOCKER_HUB_USERNAME }}
-      #     password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Create Manifest List (without pushing)
         run: |

--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -54,20 +54,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Uncomment this section if you plan to log in to DockerHub
       # - name: Login to DockerHub
       #   uses: docker/login-action@v3
       #   with:
       #     username: ${{ secrets.DOCKER_HUB_USERNAME }}
       #     password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
 
       - name: Build MetaCall Docker Images
         id: build_image
@@ -79,8 +70,6 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Export Digest
         run: |
@@ -96,7 +85,6 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-      # Uncomment this section if you plan to log out from DockerHub
       # - name: Logout from DockerHub
       #   if: always()
       #   run: docker logout
@@ -120,14 +108,13 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
 
-      # Uncomment this section if you plan to log in to DockerHub
       # - name: Login to DockerHub
       #   uses: docker/login-action@v3
       #   with:
       #     username: ${{ secrets.DOCKER_HUB_USERNAME }}
       #     password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-      - name: Create and Push Manifest List
+      - name: Create Manifest List (without pushing)
         run: |
           platforms=("linux-amd64" "linux-arm64" "linux-arm-v6" "linux-arm-v7")
           manifests=""
@@ -135,16 +122,14 @@ jobs:
             digest=$(cat /tmp/digests/${platform}_*)
             manifests="${manifests} ${IMAGE_NAME}@${digest}"
           done
-          docker manifest create ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }} ${manifests}
-          docker manifest push ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
-          docker manifest push ${{ env.IMAGE_NAME }}:latest
+          echo "Would create manifest list with: ${manifests}"
+          echo "Would tag as: ${IMAGE_NAME}:${{ steps.meta.outputs.version }} and ${IMAGE_NAME}:latest"
 
-      - name: Inspect Images
+      - name: Simulate Image Inspection
         run: |
-          docker manifest inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
-          docker manifest inspect ${{ env.IMAGE_NAME }}:latest
+          echo "Would inspect: ${IMAGE_NAME}:${{ steps.meta.outputs.version }}"
+          echo "Would inspect: ${IMAGE_NAME}:latest"
 
-      # Uncomment this section if you plan to log out from DockerHub
       # - name: Logout from DockerHub
       #   if: always()
       #   run: docker logout

--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE_NAME: index.docker.io/metacall/core
+  IMAGE_NAME: index.docker.io/metacall/coree
 
 jobs:
   build:

--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -39,8 +39,9 @@ jobs:
       - name: Define Platform
         run: |
           PLATFORM=${{ matrix.platform }}
+          PLATFORM_SAFE=${PLATFORM//\//-} # Replace slashes with dashes
           echo "METACALL_PLATFORM=${PLATFORM}" >> $GITHUB_ENV
-          echo "METACALL_PLATFORM_PAIR=${PLATFORM//\//-}" >> $GITHUB_ENV
+          echo "METACALL_PLATFORM_PAIR=${PLATFORM_SAFE}" >> $GITHUB_ENV
 
       - name: Docker Metadata
         id: meta
@@ -72,7 +73,7 @@ jobs:
       - name: Upload Digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.platform }}
+          name: digests-${{ matrix.platform //\//- }} # Replaced slashes with dashes
           path: /tmp/digests/*
           retention-days: 1
 
@@ -83,7 +84,7 @@ jobs:
       - name: Download all digests
         uses: actions/download-artifact@v4
         with:
-          name: digests-linux-amd64 # Example for one platform; you might need to handle this for all platforms
+          name: digests-linux-amd64 # Adjust as needed for each platform
           path: /tmp/digests
 
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Upload Digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.platform //\//- }} # Replaced slashes with dashes
+          name: digests-${{ matrix.platform }}
           path: /tmp/digests/*
           retention-days: 1
 
@@ -83,7 +83,7 @@ jobs:
       - name: Download all digests
         uses: actions/download-artifact@v4
         with:
-          name: digests-linux-amd64 # Update this for each platform as needed
+          name: digests-linux-amd64 # Example for one platform; you might need to handle this for all platforms
           path: /tmp/digests
 
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -61,15 +61,7 @@ jobs:
       #     password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Build MetaCall Docker Images
-        id: build_image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: ${{ matrix.platform }}
-          push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+        run: bash ./docker-compose.sh platform
 
       - name: Export Digest
         run: |
@@ -80,7 +72,7 @@ jobs:
       - name: Upload Digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ github.run_id }}-${{ github.job }}-${{ github.run_attempt }}-${{ runner.os }}-${{ matrix.platform//\//- }}
+          name: digests
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -72,23 +72,18 @@ jobs:
       - name: Upload Digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests
+          name: digests-${{ matrix.platform }}
           path: /tmp/digests/*
-          if-no-files-found: error
           retention-days: 1
-
-      # - name: Logout from DockerHub
-      #   if: always()
-      #   run: docker logout
 
   merge:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Download Digests
+      - name: Download all digests
         uses: actions/download-artifact@v4
         with:
-          name: digests-${{ github.run_id }}-${{ github.job }} # Match the uploaded artifact name
+          name: digests-*
           path: /tmp/digests
 
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - master
-      - develop # TODO: Remove this
-      - feature/**
+      - develop
+      - feature/** # Added to run on feature branches
     tags:
       - 'v*.*.*'
 concurrency:
@@ -49,32 +49,30 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      # - name: Login to DockerHub
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.DOCKER_HUB_USERNAME }}
+      #     password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       
-      - name: Build and Push MetaCall Docker Images
-        id: build_and_push
+      - name: Build MetaCall Docker Images
+        id: build_image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       
       - name: Export Digest
-        if: github.event_name != 'pull_request'
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build_and_push.outputs.digest }}"
+          digest="${{ steps.build_image.outputs.digest }}"
           touch "/tmp/digests/${METACALL_PLATFORM_PAIR}_${digest#sha256:}"
       
       - name: Upload Digest
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: digests
@@ -82,12 +80,11 @@ jobs:
           if-no-files-found: error
           retention-days: 1
       
-      - name: Logout from DockerHub
-        if: always()
-        run: docker logout
+      # - name: Logout from DockerHub
+      #   if: always()
+      #   run: docker logout
 
   merge:
-    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -106,13 +103,13 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
       
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      # - name: Login to DockerHub
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.DOCKER_HUB_USERNAME }}
+      #     password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       
-      - name: Create and Push Manifest List
+      - name: Create Manifest List (without pushing)
         run: |
           platforms=("linux-amd64" "linux-arm64" "linux-arm-v6" "linux-arm-v7")
           manifests=""
@@ -120,14 +117,14 @@ jobs:
             digest=$(cat /tmp/digests/${platform}_*)
             manifests="${manifests} ${IMAGE_NAME}@${digest}"
           done
-          docker buildx imagetools create -t ${IMAGE_NAME}:${{ steps.meta.outputs.version }} ${manifests}
-          docker buildx imagetools create -t ${IMAGE_NAME}:latest ${manifests}
+          echo "Would create manifest list with: ${manifests}"
+          echo "Would tag as: ${IMAGE_NAME}:${{ steps.meta.outputs.version }} and ${IMAGE_NAME}:latest"
       
-      - name: Inspect Image
+      - name: Simulate Image Inspection
         run: |
-          docker buildx imagetools inspect ${IMAGE_NAME}:${{ steps.meta.outputs.version }}
-          docker buildx imagetools inspect ${IMAGE_NAME}:latest
+          echo "Would inspect: ${IMAGE_NAME}:${{ steps.meta.outputs.version }}"
+          echo "Would inspect: ${IMAGE_NAME}:latest"
       
-      - name: Logout from DockerHub
-        if: always()
-        run: docker logout
+      # - name: Logout from DockerHub
+      #   if: always()
+      #   run: docker logout

--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Upload Digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ github.run_id }}-${{ github.job }}-${{ github.run_attempt }}-${{ runner.os }}-${{ matrix.platform }}
+          name: digests-${{ github.run_id }}-${{ github.job }}-${{ github.run_attempt }}-${{ runner.os }}-${{ matrix.platform//\//- }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/docker-hub-platform.yml
+++ b/.github/workflows/docker-hub-platform.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - master
-      - develop
-      - feature/** # Added to run on feature branches
+      - develop # TODO: Remove this
+      - feature/**
     tags:
       - 'v*.*.*'
 concurrency:
@@ -49,30 +49,32 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
-      # - name: Login to DockerHub
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ secrets.DOCKER_HUB_USERNAME }}
-      #     password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       
-      - name: Build MetaCall Docker Images
-        id: build_image
+      - name: Build and Push MetaCall Docker Images
+        id: build_and_push
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
-          push: false
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       
       - name: Export Digest
+        if: github.event_name != 'pull_request'
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build_image.outputs.digest }}"
+          digest="${{ steps.build_and_push.outputs.digest }}"
           touch "/tmp/digests/${METACALL_PLATFORM_PAIR}_${digest#sha256:}"
       
       - name: Upload Digest
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: digests
@@ -80,11 +82,12 @@ jobs:
           if-no-files-found: error
           retention-days: 1
       
-      # - name: Logout from DockerHub
-      #   if: always()
-      #   run: docker logout
+      - name: Logout from DockerHub
+        if: always()
+        run: docker logout
 
   merge:
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -103,13 +106,13 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
       
-      # - name: Login to DockerHub
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ secrets.DOCKER_HUB_USERNAME }}
-      #     password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       
-      - name: Create Manifest List (without pushing)
+      - name: Create and Push Manifest List
         run: |
           platforms=("linux-amd64" "linux-arm64" "linux-arm-v6" "linux-arm-v7")
           manifests=""
@@ -117,14 +120,14 @@ jobs:
             digest=$(cat /tmp/digests/${platform}_*)
             manifests="${manifests} ${IMAGE_NAME}@${digest}"
           done
-          echo "Would create manifest list with: ${manifests}"
-          echo "Would tag as: ${IMAGE_NAME}:${{ steps.meta.outputs.version }} and ${IMAGE_NAME}:latest"
+          docker buildx imagetools create -t ${IMAGE_NAME}:${{ steps.meta.outputs.version }} ${manifests}
+          docker buildx imagetools create -t ${IMAGE_NAME}:latest ${manifests}
       
-      - name: Simulate Image Inspection
+      - name: Inspect Image
         run: |
-          echo "Would inspect: ${IMAGE_NAME}:${{ steps.meta.outputs.version }}"
-          echo "Would inspect: ${IMAGE_NAME}:latest"
+          docker buildx imagetools inspect ${IMAGE_NAME}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${IMAGE_NAME}:latest
       
-      # - name: Logout from DockerHub
-      #   if: always()
-      #   run: docker logout
+      - name: Logout from DockerHub
+        if: always()
+        run: docker logout


### PR DESCRIPTION

This pull request enhances the Docker image build workflow to support exporting image digests and creating a manifest list for multi-architecture Docker builds. The changes include:

- Digest Export: The `build` job now exports digests for each platform and uploads them as artifacts.
- Manifest Creation: The `merge` job downloads all digests and creates a manifest list with these digests for each platform.
- Simulated Image Inspection: Added steps to simulate image inspection and creation of a manifest list.

The `login` and `logout` steps for DockerHub are currently commented out. Uncomment these steps if DockerHub authentication is required. The workflow now supports `linux/amd64`, `linux/arm64`, `linux/arm/v6`, and `linux/arm/v7` platforms.
