### PR TITLE
Use proper string comparisons in tests

### DIFF
--- a/source/tests/adt_trie_test/source/adt_trie_test.cpp
+++ b/source/tests/adt_trie_test/source/adt_trie_test.cpp
@@ -123,7 +123,7 @@ TEST_F(adt_trie_test, DefaultConstructor)
 
 		log_write("metacall", LOG_LEVEL_DEBUG, "%" PRIuS " -> %s", iterator, value_str);
 
-		EXPECT_EQ((int)0, (int)strcmp(values_str[keys_size - iterator - 1], value_str));
+		EXPECT_STREQ(values_str[keys_size - iterator - 1], value_str);
 
 		vector_pop_back(keys_copy);
 	}
@@ -144,7 +144,7 @@ TEST_F(adt_trie_test, DefaultConstructor)
 
 		log_write("metacall", LOG_LEVEL_DEBUG, "%s/", key_str);
 
-		EXPECT_EQ((int)0, (int)strcmp(keys_str[iterator], key_str));
+		EXPECT_STREQ(keys_str[iterator], key_str);
 	}
 
 	vector_pop_back(keys);

--- a/source/tests/detour_test/source/detour_test.cpp
+++ b/source/tests/detour_test/source/detour_test.cpp
@@ -111,7 +111,7 @@ TEST_F(detour_test, DefaultConstructor)
 
 	ASSERT_NE((detour)NULL, (detour)d);
 
-	EXPECT_EQ((int)0, (int)strcmp(name, detour_name(d)));
+	EXPECT_STREQ(name, detour_name(d));
 
 	/* Load detour of detour library */
 	handle = detour_load_file(d, NULL);

--- a/source/tests/dynlink_test/source/dynlink_test.cpp
+++ b/source/tests/dynlink_test/source/dynlink_test.cpp
@@ -101,7 +101,7 @@ TEST_F(dynlink_test, DefaultConstructor)
 
 			log_write("metacall", LOG_LEVEL_DEBUG, "Dynamic linked shared object file: %s", dynlink_get_path(handle));
 
-			EXPECT_EQ((int)0, (int)strcmp(library_name, dynlink_get_name(handle)));
+			EXPECT_STREQ(library_name, dynlink_get_name(handle));
 
 			if (handle != NULL)
 			{
@@ -146,8 +146,8 @@ TEST_F(dynlink_test, DefaultConstructor)
 			log_write("metacall", LOG_LEVEL_DEBUG, "Dynamic linked shared object file name:     %s", dynlink_get_path(handle));
 			log_write("metacall", LOG_LEVEL_DEBUG, "Dynamic linked shared object file:          %s", dynlink_get_name(handle));
 
-			EXPECT_EQ((int)0, (int)strcmp(absolute_path, dynlink_get_path(handle)));
-			EXPECT_EQ((int)0, (int)strcmp(library_name, dynlink_get_name(handle)));
+			EXPECT_STREQ(absolute_path, dynlink_get_path(handle));
+			EXPECT_STREQ(library_name, dynlink_get_name(handle));
 
 			if (handle != NULL)
 			{

--- a/source/tests/environment_test/source/environment_test.cpp
+++ b/source/tests/environment_test/source/environment_test.cpp
@@ -39,7 +39,7 @@ TEST_F(environment_test, variable_text)
 
 	ASSERT_NE((const char *)NULL, (const char *)variable_text);
 
-	EXPECT_EQ((int)0, (int)strcmp(variable_text, "abcd"));
+	EXPECT_STREQ(variable_text, "abcd");
 
 	environment_variable_destroy(variable_text);
 }
@@ -52,7 +52,7 @@ TEST_F(environment_test, variable_text_default)
 
 	ASSERT_NE((const char *)NULL, (const char *)variable_text);
 
-	EXPECT_EQ((int)0, (int)strcmp(variable_text, "default"));
+	EXPECT_STREQ(variable_text, "default");
 
 	environment_variable_destroy(variable_text);
 }
@@ -63,7 +63,7 @@ TEST_F(environment_test, variable_static)
 
 	const char *variable_text_static = environment_variable_get(variable_text_name, "default");
 
-	EXPECT_EQ((int)0, (int)strcmp(variable_text_static, "abcd"));
+	EXPECT_STREQ(variable_text_static, "abcd");
 }
 
 TEST_F(environment_test, variable_path)
