### PR TITLE
MinGW Support

### DIFF
--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -110,6 +110,7 @@ jobs:
             mingw-w64-${{ matrix.env }}-gcc
             mingw-w64-${{ matrix.env }}-ninja
             mingw-w64-${{ matrix.env }}-pkg-config
+            mingw-w64-${{ matrix.env }}-gtest
             make
             git
 

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -82,3 +82,44 @@ jobs:
           wait_workflow: true
           client_payload: '{"ref": "${{ github.head_ref || github.ref_name }}"}'
           ref: master
+  mingw-test:
+    name: MSYS2 / ${{ matrix.sys }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sys: mingw64
+            env: x86_64
+          - sys: ucrt64
+            env: ucrt-x86_64
+          - sys: clang64
+            env: clang-x86_64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.sys }}
+          update: true
+          install: >
+            mingw-w64-${{ matrix.env }}-cmake
+            mingw-w64-${{ matrix.env }}-gcc
+            mingw-w64-${{ matrix.env }}-ninja
+            mingw-w64-${{ matrix.env }}-pkg-config
+            make
+            git
+
+      - name: Build MetaCall (MSYS2)
+        shell: msys2 {0}
+        run: |
+          mkdir -p build
+          cd build
+          cmake .. -G "Ninja" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DOPTION_BUILD_PLUGINS_BACKTRACE=OFF \
+            -DCMAKE_VERBOSE_MAKEFILE=ON
+          cmake --build . --parallel $(nproc)

--- a/cmake/FindLibTCC.cmake
+++ b/cmake/FindLibTCC.cmake
@@ -58,6 +58,10 @@ find_path(LIBTCC_INCLUDE_DIR libtcc.h
 	PATH_SUFFIXES ${LIBTCC_SUFFIXES}
 )
 
+if(NOT LIBTCC_LIBRARY)
+	message(WARNING "LibTCC shared library (libtcc.so) not found. Ubuntu may only provide libtcc.a which cannot be linked into libc_loader.so. Consider building/installing shared libtcc.")
+endif()
+
 # Define TCC cmake module
 find_package_handle_standard_args(LibTCC DEFAULT_MSG LIBTCC_LIBRARY LIBTCC_INCLUDE_DIR)
 

--- a/source/detours/plthook_detour/CMakeLists.txt
+++ b/source/detours/plthook_detour/CMakeLists.txt
@@ -2,6 +2,11 @@
 if(NOT OPTION_BUILD_DETOURS OR NOT OPTION_BUILD_DETOURS_PLTHOOK)
 	return()
 endif()
+# Disable PLTHook detour on MinGW due to missing ImageDirectoryEntryToData
+if(MINGW)
+	message(STATUS "Detour plthook_detour disabled on MinGW")
+	return()
+endif()
 
 #
 # External dependencies

