### PR TITLE
Reimplement and bugfix some path functions

### DIFF
--- a/source/environment/include/environment/environment_variable_path.h
+++ b/source/environment/include/environment/environment_variable_path.h
@@ -52,7 +52,31 @@ extern "C" {
 
 /* -- Methods -- */
 
-ENVIRONMENT_API char *environment_variable_path_create(const char *name, const char *default_path, size_t default_path_size, size_t *env_size);
+/**
+ * @brief
+ *   If the value of `name` exists as an environment variable, return a live string of its value, otherwise return a live value of `default_path` or "/".
+ *
+ *   `name` should not be `NULL`.
+ *
+ *   If `default_path` is not `NULL`, `default_path_size` must be set to <= the length (including 0-terminator) of the `default_path` string.
+ *
+ *   If `env_size` is not `NULL`, the length (including 0-terminator) of the returned string will be set to it
+ * @param[in] name
+ *   The environment variable name to look up.
+ *
+ * @param[in] default_path
+ *   If the environment variable value is not found, the value to return instead.
+ *
+ * @param[in] default_path_size
+ *   The length (including 0-terminator) of `default_path` in chars.
+ *
+ * @param[out] env_size
+ *   Pointer to a size_t to write the length of the returned string to (optional).
+ *
+ * @return
+ *   The allocated string containing the environment variable value or the default or "/".
+ */
+ENVIRONMENT_API char *environment_variable_path_create(const char *const name, const char *const default_path, const size_t default_path_size, size_t *const env_size);
 
 ENVIRONMENT_API void environment_variable_path_destroy(char *variable_path);
 

--- a/source/environment/source/environment_variable_path.c
+++ b/source/environment/source/environment_variable_path.c
@@ -43,61 +43,32 @@
 
 /* -- Methods -- */
 
-char *environment_variable_path_create(const char *name, const char *default_path, size_t default_path_size, size_t *env_size)
+char *environment_variable_path_create(const char *const name, const char *const default_path, const size_t default_path_size, size_t *const env_size)
 {
-	const char *path_ptr = getenv(name);
-	char *path;
-	size_t length, size, last, end;
-
-	if (path_ptr == NULL)
+	const char *value = getenv(name);
+	size_t size;
+	if (value)
+		size = strlen(value) + 1;
+	else if (default_path)
 	{
-		if (default_path == NULL)
-		{
-			static const char empty_path[] = "";
-
-			default_path = empty_path;
-			default_path_size = sizeof(empty_path);
-		}
-
-		path_ptr = default_path;
-		length = default_path_size - 1;
+		value = default_path;
+		size = default_path_size;
 	}
 	else
 	{
-		length = strlen(path_ptr);
+		value = ENVIRONMENT_VARIABLE_PATH_SEPARATOR_STR;
+		size = sizeof(ENVIRONMENT_VARIABLE_PATH_SEPARATOR_STR);
 	}
-
-	last = length - 1;
-
-	if (ENVIRONMENT_VARIABLE_PATH_SEPARATOR(path_ptr[last]))
-	{
-		end = length;
-		size = length + 1;
-	}
-	else
-	{
-		last = length;
-		end = length + 1;
-		size = length + 2;
-	}
-
-	path = malloc(sizeof(char) * size);
-
-	if (path == NULL)
-	{
-		return NULL;
-	}
-
-	strncpy(path, path_ptr, length);
-
-	path[last] = ENVIRONMENT_VARIABLE_PATH_SEPARATOR_C;
-	path[end] = '\0';
-
-	if (env_size != NULL)
-	{
-		*env_size = size;
-	}
-
+	size_t alloc_size = size;
+	if (size > 1)
+		alloc_size += !ENVIRONMENT_VARIABLE_PATH_SEPARATOR(value[size - 2]);
+	char *const path = malloc(sizeof(char) * alloc_size);
+	memcpy(path, value, sizeof(char) * size);
+	if (size > 1)
+		path[alloc_size - 2] = ENVIRONMENT_VARIABLE_PATH_SEPARATOR_C;
+	path[alloc_size - 1] = '\0';
+	if (env_size)
+		*env_size = alloc_size;
 	return path;
 }
 

--- a/source/portability/include/portability/portability_path.h
+++ b/source/portability/include/portability/portability_path.h
@@ -109,9 +109,55 @@ extern "C" {
 
 /* -- Methods -- */
 
-PORTABILITY_API size_t portability_path_get_name(const char *path, size_t path_size, char *name, size_t name_size);
+/**
+ * @brief
+ *   Get the file name portion out of a path and strip away the file extension if any.
+ *
+ *   If `path` is NULL this will return an empty string.
+ *
+ *   If `name` is NULL or `name_size is 0 this will return the size it requires in order to write `name`.
+ *
+ *   If `path` or `name` are not NULL, then `path_size` or `name_size`, respectively, must be set to <= the length (including 0-terminator) of the memory regions pointed to by `path` and `name`.
+ * @param[in] path
+ *   The full path to extract the name from.
+ * @param[in] path_size
+ *   The length (including 0-terminator) of `path` in chars.
+ * @param[out] name
+ *   The memory location to write the extracted name to. If `NULL` the size required will be returned instead of the size written.
+ * @param[in] name_size
+ *   The size of the memory location pointed to by `name`.
+ * @return
+ *   The size of the name.
+ */
+PORTABILITY_API size_t portability_path_get_name(const char *const path, const size_t path_size, char *const name, const size_t name_size);
 
-PORTABILITY_API size_t portability_path_get_name_canonical(const char *path, size_t path_size, char *name, size_t name_size);
+/**
+ * @brief
+ *   Get the file name portion out of a path and strip away any amount of file extensions.
+ *
+ *   When called with `"/foo/bar.baz.qux"`:
+ *
+ *     - `portability_path_get_name` will produce the string `"bar.baz"`
+ *
+ *     - `portability_path_get_name_canonical` will produce the string `"bar"`
+ *
+ *   If `path` is NULL this will return an empty string.
+ *
+ *   If `name` is NULL or `name_size is 0 this will return the size it requires in order to write `name`.
+ *
+ *   If `path` or `name` are not NULL, then `path_size` or `name_size`, respectively, must be set to <= the length (including 0-terminator) of the memory regions pointed to by `path` and `name`.
+ * @param[in] path
+ *   The full path to extract the name from.
+ * @param[in] path_size
+ *   The length (including 0-terminator) of `path` in chars.
+ * @param[out] name
+ *   The memory location to write the extracted name to. If `NULL` the size required will be returned instead of the size written.
+ * @param[in] name_size
+ *   The size of the memory location pointed to by `name`.
+ * @return
+ *   The size of the name.
+ */
+PORTABILITY_API size_t portability_path_get_name_canonical(const char *const path, const size_t path_size, char *const name, const size_t name_size);
 
 PORTABILITY_API size_t portability_path_get_fullname(const char *path, size_t path_size, char *name, size_t name_size);
 

--- a/source/tests/portability_path_test/source/portability_path_test.cpp
+++ b/source/tests/portability_path_test/source/portability_path_test.cpp
@@ -68,6 +68,33 @@ TEST_F(portability_path_test, portability_path_test_path_get_module_name_with_ra
 	EXPECT_EQ((char)'\0', (char)result[size - 1]);
 }
 
+TEST_F(portability_path_test, portability_path_test_path_get_name_null)
+{
+	static const char result[] = "";
+
+	string_name name;
+
+	size_t size = portability_path_get_name(NULL, 0, name, NAME_SIZE);
+
+	EXPECT_STREQ(name, result);
+	EXPECT_EQ((size_t)size, (size_t)sizeof(result));
+	EXPECT_EQ((char)'\0', (char)result[size - 1]);
+}
+
+TEST_F(portability_path_test, portability_path_test_path_get_name_empty)
+{
+	static const char base[] = "";
+	static const char result[] = "";
+
+	string_name name;
+
+	size_t size = portability_path_get_name(base, sizeof(base), name, NAME_SIZE);
+
+	EXPECT_STREQ(name, result);
+	EXPECT_EQ((size_t)size, (size_t)sizeof(result));
+	EXPECT_EQ((char)'\0', (char)result[size - 1]);
+}
+
 TEST_F(portability_path_test, portability_path_test_path_get_name)
 {
 	static const char base[] = "/a/b/c/asd.txt";
@@ -99,6 +126,34 @@ TEST_F(portability_path_test, portability_path_test_path_get_name_end_dot)
 TEST_F(portability_path_test, portability_path_test_path_get_name_without_dot)
 {
 	static const char base[] = "/a/b/c/asd";
+	static const char result[] = "asd";
+
+	string_name name;
+
+	size_t size = portability_path_get_name(base, sizeof(base), name, NAME_SIZE);
+
+	EXPECT_STREQ(name, result);
+	EXPECT_EQ((size_t)size, (size_t)sizeof(result));
+	EXPECT_EQ((char)'\0', (char)result[size - 1]);
+}
+
+TEST_F(portability_path_test, portability_path_test_path_get_name_dot_in_path)
+{
+	static const char base[] = "/a/b.c/d/asd";
+	static const char result[] = "asd";
+
+	string_name name;
+
+	size_t size = portability_path_get_name(base, sizeof(base), name, NAME_SIZE);
+
+	EXPECT_STREQ(name, result);
+	EXPECT_EQ((size_t)size, (size_t)sizeof(result));
+	EXPECT_EQ((char)'\0', (char)result[size - 1]);
+}
+
+TEST_F(portability_path_test, portability_path_test_path_get_name_dot_in_path_and_name)
+{
+	static const char base[] = "/a/b.c/d/asd.txt";
 	static const char result[] = "asd";
 
 	string_name name;


### PR DESCRIPTION
# Description

- Get rid of some buffer overruns
- make more functions return more sensible things on NULL arguments
- properly DOCUMENT each function
- Add const type qualifiers where applicable
- Replace some string functions and loops with memcpy

This fixed some broken tests when I cloned with a "." in my parent path (like /github.com/metacall/core/...)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation update

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (code comments).
- [x] My changes generate no new warnings.
- [x] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [x] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test &> output` and attached the output.
- [x] I have tested my code with `OPTION_BUILD_ADDRESS_SANITIZER` or `./docker-compose.sh test-address-sanitizer &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer &> output`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