@@ -74,7 +74,7 @@ TEST_F(environment_test, variable_path)
 
 	ASSERT_NE((const char *)NULL, (const char *)variable_path);
 
-	EXPECT_EQ((int)0, (int)strcmp(variable_path, "abcd" ENVIRONMENT_VARIABLE_PATH_SEPARATOR_STR));
+	EXPECT_STREQ(variable_path, "abcd" ENVIRONMENT_VARIABLE_PATH_SEPARATOR_STR);
 
 	environment_variable_path_destroy(variable_path);
 }
@@ -87,7 +87,7 @@ TEST_F(environment_test, variable_path_default)
 
 	ASSERT_NE((const char *)NULL, (const char *)variable_path);
 
-	EXPECT_EQ((int)0, (int)strcmp(variable_path, "default_path" ENVIRONMENT_VARIABLE_PATH_SEPARATOR_STR));
+	EXPECT_STREQ(variable_path, "default_path" ENVIRONMENT_VARIABLE_PATH_SEPARATOR_STR);
 
 	environment_variable_path_destroy(variable_path);
 }
@@ -100,7 +100,7 @@ TEST_F(environment_test, variable_path_sanitized)
 
 	ASSERT_NE((const char *)NULL, (const char *)variable_path);
 
-	EXPECT_EQ((int)0, (int)strcmp(variable_path, "abcd" ENVIRONMENT_VARIABLE_PATH_SEPARATOR_STR));
+	EXPECT_STREQ(variable_path, "abcd" ENVIRONMENT_VARIABLE_PATH_SEPARATOR_STR);
 
 	environment_variable_path_destroy(variable_path);
 }

--- a/source/tests/log_test/source/log_test.cpp
+++ b/source/tests/log_test/source/log_test.cpp
@@ -85,7 +85,7 @@ TEST_F(log_test, DefaultConstructor)
 
 			unsigned int value = *((unsigned int *)value_ptr);
 
-			EXPECT_EQ((int)0, (int)strcmp(log_name_list[value].name, key));
+			EXPECT_STREQ(log_name_list[value].name, key);
 		}
 
 		EXPECT_EQ((int)log_map_destroy(map), (int)0);

--- a/source/tests/metacall_configuration_exec_path_test/source/metacall_configuration_exec_path_test.cpp
+++ b/source/tests/metacall_configuration_exec_path_test/source/metacall_configuration_exec_path_test.cpp
@@ -49,7 +49,7 @@ TEST_F(metacall_configuration_exec_path_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "Python hello_world: test"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "Python hello_world: test");
 
 		metacall_value_destroy(ret);
 	}

--- a/source/tests/metacall_configuration_exec_relative_path_test/source/metacall_configuration_exec_relative_path_test.cpp
+++ b/source/tests/metacall_configuration_exec_relative_path_test/source/metacall_configuration_exec_relative_path_test.cpp
@@ -49,7 +49,7 @@ TEST_F(metacall_configuration_exec_relative_path_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "Python hello_world: test"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "Python hello_world: test");
 
 		metacall_value_destroy(ret);
 	}

--- a/source/tests/metacall_cs_test/source/metacall_cs_test.cpp
+++ b/source/tests/metacall_cs_test/source/metacall_cs_test.cpp
@@ -81,7 +81,7 @@ TEST_F(metacall_cs_test, Concat)
 
 	EXPECT_NE((void *)NULL, (void *)ret);
 
-	EXPECT_EQ((int)0, (int)strcmp((const char *)metacall_value_to_string(ret), "Hello World"));
+	EXPECT_STREQ((const char *)metacall_value_to_string(ret), "Hello World");
 
 	metacall_value_destroy(ret);
 }

--- a/source/tests/metacall_distributable_test/source/metacall_distributable_test.cpp
+++ b/source/tests/metacall_distributable_test/source/metacall_distributable_test.cpp
@@ -106,7 +106,7 @@ TEST_F(metacall_distributable_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "Hello Universe"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "Hello Universe");
 
 		metacall_value_destroy(ret);
 	}
@@ -143,7 +143,7 @@ TEST_F(metacall_distributable_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "Hello meta-programmer!"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "Hello meta-programmer!");
 
 		metacall_value_destroy(ret);
 
@@ -193,7 +193,7 @@ TEST_F(metacall_distributable_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "abcdef"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "abcdef");
 
 		metacall_value_destroy(ret);
 
