### PR TITLE
Fix for UseAfterFix and DoubleFree vulnerability in scope_metadata_name() Issue #636

### DIFF
--- a/source/reflect/source/reflect_scope.c
+++ b/source/reflect/source/reflect_scope.c
@@ -272,6 +272,7 @@ value scope_metadata_name(scope sp)
 	if (v_ptr[0] == NULL)
 	{
 		value_type_destroy(v);
+		return NULL;
 	}
 
 	v_ptr[1] = value_create_string(sp->name, strlen(sp->name));
@@ -279,6 +280,7 @@ value scope_metadata_name(scope sp)
 	if (v_ptr[1] == NULL)
 	{
 		value_type_destroy(v);
+		return NULL;
 	}
 
 	return v;


### PR DESCRIPTION
# Description

This PR fixes UseAfterFree and DoubleFree vulnrability in 'scope_metadata_name()' in 'reflect_scope.c'
Previously if `value_create_string()` fails during allocation of `v_ptr[0]` or `v_ptr[1]`, `value_type_destroy(v)` was called, but execution continued,This resulted in a UseAfterFree write to destroyed array and ultimately returned dangling pointer.
This patch adds missing 'return NULL' statements after 'value_type_destroy' in both branches.

Fixes #636 


## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ x] I have performed a self-review of my own code.
- [ x] My changes generate no new warnings.
- [ x] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ x] I have tested my code with `OPTION_BUILD_ADDRESS_SANITIZER` or `./docker-compose.sh test-address-sanitizer &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ x] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

