### PR TITLE
Implement metacall_box for passing function arguments with different types

### DIFF
--- a/source/ports/rs_port/src/cast.rs
+++ b/source/ports/rs_port/src/cast.rs
@@ -235,6 +235,6 @@ pub fn metacallobj_untyped_to_raw(ret: Box<dyn MetaCallValue>) -> Option<*mut c_
     None
 }
 
-pub fn metacall_implementer_to_traitobj(v: impl MetaCallValue) -> Box<dyn MetaCallValue> {
+pub fn metacall_box(v: impl MetaCallValue) -> Box<dyn MetaCallValue> {
     Box::new(v) as Box<dyn MetaCallValue>
 }

--- a/source/ports/rs_port/src/lib.rs
+++ b/source/ports/rs_port/src/lib.rs
@@ -88,6 +88,7 @@ pub use types::*;
 #[doc(hidden)]
 mod init;
 
+pub use cast::metacall_box;
 pub use init::initialize;
 pub use init::is_initialized;
 

--- a/source/ports/rs_port/src/types/metacall_exception.rs
+++ b/source/ports/rs_port/src/types/metacall_exception.rs
@@ -180,7 +180,7 @@ impl MetaCallThrowable {
             Ok(mut value) => {
                 value.leak = true;
 
-                cast::metacall_implementer_to_traitobj(value)
+                cast::metacall_box(value)
             }
             Err(original) => original,
         }

--- a/source/ports/rs_port/src/types/metacall_value.rs
+++ b/source/ports/rs_port/src/types/metacall_value.rs
@@ -429,3 +429,36 @@ impl MetaCallValue for MetaCallThrowable {
         self.into_raw()
     }
 }
+/// Just a Rust barrier made for easier polymorphism.
+impl MetaCallValue for Box<dyn MetaCallValue> {
+    fn get_metacall_id() -> metacall_value_id {
+        metacall_value_id::METACALL_INVALID
+    }
+    fn from_metacall_raw_leak(v: *mut c_void) -> Result<Self, Box<dyn MetaCallValue>> {
+        Ok(cast::raw_to_metacallobj_untyped_leak(v))
+    }
+    fn into_metacall_raw(self) -> *mut c_void {
+        match_metacall_value!(self, {
+            bool: bool => bool.into_metacall_raw(),
+            char: char => char.into_metacall_raw(),
+            num: i16 => num.into_metacall_raw(),
+            num: i32 => num.into_metacall_raw(),
+            num: i64 => num.into_metacall_raw(),
+            num: f32 => num.into_metacall_raw(),
+            num: f64 => num.into_metacall_raw(),
+            str: String => str.into_metacall_raw(),
+            buf: Vec<i8> => buf.into_metacall_raw(),
+            arr: Vec<Box<dyn MetaCallValue>> => arr.into_metacall_raw(),
+            map: HashMap<String, Box<dyn MetaCallValue>> => map.into_metacall_raw(),
+            ptr: MetaCallPointer => ptr.into_metacall_raw(),
+            fut: MetaCallFuture => fut.into_metacall_raw(),
+            fun: MetaCallFunction => fun.into_metacall_raw(),
+            null: MetaCallNull => null.into_metacall_raw(),
+            cls: MetaCallClass => cls.into_metacall_raw(),
+            obj: MetaCallObject => obj.into_metacall_raw(),
+            exc: MetaCallException => exc.into_metacall_raw(),
+            thr: MetaCallThrowable => thr.into_metacall_raw(),
+            _ => MetaCallNull().into_metacall_raw()
+        })
+    }
+}

--- a/source/ports/rs_port/tests/metacall_test.rs
+++ b/source/ports/rs_port/tests/metacall_test.rs
@@ -81,27 +81,21 @@ fn test_float() {
 fn test_double() {
     generate_test::<f64>("test_double", 1.2345_f64);
 }
-// TODO
-// fn test_mixed_numbers() {
-//     let result = ::metacall::metacall::<i64>(
-//         "test_mixed_numbers",
-//         [
-//             Box::new(1 as i16) as Box<dyn MetaCallValue>,
-//             Box::new(2 as i32) as Box<dyn MetaCallValue>,
-//             Box::new(3 as i64) as Box<dyn MetaCallValue>,
-//         ],
-//     );
+fn test_mixed_numbers() {
+    let result = ::metacall::metacall::<i64>(
+        "test_mixed_numbers",
+        [
+            ::metacall::metacall_box(1 as i16),
+            ::metacall::metacall_box(2 as i32),
+            ::metacall::metacall_box(3 as i64),
+        ],
+    );
 
-//     // TODO
-//     // ::metacall::metacall::<i64>("test_mixed_numbers", [1_i16, 2_i32, 3_i64]);
-//     // ::metacall::metacall::<i64>("test_mixed_numbers", (1_i16, 2_i32, 3_i64));
-
-//     assert!(result.is_ok());
-
-//     if let Ok(ret) = result {
-//         assert_eq!(ret, 6_i64)
-//     }
-// }
+    assert!(result.is_ok());
+    if let Ok(ret) = result {
+        assert_eq!(ret, 6_i64)
+    }
+}
 fn test_string() {
     generate_test::<String>(
         "return_the_argument_py",
@@ -393,8 +387,7 @@ fn metacall() {
         test_int();
         test_long();
         test_short();
-        // TODO
-        // test_mixed_numbers();
+        test_mixed_numbers();
     }
     if load::from_single_file("node", js_test_file).is_ok() {
         test_exception();

--- a/source/ports/rs_port/tests/metacall_test.rs
+++ b/source/ports/rs_port/tests/metacall_test.rs
@@ -92,6 +92,7 @@ fn test_mixed_numbers() {
     );
 
     assert!(result.is_ok());
+
     if let Ok(ret) = result {
         assert_eq!(ret, 6_i64)
     }


### PR DESCRIPTION
…types

# Description

Implement metacall_box for passing function arguments with different types

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my own code.
- [x- I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_ADDRESS_SANITIZER` or `./docker-compose.sh test-address-sanitizer &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer &> output`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