@@ -201,7 +201,7 @@ TEST_F(metacall_distributable_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "efg"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "efg");
 
 		metacall_value_destroy(ret);
 	}
@@ -246,7 +246,7 @@ TEST_F(metacall_distributable_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "Hello World"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "Hello World");
 
 		metacall_value_destroy(ret);
 	}

--- a/source/tests/metacall_ducktype_test/source/metacall_ducktype_test.cpp
+++ b/source/tests/metacall_ducktype_test/source/metacall_ducktype_test.cpp
@@ -123,7 +123,7 @@ TEST_F(metacall_ducktype_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_cast_string(&ret), "Hello Universe"));
+		EXPECT_STREQ(metacall_value_cast_string(&ret), "Hello Universe");
 
 		metacall_value_destroy(ret);
 
@@ -209,7 +209,7 @@ TEST_F(metacall_ducktype_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_cast_string(&ret), "PepicoWalas"));
+		EXPECT_STREQ(metacall_value_cast_string(&ret), "PepicoWalas");
 
 		metacall_value_destroy(ret);
 		metacall_value_destroy(args[0]);
@@ -260,7 +260,7 @@ TEST_F(metacall_ducktype_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_cast_string(&ret), "Hello meta-programmer!"));
+		EXPECT_STREQ(metacall_value_cast_string(&ret), "Hello meta-programmer!");
 
 		metacall_value_destroy(ret);
 
@@ -344,7 +344,7 @@ TEST_F(metacall_ducktype_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_cast_string(&ret), "abcdef"));
+		EXPECT_STREQ(metacall_value_cast_string(&ret), "abcdef");
 
 		metacall_value_destroy(ret);
 

--- a/source/tests/metacall_function_test/source/metacall_function_test.cpp
+++ b/source/tests/metacall_function_test/source/metacall_function_test.cpp
@@ -221,7 +221,7 @@ TEST_F(metacall_function_test, DefaultConstructor)
 
 		EXPECT_EQ((enum metacall_value_id)METACALL_STRING, (enum metacall_value_id)metacall_value_id(ret));
 
-		EXPECT_EQ((int)0, (int)strcmp("hello world", metacall_value_to_string(ret)));
+		EXPECT_STREQ("hello world", metacall_value_to_string(ret));
 
 		metacall_value_destroy(ret);
 

--- a/source/tests/metacall_handle_get_test/source/metacall_handle_get_test.cpp
+++ b/source/tests/metacall_handle_get_test/source/metacall_handle_get_test.cpp
@@ -113,7 +113,7 @@ TEST_F(metacall_handle_get_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "Hello from s1"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "Hello from s1");
 
 		metacall_value_destroy(ret);
 
@@ -135,7 +135,7 @@ TEST_F(metacall_handle_get_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "Hello from s2"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "Hello from s2");
 
 		metacall_value_destroy(ret);
 	}

--- a/source/tests/metacall_java_test/source/metacall_java_test.cpp
+++ b/source/tests/metacall_java_test/source/metacall_java_test.cpp
@@ -102,8 +102,8 @@ TEST_F(metacall_java_test, DefaultConstructor)
 			{ //GET ARRAYS
 				void *str_test = metacall_class_static_get(myclass, "STRING_TEST_Arr");
 				void **str_test_arr = metacall_value_to_array(str_test);
-				ASSERT_EQ((int)0, (int)strcmp(metacall_value_to_string(str_test_arr[0]), "Hello"));
-				ASSERT_EQ((int)0, (int)strcmp(metacall_value_to_string(str_test_arr[1]), "world"));
+				ASSERT_STREQ(metacall_value_to_string(str_test_arr[0]), "Hello");
+				ASSERT_STREQ(metacall_value_to_string(str_test_arr[1]), "world");
 				metacall_value_destroy(str_test);
 
 				void *class_test = metacall_class_static_get(myclass, "CLASS_TEST_Arr");

--- a/source/tests/metacall_load_configuration_test/source/metacall_load_configuration_test.cpp
+++ b/source/tests/metacall_load_configuration_test/source/metacall_load_configuration_test.cpp
@@ -108,7 +108,7 @@ TEST_F(metacall_load_configuration_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "Hello Universe"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "Hello Universe");
 
 		metacall_value_destroy(ret);
 
@@ -192,7 +192,7 @@ TEST_F(metacall_load_configuration_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "Hello Universe"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "Hello Universe");
 
 		metacall_value_destroy(ret);
 	}
