### PR TITLE
Fix: Python 3.12+ compatibility and NodeJS CI module resolution

### DIFF
--- a/.github/workflows/release-nodejs.yml
+++ b/.github/workflows/release-nodejs.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: [ master, develop ]
+    branches: [master, develop]
     paths:
-      - '.github/workflows/release-nodejs.yml'
-      - 'source/ports/node_port/**'
+      - ".github/workflows/release-nodejs.yml"
+      - "source/ports/node_port/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -18,32 +18,94 @@ jobs:
     name: NodeJS Port Tests
     runs-on: ${{ matrix.os }}
     strategy:
-        fail-fast: false
-        matrix:
-          os: [ubuntu-latest, windows-latest, macos-latest]
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Install MetaCall Unix
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         run: curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
+
       - name: Install MetaCall Windows
         if: matrix.os == 'windows-latest'
         run: powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
 
+      - name: Fix NPM Permissions (macOS)
+        if: matrix.os == 'macos-latest'
+        run: sudo chown -R $(id -u):$(id -g) ~/.npm
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Install Dependencies
         working-directory: source/ports/node_port
         run: npm install
 
-      - name: Test the NodeJS Port
+
+      - name: Populate scripts directory (Unix)
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+        run: |
+          mkdir -p source/ports/node_port/scripts
+
+          # Python scripts (source/*/source/ → scripts/)
+          cp source/scripts/python/helloworld/source/helloworld.py  source/ports/node_port/scripts/
+          cp source/scripts/python/ducktype/source/ducktype.py       source/ports/node_port/scripts/
+          cp source/scripts/python/example/source/example.py         source/ports/node_port/scripts/
+          cp source/scripts/python/classname/source/classname.py     source/ports/node_port/scripts/
+          cp source/scripts/python/function/source/function.py       source/ports/node_port/scripts/
+
+          # Ruby scripts
+          cp source/scripts/ruby/ducktype/source/ducktype.rb         source/ports/node_port/scripts/
+          cp source/scripts/ruby/cache/source/cache.rb               source/ports/node_port/scripts/
+
+          # TypeScript badrequire package
+          # ts_project copies source/badrequire/source/ → LOADER_SCRIPT_PATH/
+          # source/badrequire/source/ contains the badrequire/ subdirectory, so
+          # the result is LOADER_SCRIPT_PATH/badrequire/  (matching CMake).
+          cp -r source/scripts/typescript/badrequire/source/badrequire \
+                source/ports/node_port/scripts/badrequire
+
+      - name: Populate scripts directory (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path source/ports/node_port/scripts | Out-Null
+
+          # Python scripts
+          Copy-Item source/scripts/python/helloworld/source/helloworld.py  source/ports/node_port/scripts/
+          Copy-Item source/scripts/python/ducktype/source/ducktype.py       source/ports/node_port/scripts/
+          Copy-Item source/scripts/python/example/source/example.py         source/ports/node_port/scripts/
+          Copy-Item source/scripts/python/classname/source/classname.py     source/ports/node_port/scripts/
+          Copy-Item source/scripts/python/function/source/function.py       source/ports/node_port/scripts/
+
+          # Ruby scripts
+          Copy-Item source/scripts/ruby/ducktype/source/ducktype.rb         source/ports/node_port/scripts/
+          Copy-Item source/scripts/ruby/cache/source/cache.rb               source/ports/node_port/scripts/
+
+          # TypeScript badrequire package
+          Copy-Item -Recurse `
+            source/scripts/typescript/badrequire/source/badrequire `
+            source/ports/node_port/scripts/badrequire
+
+      - name: Test the NodeJS Port (Unix)
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         working-directory: source/ports/node_port
+        env:
+          LOADER_SCRIPT_PATH: ${{ github.workspace }}/source/ports/node_port/scripts
+        run: node test.js
+
+      - name: Test the NodeJS Port (Windows)
+        if: matrix.os == 'windows-latest'
+        working-directory: source/ports/node_port
+        env:
+          LOADER_SCRIPT_PATH: ${{ github.workspace }}\source\ports\node_port\scripts
         run: node test.js
 
   release:

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,3 +17,4 @@ onkardahale <dahaleonkar@gmail.com>
 Akshit Garg <garg.akshit@gmail.com>
 burnerlee <avi.aviral140@gmail.com>
 Praveen Kumar <pkspyder007@gmail.com>
+k5602 <188656344+k5602@users.noreply.github.com>

--- a/source/loaders/py_loader/source/py_loader_impl.c
+++ b/source/loaders/py_loader/source/py_loader_impl.c
@@ -53,9 +53,9 @@
 #endif
 
 /* Set this variable to 1 in order to debug garbage collection data
-* and threading flow for improving the debug of memory leaks and async bugs.
-* Set it to 0 in order to remove all the noise.
-*/
+ * and threading flow for improving the debug of memory leaks and async bugs.
+ * Set it to 0 in order to remove all the noise.
+ */
 #define DEBUG_PRINT_ENABLED 0
 
 typedef struct loader_impl_py_function_type
@@ -63,7 +63,7 @@ typedef struct loader_impl_py_function_type
 	PyObject *func;
 	PyObject **values; // Cache and re-use the values array
 	loader_impl impl;
-} * loader_impl_py_function;
+} *loader_impl_py_function;
 
 typedef struct loader_impl_py_future_type
 {
@@ -71,14 +71,14 @@ typedef struct loader_impl_py_future_type
 	loader_impl_py py_impl;
 	PyObject *future;
 
-} * loader_impl_py_future;
+} *loader_impl_py_future;
 
 typedef struct loader_impl_py_class_type
 {
 	PyObject *cls;
 	loader_impl impl;
 
-} * loader_impl_py_class;
+} *loader_impl_py_class;
 
 typedef struct loader_impl_py_object_type
 {
@@ -86,21 +86,21 @@ typedef struct loader_impl_py_object_type
 	loader_impl impl;
 	value obj_class;
 
-} * loader_impl_py_object;
+} *loader_impl_py_object;
 
 typedef struct loader_impl_py_handle_module_type
 {
 	PyObject *instance;
 	PyObject *name;
 
-} * loader_impl_py_handle_module;
+} *loader_impl_py_handle_module;
 
 typedef struct loader_impl_py_handle_type
 {
 	loader_impl_py_handle_module modules;
 	size_t size;
 
-} * loader_impl_py_handle;
+} *loader_impl_py_handle;
 
 struct loader_impl_py_type
 {
@@ -146,7 +146,7 @@ typedef struct loader_impl_py_await_invoke_callback_state_type
 	void *context;
 	PyObject *coroutine;
 
-} * loader_impl_py_await_invoke_callback_state;
+} *loader_impl_py_await_invoke_callback_state;
 
 static int py_loader_impl_check_class(loader_impl_py py_impl, PyObject *obj);
 
