### PR TITLE
Fix TCC symbol lookup failure on macOS in c_loader 

### DIFF
--- a/source/loaders/c_loader/source/c_loader_impl.cpp
+++ b/source/loaders/c_loader/source/c_loader_impl.cpp
@@ -790,7 +790,19 @@ static void c_loader_impl_discover_symbols(void *ctx, const char *name, const vo
 {
 	std::map<std::string, const void *> *symbols = static_cast<std::map<std::string, const void *> *>(ctx);
 
+#if (defined(__APPLE__) && defined(__MACH__)) || defined(__MACOSX__)
+	/* On macOS, TCC may prefix C symbols with a leading underscore per the platform ABI.
+	 * Strip it so that lookup by plain function name (as reported by Clang) always works,
+	 * regardless of whether the system TCC or the MetaCall forked TCC is in use. */
+	std::string sym_name(name);
+	if (!sym_name.empty() && sym_name[0] == '_')
+	{
+		sym_name = sym_name.substr(1);
+	}
+	symbols->insert(std::pair<std::string, const void *>(sym_name, addr));
+#else
 	symbols->insert(std::pair<std::string, const void *>(name, addr));
+#endif
 }
 
 int function_c_interface_create(function func, function_impl impl)
@@ -1359,19 +1371,14 @@ static int c_loader_impl_discover_signature(loader_impl impl, loader_impl_c_hand
 {
 	auto cursor_type = clang_getCursorType(cursor);
 	auto func_name = c_loader_impl_cxstring_to_str(clang_getCursorSpelling(cursor));
-	auto symbol_name = func_name;
 
-#if (defined(__APPLE__) && defined(__MACH__)) || defined(__MACOSX__)
-	symbol_name.insert(0, 1, '_');
-#endif
-
-	if (scope_get(sp, symbol_name.c_str()) != NULL)
+	if (scope_get(sp, func_name.c_str()) != NULL)
 	{
 		log_write("metacall", LOG_LEVEL_WARNING, "Symbol '%s' redefined, skipping the function", func_name.c_str());
 		return 0;
 	}
 
-	const void *address = c_handle->symbol(symbol_name);
+	const void *address = c_handle->symbol(func_name);
 
 	if (address == NULL)
 	{


### PR DESCRIPTION
### Summary

Fixes #442 — the C loader test (`metacall_test`) fails on macOS because TCC-compiled symbols cannot be discovered, with the error:

```
Symbol 'compiled_print' not found, skipping the function
Failed to discover C function declaration 'compiled_print'
```

### Root Cause

On macOS, TCC may store symbols with a leading `_` prefix per the platform ABI (e.g. `compiled_print` → `_compiled_print`). Clang's AST parser always reports plain names. When the symbols map is populated with `_`-prefixed names, the plain-name lookup in `c_loader_impl_discover_signature` fails.

The existing `#if __APPLE__` workaround in `c_loader_impl_discover_signature` tried to compensate by prepending `_` at lookup time — this worked for the system TCC, but fails with the MetaCall forked TCC (which does NOT add the underscore prefix). Since CI uses the forked TCC (by design), the test failed.

### Fix

Rather than patching the lookup side (which is TCC-variant-dependent), normalize symbol names at **insertion time** in `c_loader_impl_discover_symbols`:

- On macOS: strip any leading `_` from the symbol name before inserting into the map
- If the forked TCC (no prefix) is in use: the `if` condition is false, no change in behaviour
- If the system TCC (with prefix) is in use: the `_` is stripped, map holds plain name

Then remove the now-redundant `#if __APPLE__` prefix-prepend in `c_loader_impl_discover_signature` so lookups always use the plain Clang-reported name.

### Files Changed

- `source/loaders/c_loader/source/c_loader_impl.cpp`
  - `c_loader_impl_discover_symbols()` — strip leading `_` on macOS at insertion time
  - `c_loader_impl_discover_signature()` — remove `#if __APPLE__` block, use `func_name` directly

### Testing

Build verified clean. The fix makes behaviour consistent across both TCC variants.