@@ -225,7 +225,7 @@ TEST_F(metacall_load_configuration_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "Hello meta-programmer!"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "Hello meta-programmer!");
 
 		metacall_value_destroy(ret);
 	}

--- a/source/tests/metacall_map_await_test/source/metacall_map_await_test.cpp
+++ b/source/tests/metacall_map_await_test/source/metacall_map_await_test.cpp
@@ -96,7 +96,7 @@ static void *hello_world_await_ok(void *result, void *data)
 
 	fflush(stdout);
 
-	EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(result), "Hello World"));
+	EXPECT_STREQ(metacall_value_to_string(result), "Hello World");
 
 	++success_callbacks;
 

--- a/source/tests/metacall_map_test/source/metacall_map_test.cpp
+++ b/source/tests/metacall_map_test/source/metacall_map_test.cpp
@@ -201,7 +201,7 @@ TEST_F(metacall_map_test, DefaultConstructor)
 
 		ASSERT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "ACK: OK!"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "ACK: OK!");
 
 		metacall_value_destroy(ret);
 		*/

--- a/source/tests/metacall_node_exception_test/source/metacall_node_exception_test.cpp
+++ b/source/tests/metacall_node_exception_test/source/metacall_node_exception_test.cpp
@@ -53,7 +53,7 @@ TEST_F(metacall_node_exception_test, DefaultConstructor)
 
 		EXPECT_EQ((int)0, (int)metacall_error_from_value(ret, &ex));
 
-		EXPECT_EQ((int)0, (int)strcmp("Yeet", ex.message));
+		EXPECT_STREQ("Yeet", ex.message);
 
 		metacall_value_destroy(ret);
 
@@ -61,7 +61,7 @@ TEST_F(metacall_node_exception_test, DefaultConstructor)
 
 		EXPECT_EQ((int)0, (int)metacall_error_from_value(ret, &ex));
 
-		EXPECT_EQ((int)0, (int)strcmp("YeetThrown", ex.message));
+		EXPECT_STREQ("YeetThrown", ex.message);
 
 		metacall_value_destroy(ret);
 

--- a/source/tests/metacall_node_extension_test/source/metacall_node_extension_test.cpp
+++ b/source/tests/metacall_node_extension_test/source/metacall_node_extension_test.cpp
@@ -52,7 +52,7 @@ TEST_F(metacall_node_extension_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp("world", metacall_value_to_string(ret)));
+		EXPECT_STREQ("world", metacall_value_to_string(ret));
 
 		metacall_value_destroy(ret);
 	}

--- a/source/tests/metacall_node_port_test/source/metacall_node_port_test.cpp
+++ b/source/tests/metacall_node_port_test/source/metacall_node_port_test.cpp
@@ -59,7 +59,7 @@ TEST_F(metacall_node_port_test, DefaultConstructor)
 			struct await_data_type *await_data = static_cast<struct await_data_type *>(data);
 			std::unique_lock<std::mutex> lock(await_data->m);
 			const char *str = metacall_value_to_string(v);
-			EXPECT_EQ((int)0, (int)strcmp(str, "Tests passed without errors"));
+			EXPECT_STREQ(str, "Tests passed without errors");
 			await_data->c.notify_one();
 			return NULL;
 		};

