### PR TITLE
feat: Add C loader support for node_port

### DIFF
--- a/source/ports/node_port/index.js
+++ b/source/ports/node_port/index.js
@@ -289,6 +289,8 @@ const file_extensions_to_tag = {
 	tsx: 'ts',
 	/* Rust Loader */
 	rs: 'rs',
+	/* C Loader */
+	c: 'c',
 
 	/* Note: By default js extension uses NodeJS loader instead of JavaScript V8 */
 	/* Probably in the future we can differenciate between them, but it is not trivial */


### PR DESCRIPTION
# Description

## Issue

The modern API for node port has the following design for most of the languages:
```js

require('metacall')

const { sum } = require('./sum.py')

const const result = sum(1, 2)
console.log(result) // 3
```

However, not for C loader.

It used to result in the following error:
```
Exception in node_loader_trampoline_load_from_file while loading: [ 'main.js' ] /home/adarsh/gsoc/metacall-tut/bun-ffi/sum.c:1
double sum(double a, double b)
       ^^^

SyntaxError: Unexpected identifier
    at internalCompileFunction (node:internal/vm:73:18)
    at wrapSafe (node:internal/modules/cjs/loader:1274:20)
    at Module._compile (node:internal/modules/cjs/loader:1320:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1414:10)
    at Module.load (node:internal/modules/cjs/loader:1197:32)
    at Module._load (node:internal/modules/cjs/loader:1013:12)
    at Module.require [as node_require] (node:internal/modules/cjs/loader:1225:19)
    at mod.require (/usr/local/lib/node_modules/metacall/index.js:363:22)
    at require (node:internal/modules/helpers:177:18)
    at Object.<anonymous> (/home/adarsh/gsoc/metacall-tut/bun-ffi/main.js:1:15)
Error: Failed to load script 'main.js' with loader 'node'
```

## Fix

This PR fixes this issue by simply adding C loader to node port.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_ADDRESS_SANITIZER` or `./docker-compose.sh test-address-sanitizer &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer &> output`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