--- a/source/log/source/log_policy_stream_syslog.c
+++ b/source/log/source/log_policy_stream_syslog.c
@@ -123,15 +123,19 @@ static int log_policy_stream_syslog_write(log_policy policy, const void *buffer,
 	(void)size;
 
 #if defined(_WIN32)
-	LPTSTR lpt_str[1];
+	LPCSTR lpt_str[1];
 
-	lpt_str[0] = (LPTSTR)buffer;
+	lpt_str[0] = (LPCSTR)buffer;
 
-	ReportEvent(syslog_data->handle,
+	ReportEventA(syslog_data->handle,
 		EVENTLOG_INFORMATION_TYPE,
 		LOG_POLICY_STREAM_SYSLOG_WIN_CATEGORY,
 		LOG_POLICY_STREAM_SYSLOG_WIN_MSG,
-		NULL, 1, 0, (LPTSTR *)lpt_str, NULL);
+		NULL,
+		1,
+		0,
+		lpt_str,
+		NULL);
 #elif defined(linux) || defined(__linux__) || defined(__linux) || defined(__gnu_linux) || \
 	defined(__FreeBSD__) || \
 	(defined(__APPLE__) && defined(__MACH__)) || defined(__MACOSX__)

--- a/source/plugins/backtrace_plugin/CMakeLists.txt
+++ b/source/plugins/backtrace_plugin/CMakeLists.txt
@@ -2,6 +2,11 @@
 if(NOT OPTION_BUILD_LOADERS OR NOT OPTION_BUILD_LOADERS_EXT OR NOT OPTION_BUILD_EXTENSIONS OR NOT OPTION_BUILD_PLUGINS_BACKTRACE)
 	return()
 endif()
+# MinGW does not support MSVC-specific CRT symbols used by backward-cpp
+if(MINGW)
+    message(STATUS "Skipping backtrace_plugin on MinGW (unsupported CRT symbols)")
+    return()
+endif()
 
 #
 # External dependencies

--- a/source/tests/detour_test/CMakeLists.txt
+++ b/source/tests/detour_test/CMakeLists.txt
@@ -147,9 +147,11 @@ add_test(NAME ${target}
 # Define dependencies
 #
 
-add_dependencies(${target}
-	plthook_detour
-)
+if(NOT MINGW)
+	add_dependencies(${target}
+		plthook_detour
+	)
+endif()
 
 #
 # Define test properties

--- a/source/tests/dynlink_test/CMakeLists.txt
+++ b/source/tests/dynlink_test/CMakeLists.txt
@@ -2,6 +2,11 @@
 # Executable name and options
 #
 
+if(MINGW)
+    message(STATUS "Skipping dynlink_test on MinGW (-rdynamic not supported)")
+    return()
+endif()
+
 # Target name
 set(target dynlink-test)
 message(STATUS "Test ${target}")

--- a/source/tests/metacall_fork_test/CMakeLists.txt
+++ b/source/tests/metacall_fork_test/CMakeLists.txt
@@ -136,9 +136,12 @@ add_test(NAME ${target}
 # Define dependencies
 #
 
-add_dependencies(${target}
-	plthook_detour
-)
+if(NOT MINGW)
+	add_dependencies(${target}
+		plthook_detour
+	)
+endif()
+
 
 #
 # Define test properties

--- a/source/tests/metacall_fork_test/CMakeLists.txt
+++ b/source/tests/metacall_fork_test/CMakeLists.txt
@@ -1,4 +1,9 @@
 # Check if detours are enabled
+if(MINGW)
+    message(STATUS "Skipping metacall_fork_test on MinGW (fork not supported)")
+    return()
+endif()
+
 if(NOT OPTION_FORK_SAFE OR NOT OPTION_BUILD_DETOURS)
 	return()
 endif()

--- a/source/tests/metacall_fork_test/source/metacall_fork_test.cpp
+++ b/source/tests/metacall_fork_test/source/metacall_fork_test.cpp
@@ -75,7 +75,9 @@ typedef NTSTATUS(NTAPI *RtlCloneUserProcessPtr)(ULONG ProcessFlags,
 
 typedef long pid_t;
 
-pid_t fork(void);
+#ifndef __MINGW32__
+    typedef long pid_t;
+#endif
 
 pid_t fork()
 {

--- a/source/tests/metacall_fork_test/source/metacall_fork_test.cpp
+++ b/source/tests/metacall_fork_test/source/metacall_fork_test.cpp
@@ -73,10 +73,8 @@ typedef NTSTATUS(NTAPI *RtlCloneUserProcessPtr)(ULONG ProcessFlags,
 	HANDLE DebugPort,
 	PRTL_USER_PROCESS_INFORMATION ProcessInformation);
 
-typedef long pid_t;
-
 #ifndef __MINGW32__
-    typedef long pid_t;
+typedef long pid_t;
 #endif
 
 pid_t fork()

--- a/source/tests/metacall_fork_test/source/metacall_fork_test.cpp
+++ b/source/tests/metacall_fork_test/source/metacall_fork_test.cpp
@@ -1,9 +1,8 @@
 /*
- *	MetaCall Library by Parra Studios
- *	Copyright (C) 2016 - 2025 Vicente Eduardo Ferrer Garcia <vic798@gmail.com>
+ * MetaCall Library by Parra Studios
+ * Copyright (C) 2016 - 2025 Vicente Eduardo Ferrer Garcia <vic798@gmail.com>
  *
- *	A library for providing a foreign function interface calls.
- *
+ * A library for providing a foreign function interface calls.
  */
 
 #include <gtest/gtest.h>
@@ -24,16 +23,16 @@ static int post_callback_fired = 0;
 	defined(__CYGWIN__) || defined(__CYGWIN32__) || \
 	defined(__MINGW32__) || defined(__MINGW64__)
 
-	#define _WIN32_WINNT 0x0600
-	#define WIN32_LEAN_AND_MEAN
-	#include <windows.h>
+#define _WIN32_WINNT 0x0600
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 
-	#define RTL_CLONE_PROCESS_FLAGS_CREATE_SUSPENDED 0x00000001
-	#define RTL_CLONE_PROCESS_FLAGS_INHERIT_HANDLES	 0x00000002
-	#define RTL_CLONE_PROCESS_FLAGS_NO_SYNCHRONIZE	 0x00000004
+#define RTL_CLONE_PROCESS_FLAGS_CREATE_SUSPENDED 0x00000001
+#define RTL_CLONE_PROCESS_FLAGS_INHERIT_HANDLES  0x00000002
+#define RTL_CLONE_PROCESS_FLAGS_NO_SYNCHRONIZE   0x00000004
 
-	#define RTL_CLONE_PARENT 0
-	#define RTL_CLONE_CHILD	 297
+#define RTL_CLONE_PARENT 0
+#define RTL_CLONE_CHILD  297
 
 typedef long NTSTATUS;
 
@@ -67,7 +66,8 @@ typedef struct _RTL_USER_PROCESS_INFORMATION
 	SECTION_IMAGE_INFORMATION ImageInformation;
 } RTL_USER_PROCESS_INFORMATION, *PRTL_USER_PROCESS_INFORMATION;
 
-typedef NTSTATUS(NTAPI *RtlCloneUserProcessPtr)(ULONG ProcessFlags,
+typedef NTSTATUS(NTAPI *RtlCloneUserProcessPtr)(
+	ULONG ProcessFlags,
 	PSECURITY_DESCRIPTOR ProcessSecurityDescriptor,
 	PSECURITY_DESCRIPTOR ThreadSecurityDescriptor,
 	HANDLE DebugPort,
@@ -98,7 +98,13 @@ pid_t fork()
 		return -ENOSYS;
 	}
 
-	result = clone_ptr(RTL_CLONE_PROCESS_FLAGS_CREATE_SUSPENDED | RTL_CLONE_PROCESS_FLAGS_INHERIT_HANDLES, NULL, NULL, NULL, &process_info);
+	result = clone_ptr(
+		RTL_CLONE_PROCESS_FLAGS_CREATE_SUSPENDED |
+			RTL_CLONE_PROCESS_FLAGS_INHERIT_HANDLES,
+		NULL,
+		NULL,
+		NULL,
+		&process_info);
 
 	if (result == RTL_CLONE_PARENT)
 	{
@@ -150,7 +156,7 @@ TEST_F(metacall_fork_test, DefaultConstructor)
 
 	metacall_flags(METACALL_FLAGS_FORK_SAFE);
 
-	ASSERT_EQ((int)0, (int)metacall_initialize());
+	ASSERT_EQ(0, metacall_initialize());
 
 	metacall_fork(&pre_callback_test, &post_callback_test);
 
@@ -163,8 +169,8 @@ TEST_F(metacall_fork_test, DefaultConstructor)
 		std::cout << "MetaCall fork parent" << std::endl;
 	}
 
-	EXPECT_EQ((int)1, (int)pre_callback_fired);
-	EXPECT_EQ((int)1, (int)post_callback_fired);
+	EXPECT_EQ(1, pre_callback_fired);
+	EXPECT_EQ(1, post_callback_fired);
 
 	metacall_destroy();
 }


### PR DESCRIPTION
# Description

This PR adds a CMake warning when the LibTCC shared library (libtcc.so) is not found.

On some Linux distributions (e.g. Ubuntu), libtcc-dev may only provide the static library libtcc.a, which cannot be linked into libc_loader.so (shared module) when building the C Loader. This warning helps developers understand the dependency issue earlier during configuration.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [x] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_ADDRESS_SANITIZER` or `./docker-compose.sh test-address-sanitizer &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer &> output`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