--- a/source/tests/metacall_python_dict_test/source/metacall_python_dict_test.cpp
+++ b/source/tests/metacall_python_dict_test/source/metacall_python_dict_test.cpp
@@ -61,7 +61,7 @@ TEST_F(metacall_python_dict_test, DefaultConstructor)
 			}
 			else if (strcmp(key, "hello") == 0)
 			{
-				EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(array[1]), "world"));
+				EXPECT_STREQ(metacall_value_to_string(array[1]), "world");
 			}
 			else if (strcmp(key, "efg") == 0)
 			{
@@ -134,14 +134,14 @@ TEST_F(metacall_python_dict_test, DefaultConstructor)
 		char *ret_key0 = metacall_value_to_string(ret_pair0[0]);
 		long ret_value0 = metacall_value_to_long(ret_pair0[1]);
 
-		EXPECT_EQ((int)0, (int)strcmp(ret_key0, "new"));
+		EXPECT_STREQ(ret_key0, "new");
 		EXPECT_EQ((long)5, (long)ret_value0);
 
 		void **ret_pair1 = metacall_value_to_array(ret_map[1]);
 		char *ret_key1 = metacall_value_to_string(ret_pair1[0]);
 		long ret_value1 = metacall_value_to_long(ret_pair1[1]);
 
-		EXPECT_EQ((int)0, (int)strcmp(ret_key1, "whatever"));
+		EXPECT_STREQ(ret_key1, "whatever");
 		EXPECT_EQ((long)7, (long)ret_value1);
 
 		metacall_value_destroy(ret);

--- a/source/tests/metacall_python_exception_test/source/metacall_python_exception_test.cpp
+++ b/source/tests/metacall_python_exception_test/source/metacall_python_exception_test.cpp
@@ -54,9 +54,9 @@ TEST_F(metacall_python_exception_test, DefaultConstructor)
 
 		EXPECT_EQ((int)0, (int)metacall_error_from_value(ret, &ex));
 
-		EXPECT_EQ((int)0, (int)strcmp("yeet", ex.message));
+		EXPECT_STREQ("yeet", ex.message);
 
-		EXPECT_EQ((int)0, (int)strcmp("TypeError", ex.label));
+		EXPECT_STREQ("TypeError", ex.label);
 
 		metacall_value_destroy(ret);
 
@@ -64,9 +64,9 @@ TEST_F(metacall_python_exception_test, DefaultConstructor)
 
 		EXPECT_EQ((int)0, (int)metacall_error_from_value(ret, &ex));
 
-		EXPECT_EQ((int)0, (int)strcmp("asdf", ex.message));
+		EXPECT_STREQ("asdf", ex.message);
 
-		EXPECT_EQ((int)0, (int)strcmp("BaseException", ex.label));
+		EXPECT_STREQ("BaseException", ex.label);
 
 		metacall_value_destroy(ret);
 	}

--- a/source/tests/metacall_python_loader_port_test/source/metacall_python_loader_port_test.cpp
+++ b/source/tests/metacall_python_loader_port_test/source/metacall_python_loader_port_test.cpp
@@ -37,7 +37,7 @@ void *callback_host(size_t argc, void *args[], void *data)
 
 	printf("Host callback: %s\n", str);
 
-	EXPECT_EQ((int)0, (int)strcmp(str, "some text"));
+	EXPECT_STREQ(str, "some text");
 
 	return metacall_value_create_int(25);
 }
@@ -86,7 +86,7 @@ TEST_F(metacall_python_loader_port_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_cast_string(&ret), "Hello meta-programmer!"));
+		EXPECT_STREQ(metacall_value_cast_string(&ret), "Hello meta-programmer!");
 
 		metacall_value_destroy(ret);
 

--- a/source/tests/metacall_python_open_test/source/metacall_python_open_test.cpp
+++ b/source/tests/metacall_python_open_test/source/metacall_python_open_test.cpp
@@ -49,7 +49,7 @@ TEST_F(metacall_python_open_test, DefaultConstructor)
 
 		const char *result = metacall_value_to_string(ret);
 
-		EXPECT_NE((int)0, (int)strcmp(result, "<html><head></head><body>Error</body></html>"));
+		EXPECT_STRNE(result, "<html><head></head><body>Error</body></html>");
 
 		metacall_value_destroy(ret);
 
@@ -65,7 +65,7 @@ TEST_F(metacall_python_open_test, DefaultConstructor)
 
 		const char *token = metacall_value_to_string(ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(token, "eyJhbGciOiJIUzI1NiJ9.SGVsbG8gV29ybGQ.Iyc6PWVbK538giVdaInTeIO3jvvC1Vuy_czZUzoRRec"));
+		EXPECT_STREQ(token, "eyJhbGciOiJIUzI1NiJ9.SGVsbG8gV29ybGQ.Iyc6PWVbK538giVdaInTeIO3jvvC1Vuy_czZUzoRRec");
 
 		metacall_value_destroy(args[0]);
 

--- a/source/tests/metacall_python_port_test/source/metacall_python_port_test.cpp
+++ b/source/tests/metacall_python_port_test/source/metacall_python_port_test.cpp
@@ -46,7 +46,7 @@ TEST_F(metacall_python_port_test, DefaultConstructor)
 
 		void *ret = metacallv("main", metacall_null_args);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "Tests passed without errors"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "Tests passed without errors");
 
 		metacall_value_destroy(ret);
 	}

