### PR TITLE
docs(rs_port): update metacall_handle and metacall_handle_no_arg docu…

### DIFF
--- a/source/ports/rs_port/src/metacall.rs
+++ b/source/ports/rs_port/src/metacall.rs
@@ -99,8 +99,8 @@ pub fn metacall<T: MetaCallValue>(
     }
 }
 
-/// Calls a function within a specific ['Handle'] with arguments. The generic
-/// parameter is the return type of the function you're calling. Checkout ['MetaCallValue'] for possible types.
+/// Calls a function within a specific [Handle](Handle) with arguments. The generic
+/// parameter is the return type of the function you're calling. Checkout [MetaCallValue](MetaCallValue) for possible types.
 /// For example: ...
 /// ```
 /// let sum = metacall::metacall_handle::<i32>(handle, "sum", [1, 2]).unwrap();


### PR DESCRIPTION
@viferga 

Fixes #595 

Updated all documentation examples in the rs_port to use the new Handle parameter.
  - Updated examples in `load.rs` (`from_single_file`, `from_file`, `from_memory`)
  - Fixed documentation for `metacall_handle` and `metacall_handle_no_arg` in `metacall.rs`

