### PR TITLE
replace string loader tags with `Tag` enum

### DIFF
--- a/source/ports/rs_port/README.md
+++ b/source/ports/rs_port/README.md
@@ -51,7 +51,7 @@ fn main() {
     let _metacall = initialize().unwrap();
      
     // Load the file
-    load::from_single_file("ts", "sum.ts").unwrap();
+    load::from_single_file(load::Tag::TypeScript, "sum.ts").unwrap();
 
     // Call the sum function
     let sum = metacall::<f64>("sum", [1.0, 2.0]).unwrap();

--- a/source/ports/rs_port/inline/src/lib.rs
+++ b/source/ports/rs_port/inline/src/lib.rs
@@ -2,7 +2,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 
 macro_rules! gen_inline_macro {
-    ($($name:ident),*) => (
+    ($($name:ident => $tag:ident),*) => (
         $(
             #[proc_macro]
             pub fn $name(input: TokenStream) -> TokenStream {
@@ -10,7 +10,7 @@ macro_rules! gen_inline_macro {
                 let buffer = token_stream_input.to_string();
 
                 let result = quote! {{
-                    ::metacall::load::from_memory(stringify!($name), #buffer.to_string()).unwrap()
+                    ::metacall::load::from_memory(::metacall::load::Tag::$tag, #buffer.to_string()).unwrap()
                 }};
 
                 result.into()
@@ -19,4 +19,14 @@ macro_rules! gen_inline_macro {
     )
 }
 
-gen_inline_macro!(py, node, ts, cs, rb, cob, rpc, java, wasm);
+gen_inline_macro!(
+    py => Python,
+    node => NodeJS,
+    ts => TypeScript,
+    cs => CSharp,
+    rb => Ruby,
+    cob => Cobol,
+    rpc => RPC,
+    java => Java,
+    wasm => Wasm
+);

--- a/source/ports/rs_port/src/lib.rs
+++ b/source/ports/rs_port/src/lib.rs
@@ -49,7 +49,7 @@
 //!     
 //!     // Load the file (Checkout the loaders module for loading multiple files
 //!     // or loading from string)
-//!     load::from_single_file("ts", "sum.ts").unwrap();
+//!     load::from_single_file(load::Tag::TypeScript, "sum.ts").unwrap();
 //!
 //!     // Call the sum function (Also checkout other metacall functions)
 //!     let sum = metacall::<f64>("sum", [1.0, 2.0]).unwrap();
@@ -66,14 +66,14 @@ pub(crate) use macros::private_macros::*;
 /// Contains MetaCall loaders from file and memory. Usage example: ...
 /// ```
 /// // Loading a single file with Nodejs.
-/// metacall::load::from_single_file("node", "index.js").unwrap();
+/// metacall::load::from_single_file(metacall::load::Tag::NodeJS, "index.js").unwrap();
 ///
 /// // Loading multiple files with Nodejs.
-/// metacall::load::from_file("node", ["index.js", "main.js"]).unwrap();
+/// metacall::load::from_file(metacall::load::Tag::NodeJS, ["index.js", "main.js"]).unwrap();
 ///
 /// // Loading a string with Nodejs.
 /// let script = "function greet() { return 'hi there!' }; module.exports = { greet };";
-/// metacall::load::from_memory("node", script).unwrap();
+/// metacall::load::from_memory(metacall::load::Tag::NodeJS, script).unwrap();
 /// ```
 pub mod load;
 

--- a/source/ports/rs_port/src/load.rs
+++ b/source/ports/rs_port/src/load.rs
@@ -5,28 +5,82 @@ use crate::{
 };
 use std::{
     ffi::CString,
+    fmt,
     path::{Path, PathBuf},
     ptr,
 };
 
+pub enum Tag {
+    C,
+    Cobol,
+    Crystal,
+    CSharp,
+    Dart,
+    Deno,
+    Extension,
+    File,
+    Java,
+    Julia,
+    JavaScript,
+    JSM,
+    Kind,
+    LLVM,
+    Lua,
+    Mock,
+    NodeJS,
+    Python,
+    Ruby,
+    RPC,
+    Rust,
+    TypeScript,
+    Wasm,
+}
+
+impl fmt::Display for Tag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Tag::C => write!(f, "c"),
+            Tag::Cobol => write!(f, "cob"),
+            Tag::Crystal => write!(f, "cr"),
+            Tag::CSharp => write!(f, "cs"),
+            Tag::Dart => write!(f, "dart"),
+            Tag::Deno => write!(f, "deno"),
+            Tag::Extension => write!(f, "ext"),
+            Tag::File => write!(f, "file"),
+            Tag::Java => write!(f, "java"),
+            Tag::Julia => write!(f, "jl"),
+            Tag::JavaScript => write!(f, "js"),
+            Tag::JSM => write!(f, "jsm"),
+            Tag::Kind => write!(f, "kind"),
+            Tag::LLVM => write!(f, "llvm"),
+            Tag::Lua => write!(f, "lua"),
+            Tag::Mock => write!(f, "mock"),
+            Tag::NodeJS => write!(f, "node"),
+            Tag::Python => write!(f, "py"),
+            Tag::Ruby => write!(f, "rb"),
+            Tag::RPC => write!(f, "rpc"),
+            Tag::Rust => write!(f, "rs"),
+            Tag::TypeScript => write!(f, "ts"),
+            Tag::Wasm => write!(f, "wasm"),
+        }
+    }
+}
+
 /// Loads a script from a single file. Usage example: ...
 /// ```
 /// // A Nodejs script
-/// metacall::load::from_single_file("node", "index.js").unwrap();
+/// metacall::load::from_single_file(Tag::NodeJS, "index.js").unwrap();
 /// ```
-pub fn from_single_file(
-    tag: impl ToString,
-    script: impl AsRef<Path>,
-) -> Result<(), MetaCallLoaderError> {
+pub fn from_single_file(tag: Tag, script: impl AsRef<Path>) -> Result<(), MetaCallLoaderError> {
     from_file(tag, [script])
 }
 /// Loads a script from file. Usage example: ...
 /// ```
 /// // A Nodejs script
-/// metacall::load::from_file("node", ["index.js", "main.js"]).unwrap();
+/// metacall::load::from_file(Tag::NodeJS, ["index.js", "main.js"]).unwrap();
 /// ```
 pub fn from_file(
-    tag: impl ToString,
+    tag: Tag,
     scripts: impl IntoIterator<Item = impl AsRef<Path>>,
 ) -> Result<(), MetaCallLoaderError> {
     let c_tag = cstring_enum!(tag, MetaCallLoaderError)?;
@@ -71,9 +125,9 @@ pub fn from_file(
 /// let script = "function greet() { return 'hi there!' }; module.exports = { greet };";
 ///
 /// // A Nodejs script
-/// metacall::load::from_memory("node", script).unwrap();
+/// metacall::load::from_memory(Tag::NodeJS, script).unwrap();
 /// ```
-pub fn from_memory(tag: impl ToString, script: impl ToString) -> Result<(), MetaCallLoaderError> {
+pub fn from_memory(tag: Tag, script: impl ToString) -> Result<(), MetaCallLoaderError> {
     let script = script.to_string();
     let c_tag = cstring_enum!(tag, MetaCallLoaderError)?;
     let c_script = cstring_enum!(script, MetaCallLoaderError)?;

--- a/source/ports/rs_port/tests/inlines_test.rs
+++ b/source/ports/rs_port/tests/inlines_test.rs
@@ -1,7 +1,8 @@
 use metacall::{
     initialize,
     inline::{node, py, ts},
-    is_initialized, load,
+    is_initialized,
+    load::{self, Tag},
 };
 
 #[test]
@@ -10,30 +11,30 @@ fn inlines() {
 
     assert!(is_initialized());
 
-    if load::from_memory("py", "").is_ok() {
+    if load::from_memory(Tag::Python, "").is_ok() {
         py! {
             print("hello world")
         }
     }
-    if load::from_memory("py", "").is_ok() {
+    if load::from_memory(Tag::Python, "").is_ok() {
         py! {print("hello world")}
     }
 
-    if load::from_memory("node", "").is_ok() {
+    if load::from_memory(Tag::NodeJS, "").is_ok() {
         node! {
             console.log("hello world");
         }
     }
-    if load::from_memory("node", "").is_ok() {
+    if load::from_memory(Tag::NodeJS, "").is_ok() {
         node! {console.log("hello world")}
     }
 
-    if load::from_memory("ts", "").is_ok() {
+    if load::from_memory(Tag::TypeScript, "").is_ok() {
         ts! {
             console.log("hello world");
         }
     }
-    if load::from_memory("ts", "").is_ok() {
+    if load::from_memory(Tag::TypeScript, "").is_ok() {
         ts! {console.log("hello world")}
     }
 }

--- a/source/ports/rs_port/tests/invalid_loaders_test.rs
+++ b/source/ports/rs_port/tests/invalid_loaders_test.rs
@@ -1,4 +1,8 @@
-use metacall::{initialize, is_initialized, load, MetaCallLoaderError};
+use metacall::{
+    initialize, is_initialized,
+    load::{self, Tag},
+    MetaCallLoaderError,
+};
 use std::env;
 
 #[test]
@@ -9,25 +13,24 @@ fn invalid_loaders() {
 
     let scripts_dir = env::current_dir().unwrap().join("tests/scripts");
     let inavlid_file = scripts_dir.join("whatever.yeet");
-    let valid_file = scripts_dir.join("script.js");
+    let js_file = scripts_dir.join("script.js");
 
     if let Err(MetaCallLoaderError::FileNotFound(_)) =
-        load::from_single_file("random", inavlid_file)
+        load::from_single_file(load::Tag::NodeJS, inavlid_file)
     {
         // Everything Ok
     } else {
         panic!("Expected the loader fail with `FileNotFound` error variant!");
     }
 
-    if let Err(MetaCallLoaderError::FromFileFailure) = load::from_single_file("random", valid_file)
-    {
+    if let Err(MetaCallLoaderError::FromFileFailure) = load::from_single_file(Tag::Lua, js_file) {
         // Everything Ok
     } else {
         panic!("Expected the loader fail with `FromFileFailure` error variant!");
     }
 
     if let Err(MetaCallLoaderError::FromMemoryFailure) =
-        load::from_memory("random", "Invalid code!")
+        load::from_memory(load::Tag::NodeJS, "Invalid code!")
     {
         // Everything Ok
     } else {

--- a/source/ports/rs_port/tests/loaders_test.rs
+++ b/source/ports/rs_port/tests/loaders_test.rs
@@ -1,4 +1,8 @@
-use metacall::{initialize, is_initialized, load, metacall_no_arg};
+use metacall::{
+    initialize, is_initialized,
+    load::{self, Tag},
+    metacall_no_arg,
+};
 use std::{
     env,
     fs::{self, File},
@@ -17,10 +21,10 @@ fn call_greet(test: &str, num: u32) {
 }
 
 fn load_from_memory_test() {
-    load::from_memory("node", SCRIPT1).unwrap();
+    load::from_memory(Tag::NodeJS, SCRIPT1).unwrap();
     call_greet("load_from_memory", 1);
 
-    load::from_memory("node", SCRIPT3).unwrap();
+    load::from_memory(Tag::NodeJS, SCRIPT3).unwrap();
 }
 
 fn load_from_file_test() {
@@ -34,7 +38,7 @@ fn load_from_file_test() {
     temp_js.write_all(SCRIPT2.as_bytes()).unwrap();
     temp_js.flush().unwrap();
 
-    load::from_single_file("node", temp_js_path).unwrap();
+    load::from_single_file(Tag::NodeJS, temp_js_path).unwrap();
 
     call_greet("load_from_file", 2);
 

--- a/source/ports/rs_port/tests/metacall_exception_test.rs
+++ b/source/ports/rs_port/tests/metacall_exception_test.rs
@@ -1,4 +1,7 @@
-use metacall::{initialize, is_initialized, load};
+use metacall::{
+    initialize, is_initialized,
+    load::{self, Tag},
+};
 use std::env;
 
 #[test]
@@ -10,7 +13,7 @@ fn inlines() {
     let tests_dir = env::current_dir().unwrap().join("tests/scripts");
     let js_test_file = tests_dir.join("script.js");
 
-    if load::from_single_file("node", js_test_file).is_ok() {
+    if load::from_single_file(Tag::NodeJS, js_test_file).is_ok() {
         // This should not generate a segmentation fault
         let val =
             metacall::metacall_no_arg::<metacall::MetaCallException>("test_exception").unwrap();

--- a/source/ports/rs_port/tests/metacall_test.rs
+++ b/source/ports/rs_port/tests/metacall_test.rs
@@ -1,7 +1,8 @@
 use metacall::{
-    initialize, is_initialized, load, MetaCallClass, MetaCallException, MetaCallFunction,
-    MetaCallFuture, MetaCallNull, MetaCallObject, MetaCallPointer, MetaCallThrowable,
-    MetaCallValue,
+    initialize, is_initialized,
+    load::{self, Tag},
+    MetaCallClass, MetaCallException, MetaCallFunction, MetaCallFuture, MetaCallNull,
+    MetaCallObject, MetaCallPointer, MetaCallThrowable, MetaCallValue,
 };
 use std::{any::Any, collections::HashMap, env, fmt::Debug};
 
@@ -368,7 +369,7 @@ fn metacall() {
     let js_test_file = tests_dir.join("script.js");
     let c_test_file = tests_dir.join("script.c");
     let py_test_file = tests_dir.join("script.py");
-    let py_loaded = load::from_single_file("py", py_test_file).is_ok();
+    let py_loaded = load::from_single_file(Tag::Python, py_test_file).is_ok();
 
     if py_loaded {
         test_buffer();
@@ -381,7 +382,7 @@ fn metacall() {
         test_string();
         test_null();
     }
-    if load::from_single_file("c", c_test_file).is_ok() {
+    if load::from_single_file(load::Tag::C, c_test_file).is_ok() {
         test_char();
         test_double();
         test_float();
@@ -390,7 +391,7 @@ fn metacall() {
         test_short();
         test_mixed_numbers();
     }
-    if load::from_single_file("node", js_test_file).is_ok() {
+    if load::from_single_file(load::Tag::NodeJS, js_test_file).is_ok() {
         test_exception();
         test_throwable();
         test_future();


### PR DESCRIPTION


# Description

Use Tag enum instead of strings in `load::from_single_file`, `load::from_file` and `load::from_memory`.
Prevents runtime errors from invalid tags like "rust" instead of "rs".

Fixes #585

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Documentation update

# Checklist:

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_ADDRESS_SANITIZER` or `./docker-compose.sh test-address-sanitizer &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer &> output`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