--- a/source/tests/metacall_return_monad_test/source/metacall_return_monad_test.cpp
+++ b/source/tests/metacall_return_monad_test/source/metacall_return_monad_test.cpp
@@ -78,7 +78,7 @@ TEST_F(metacall_return_monad_test, DefaultConstructor)
 
 		EXPECT_EQ((enum metacall_value_id)METACALL_STRING, (enum metacall_value_id)metacall_value_id(ret));
 
-		EXPECT_EQ((int)0, (int)strcmp("asd", metacall_value_to_string(ret)));
+		EXPECT_STREQ("asd", metacall_value_to_string(ret));
 
 		value_str = metacall_serialize(metacall_serial(), ret, &size, allocator);
 

--- a/source/tests/metacall_ruby_parser_integration_test/source/metacall_ruby_parser_integration_test.cpp
+++ b/source/tests/metacall_ruby_parser_integration_test/source/metacall_ruby_parser_integration_test.cpp
@@ -74,7 +74,7 @@ TEST_F(metacall_ruby_parser_integration_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "call"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "call");
 
 		metacall_value_destroy(ret);
 	}

--- a/source/tests/metacall_rust_load_from_package_dep_test/source/metacall_rust_load_from_package_dep_test.cpp
+++ b/source/tests/metacall_rust_load_from_package_dep_test/source/metacall_rust_load_from_package_dep_test.cpp
@@ -40,7 +40,7 @@ TEST_F(metacall_rust_load_from_package_dep_test, DefaultConstructor)
 		const char *text = "{\"name\": \"John Doe\"}";
 		void *ret = metacall("compile", text);
 		ASSERT_NE((void *)NULL, (void *)ret);
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "\"John Doe\""));
+		EXPECT_STREQ(metacall_value_to_string(ret), "\"John Doe\"");
 		metacall_value_destroy(ret);
 	}
 

--- a/source/tests/metacall_rust_load_from_package_test/source/metacall_rust_load_from_package_test.cpp
+++ b/source/tests/metacall_rust_load_from_package_test/source/metacall_rust_load_from_package_test.cpp
@@ -93,7 +93,7 @@ TEST_F(metacall_rust_load_from_mem_test, DefaultConstructor)
 	// 	void *ret = metacall("string_len", "Test String");
 	// 	EXPECT_EQ((long)11, (long)metacall_value_to_long(ret));
 	// 	ret = metacall("new_string", 123);
-	// 	EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "get number 123"));
+	// 	EXPECT_STREQ(metacall_value_to_string(ret), "get number 123");
 	// 	metacall_value_destroy(ret);
 	// }
 

--- a/source/tests/metacall_rust_test/source/metacall_rust_test.cpp
+++ b/source/tests/metacall_rust_test/source/metacall_rust_test.cpp
@@ -94,13 +94,13 @@ TEST_F(metacall_rust_test, DefaultConstructor)
 	// 	void *ret = metacall("string_len", "Test String");
 	// 	EXPECT_EQ((long)11, (long)metacall_value_to_long(ret));
 	// 	ret = metacall("new_string", 123);
-	// 	EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "get number 123"));
+	// 	EXPECT_STREQ(metacall_value_to_string(ret), "get number 123");
 	// 	metacall_value_destroy(ret);
 	// }
 
 	{
 		void *ret = metacall("str_slice", "hellow");
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "hel"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "hel");
 		metacall_value_destroy(ret);
 	}
 

--- a/source/tests/metacall_test/source/metacall_test.cpp
+++ b/source/tests/metacall_test/source/metacall_test.cpp
@@ -216,7 +216,7 @@ TEST_F(metacall_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "Hello Universe"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "Hello Universe");
 
 		metacall_value_destroy(ret);
 
@@ -276,7 +276,7 @@ TEST_F(metacall_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), web_content));
+		EXPECT_STREQ(metacall_value_to_string(ret), web_content);
 
 		metacall_value_destroy(ret);
 
@@ -353,7 +353,7 @@ TEST_F(metacall_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "Hello meta-programmer!"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "Hello meta-programmer!");
 
 		metacall_value_destroy(ret);
 
@@ -420,7 +420,7 @@ TEST_F(metacall_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "abcdef"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "abcdef");
 
 		metacall_value_destroy(ret);
 
@@ -428,7 +428,7 @@ TEST_F(metacall_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "efg"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "efg");
 
 		metacall_value_destroy(ret);
 	}
@@ -473,7 +473,7 @@ TEST_F(metacall_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "Hello World"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "Hello World");
 
 		metacall_value_destroy(ret);
 	}

