### PR TITLE
Update Release Workflow and Upload/Download Artifact Actions to Latest Versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GHR_VERSION: 0.12.0
+  GHR_VERSION: 0.17.0
   IMAGE_NAME: index.docker.io/metacall/core
   IMAGE_REGISTRY: index.docker.io
   ARTIFACTS_PATH: ./build-artifacts
@@ -33,7 +33,7 @@ jobs:
       - name: Extract built artifacts
         run: bash ./docker-compose.sh pack
       - name: Upload built artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: built-artifacts
           path: ${{ env.ARTIFACTS_PATH }}/
@@ -48,7 +48,7 @@ jobs:
         with:
           fetch-depth: 0  # To fetch all tags
       - name: Download built artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.1.8
         with:
           name: built-artifacts
           path: ${{ env.ARTIFACTS_PATH }}/


### PR DESCRIPTION
**PR Description**:
This PR updates the release workflow to use the latest versions of key GitHub Actions and tools, ensuring enhanced stability and compatibility. 

Changes:
- Updated `upload-artifact` action to version `v4`.
- Updated `download-artifact` action to the latest version `4.1.8`.
- Upgraded GHR (GitHub Release) tool to the latest version for improved release management.

@viferga 