@@ -200,8 +200,8 @@ static const char py_loader_capsule_null_id[] = "__metacall_capsule_null__";
 PyObject *py_loader_impl_capsule_new_null(void)
 {
 	/* We want to create a new capsule with contents set to NULL, but PyCapsule
-	* does not allow that, instead we are going to identify our NULL capsule with
-	* this configuration (setting the capsule to Py_None) */
+	 * does not allow that, instead we are going to identify our NULL capsule with
+	 * this configuration (setting the capsule to Py_None) */
 	return PyCapsule_New((void *)Py_NonePtr(), py_loader_capsule_null_id, NULL);
 }
 
@@ -2112,6 +2112,10 @@ int py_loader_impl_initialize_import(loader_impl_py py_impl)
 		"			if module_name in sys.modules:\n"
 		"				return sys.modules[module_name]\n"
 		"			else:\n"
+		"				# Guard against relative module names\n"
+		"				# ImportError in Python 3.12+ when passed to find_spec directly.\n"
+		"				if module_name.startswith('.') or '/' in module_name or '\\\\' in module_name:\n"
+		"					return FileNotFoundError('Module ' + module_name + ' could not be found')\n"
 		"				spec = importlib.util.find_spec(module_name)\n"
 		"				if spec is None:\n"
 		"					return FileNotFoundError('Module ' + module_name + ' could not be found')\n"
@@ -2499,9 +2503,9 @@ loader_impl_data py_loader_impl_initialize(loader_impl impl, configuration confi
 		py_loader_impl_main_module = argv[1];
 
 		/* If we are running on host, this means the main is already executed by the host, so we can skip it,
-		* otherwise if we are not in host and we run it for the first time, we can prepare the loader
-		* for running the main the first time
-		*/
+		 * otherwise if we are not in host and we run it for the first time, we can prepare the loader
+		 * for running the main the first time
+		 */
 		if (host == 0)
 		{
 			py_loader_impl_run_main = 0;
@@ -3658,7 +3662,7 @@ int py_loader_impl_discover_class(loader_impl impl, PyObject *py_class, klass c)
 					PyUnicode_AsUTF8(tuple_key),
 					args_count,
 					NULL,			   /* There's no need to pass the method implementation (tuple_val) here,
-					* it is used only for introspection, not for invoking it, that's done by name */
+										* it is used only for introspection, not for invoking it, that's done by name */
 					VISIBILITY_PUBLIC, /* TODO: check @property decorator for protected access? */
 					func_synchronicity,
 					NULL);
@@ -3725,7 +3729,7 @@ static int py_loader_impl_validate_object(loader_impl impl, PyObject *obj, objec
 			log_write("metacall", LOG_LEVEL_DEBUG, "Discover object member %s, type %s",
 					  PyUnicode_AsUTF8(dict_key),
 					  type_id_name(py_loader_impl_capi_to_value_type(dict_val)));
-			
+
 		}
 	}
 


### PR DESCRIPTION
### Description

This PR addresses module resolution failures in the MetaCall Python loader and systematic test failures in the NodeJS port CI/CD workflow.

### Changes

#### 1. Python 3.12+ Compatibility Fix
- Added a guard in `source/loaders/py_loader/source/py_loader_impl.c` to handle relative module names (starting with `.` or containing path separators) before calling `importlib.util.find_spec()`.
- This prevents `ImportError: no package specified` which was introduced in Python 3.12+, restoring clean "module not found" behavior.

#### 2. NodeJS CI/CD Workflow Improvements
- Updated `.github/workflows/release-nodejs.yml` to replicate the script directory structure expected by the loaders.
- Populated `source/ports/node_port/scripts` with required Python, Ruby, and TypeScript test modules during the CI run.
- Set `LOADER_SCRIPT_PATH` to ensure cross-platform test success on Ubuntu, macOS, and Windows.
- Added a fix for NPM permissions on macOS runners.

#### 3. Project Maintenance
- Updated `CONTRIBUTORS` file to include the author as required by the repository's git hooks.

### Validation
- Verified that all 18 NodeJS port tests pass across all target operating systems (Ubuntu, macOS, Windows).
- Confirmed that Python 3.12+ no longer produces loud tracebacks on invalid relative imports.