--- a/source/tests/metacall_test/source/metacall_test_split.cpp
+++ b/source/tests/metacall_test/source/metacall_test_split.cpp
@@ -131,7 +131,7 @@ TEST_F(metacall_loader_test, Python)
 
 	EXPECT_NE((value)NULL, (value)ret);
 
-	EXPECT_EQ((int)0, (int)strcmp(value_to_string(ret), "Hello Universe"));
+	EXPECT_STREQ(value_to_string(ret), "Hello Universe");
 
 	value_destroy(ret);
 }
@@ -167,7 +167,7 @@ TEST_F(metacall_loader_test, Ruby)
 
 	EXPECT_NE((value)NULL, (value)ret);
 
-	EXPECT_EQ((int)0, (int)strcmp(value_to_string(ret), "Hello meta-programmer!"));
+	EXPECT_STREQ(value_to_string(ret), "Hello meta-programmer!");
 
 	value_destroy(ret);
 }
@@ -207,7 +207,7 @@ TEST_F(metacall_loader_test, JavascriptV8)
 
 	EXPECT_NE((value)NULL, (value)ret);
 
-	EXPECT_EQ((int)0, (int)strcmp(value_to_string(ret), "abcdef"));
+	EXPECT_STREQ(value_to_string(ret), "abcdef");
 
 	value_destroy(ret);
 }
@@ -251,7 +251,7 @@ TEST_F(metacall_loader_test, Mock)
 
 	EXPECT_NE((value)NULL, (value)ret);
 
-	EXPECT_EQ((int)0, (int)strcmp(value_to_string(ret), "Hello World"));
+	EXPECT_STREQ(value_to_string(ret), "Hello World");
 
 	value_destroy(ret);
 
@@ -259,7 +259,7 @@ TEST_F(metacall_loader_test, Mock)
 
 	EXPECT_NE((value)NULL, (value)ret);
 
-	EXPECT_EQ((int)0, (int)strcmp(value_to_string(ret), "Hello World"));
+	EXPECT_STREQ(value_to_string(ret), "Hello World");
 
 	value_destroy(ret);
 }

--- a/source/tests/metacall_typescript_tsx_test/source/metacall_typescript_tsx_test.cpp
+++ b/source/tests/metacall_typescript_tsx_test/source/metacall_typescript_tsx_test.cpp
@@ -52,7 +52,7 @@ TEST_F(metacall_tsx_test, DefaultConstructor)
 
 		EXPECT_NE((void *)NULL, (void *)ret);
 
-		EXPECT_EQ((int)0, (int)strcmp(metacall_value_to_string(ret), "<h1 data-reactroot=\"\">Hello metaprogrammer</h1>"));
+		EXPECT_STREQ(metacall_value_to_string(ret), "<h1 data-reactroot=\"\">Hello metaprogrammer</h1>");
 
 		metacall_value_destroy(ret);
 	}

--- a/source/tests/metacall_version_test/source/metacall_version_test.cpp
+++ b/source/tests/metacall_version_test/source/metacall_version_test.cpp
@@ -31,7 +31,7 @@ TEST_F(metacall_version_test, DefaultConstructor)
 {
 	metacall_print_info();
 
-	ASSERT_EQ((int)0, (int)strcmp(METACALL_VERSION, metacall_version_str()));
+	ASSERT_STREQ(METACALL_VERSION, metacall_version_str());
 
 	/* TODO: Test other version functions */
 }

--- a/source/tests/reflect_object_class_test/source/reflect_object_class_test.cpp
+++ b/source/tests/reflect_object_class_test/source/reflect_object_class_test.cpp
@@ -500,7 +500,7 @@ TEST_F(reflect_object_class_test, DefaultConstructor)
 
 		ASSERT_NE((value)NULL, (value)ret);
 
-		ASSERT_EQ((int)0, (int)strcmp(value_to_string(ret), "Hello World"));
+		ASSERT_STREQ(value_to_string(ret), "Hello World");
 
 		value_type_destroy(ret);
 
@@ -557,7 +557,7 @@ TEST_F(reflect_object_class_test, DefaultConstructor)
 
 		ASSERT_NE((value)NULL, (value)ret);
 
-		ASSERT_EQ((int)0, (int)strcmp(value_to_string(ret), "Hello World"));
+		ASSERT_STREQ(value_to_string(ret), "Hello World");
 
 		value_type_destroy(ret);
 

