### PR TITLE
ci(msys2): add MinGW/UCRT CI matrix and install gtest

### DIFF
--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -110,6 +110,7 @@ jobs:
             mingw-w64-${{ matrix.env }}-gcc
             mingw-w64-${{ matrix.env }}-ninja
             mingw-w64-${{ matrix.env }}-pkg-config
+            mingw-w64-${{ matrix.env }}-gtest
             make
             git
 

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -82,3 +82,44 @@ jobs:
           wait_workflow: true
           client_payload: '{"ref": "${{ github.head_ref || github.ref_name }}"}'
           ref: master
+  mingw-test:
+    name: MSYS2 / ${{ matrix.sys }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sys: mingw64
+            env: x86_64
+          - sys: ucrt64
+            env: ucrt-x86_64
+          - sys: clang64
+            env: clang-x86_64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.sys }}
+          update: true
+          install: >
+            mingw-w64-${{ matrix.env }}-cmake
+            mingw-w64-${{ matrix.env }}-gcc
+            mingw-w64-${{ matrix.env }}-ninja
+            mingw-w64-${{ matrix.env }}-pkg-config
+            make
+            git
+
+      - name: Build MetaCall (MSYS2)
+        shell: msys2 {0}
+        run: |
+          mkdir -p build
+          cd build
+          cmake .. -G "Ninja" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DOPTION_BUILD_PLUGINS_BACKTRACE=OFF \
+            -DCMAKE_VERBOSE_MAKEFILE=ON
+          cmake --build . --parallel $(nproc)


### PR DESCRIPTION
# Description

This PR adds MSYS2-based CI coverage for Windows (MinGW/UCRT/Clang) and installs GoogleTest to ensure MinGW test jobs can run correctly.The change only updates GitHub Actions workflows.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_ADDRESS_SANITIZER` or `./docker-compose.sh test-address-sanitizer &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer &> output`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.