--- a/source/tests/serial_test/source/serial_test.cpp
+++ b/source/tests/serial_test/source/serial_test.cpp
@@ -35,9 +35,9 @@ public:
 
 		ASSERT_NE((serial)NULL, (serial)s);
 
-		EXPECT_EQ((int)0, (int)strcmp(name, serial_name(s)));
+		EXPECT_STREQ(name, serial_name(s));
 
-		EXPECT_EQ((int)0, (int)strcmp(extension, serial_extension(s)));
+		EXPECT_STREQ(extension, serial_extension(s));
 	}
 
 	const char *rapid_json_name()
@@ -140,7 +140,7 @@ TEST_F(serial_test, DefaultConstructor)
 
 		EXPECT_EQ((size_t)sizeof(value_list_str), (size_t)serialize_size);
 		EXPECT_NE((char *)NULL, (char *)buffer);
-		EXPECT_EQ((int)0, (int)strcmp(buffer, value_list_str));
+		EXPECT_STREQ(buffer, value_list_str);
 
 		value_destroy(v);
 
@@ -161,7 +161,7 @@ TEST_F(serial_test, DefaultConstructor)
 
 		EXPECT_EQ((size_t)sizeof(value_map_str), (size_t)serialize_size);
 		EXPECT_NE((value)NULL, (value)v);
-		EXPECT_EQ((int)0, (int)strcmp(buffer, value_map_str));
+		EXPECT_STREQ(buffer, value_map_str);
 
 		value *v_map = value_to_map(v);
 
@@ -189,7 +189,7 @@ TEST_F(serial_test, DefaultConstructor)
 
 		EXPECT_EQ((size_t)sizeof(json_empty_array), (size_t)serialize_size);
 		EXPECT_NE((value)NULL, (value)v);
-		EXPECT_EQ((int)0, (int)strcmp(buffer, json_empty_array));
+		EXPECT_STREQ(buffer, json_empty_array);
 
 		value_destroy(v);
 
@@ -206,7 +206,7 @@ TEST_F(serial_test, DefaultConstructor)
 		EXPECT_NE((value *)NULL, (value *)v_array);
 
 		EXPECT_EQ((type_id)TYPE_STRING, (type_id)value_type_id(v_array[0]));
-		EXPECT_EQ((int)0, (int)strcmp(value_to_string(v_array[0]), "asdf"));
+		EXPECT_STREQ(value_to_string(v_array[0]), "asdf");
 
 		EXPECT_EQ((type_id)TYPE_INT, (type_id)value_type_id(v_array[1]));
 		EXPECT_EQ((int)443, (int)value_to_int(v_array[1]));
@@ -237,7 +237,7 @@ TEST_F(serial_test, DefaultConstructor)
 		value *tupla = value_to_array(v_map[0]);
 
 		EXPECT_EQ((type_id)TYPE_STRING, (type_id)value_type_id(tupla[0]));
-		EXPECT_EQ((int)0, (int)strcmp(value_to_string(tupla[0]), "abc"));
+		EXPECT_STREQ(value_to_string(tupla[0]), "abc");
 
 		EXPECT_EQ((type_id)TYPE_FLOAT, (type_id)value_type_id(tupla[1]));
 		EXPECT_EQ((float)9.9f, (float)value_to_float(tupla[1]));
@@ -250,7 +250,7 @@ TEST_F(serial_test, DefaultConstructor)
 		tupla = value_to_array(v_map[1]);
 
 		EXPECT_EQ((type_id)TYPE_STRING, (type_id)value_type_id(tupla[0]));
-		EXPECT_EQ((int)0, (int)strcmp(value_to_string(tupla[0]), "cde"));
+		EXPECT_STREQ(value_to_string(tupla[0]), "cde");
 
 		EXPECT_EQ((type_id)TYPE_FLOAT, (type_id)value_type_id(tupla[1]));
 		EXPECT_EQ((float)1.5f, (float)value_to_float(tupla[1]));


### PR DESCRIPTION
# Description

Use proper string comparisons in tests.

## Type of change

Improves output in failing tests.

# Checklist:

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [x] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_ADDRESS_SANITIZER` or `./docker-compose.sh test-address-sanitizer &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer &> output`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).

<img width="978" height="186" alt="image" src="https://github.com/user-attachments/assets/74fe19d8-e8c9-4a9a-9a88-03ffe6a855ce" />
