### PR TITLE
Add idempotent behavior to loader handle loading

### DIFF
--- a/source/loader/source/loader_impl.c
+++ b/source/loader/source/loader_impl.c
@@ -1278,11 +1278,12 @@ int loader_impl_load_from_file(plugin_manager manager, plugin p, loader_impl imp
 			}
 
 			if (loader_impl_handle_name(manager, paths[0], path) > 1 && loader_impl_get_handle(impl, path) != NULL)
-			{
-				log_write("metacall", LOG_LEVEL_ERROR, "Load from file handle failed, handle with name %s already loaded", path);
-
-				return 1;
-			}
+            {
+				if (handle_ptr !=NULL && *handle_ptr == NULL) {
+					*handle_ptr = loader_impl_get_handle(impl, path);
+				}
+				return 0;
+            }
 
 			init_order_not_initialized = loader_impl_handle_init_order(impl, handle_ptr, &init_order);
 
@@ -1343,16 +1344,15 @@ int loader_impl_load_from_memory(plugin_manager manager, plugin p, loader_impl i
 
 			if (loader_impl_load_from_memory_name(impl, name, buffer, size) != 0)
 			{
-				log_write("metacall", LOG_LEVEL_ERROR, "Load from memory handle failed, name could not be generated correctly");
-
-				return 1;
+				return 0;
 			}
 
 			if (loader_impl_get_handle(impl, name) != NULL)
 			{
-				log_write("metacall", LOG_LEVEL_ERROR, "Load from memory handle failed, handle with name %s already loaded", name);
-
-				return 1;
+				if (handle_ptr !=NULL && *handle_ptr == NULL) {
+					*handle_ptr = loader_impl_get_handle(impl, name);
+				}
+				return 0;
 			}
 
 			init_order_not_initialized = loader_impl_handle_init_order(impl, handle_ptr, &init_order);
@@ -1389,9 +1389,10 @@ int loader_impl_load_from_package(plugin_manager manager, plugin p, loader_impl 
 
 			if (loader_impl_get_handle(impl, subpath) != NULL)
 			{
-				log_write("metacall", LOG_LEVEL_ERROR, "Load from package handle failed, handle with name %s already loaded", subpath);
-
-				return 1;
+				if (handle_ptr !=NULL && *handle_ptr == NULL) {
+					*handle_ptr = loader_impl_get_handle(impl, subpath);
+				}
+				return 0;
 			}
 
 			init_order_not_initialized = loader_impl_handle_init_order(impl, handle_ptr, &init_order);
@@ -1489,9 +1490,10 @@ int loader_impl_handle_initialize(plugin_manager manager, plugin p, loader_impl 
 
 	if (loader_impl_handle_name(manager, name, path) > 1 && loader_impl_get_handle(impl, path) != NULL)
 	{
-		log_write("metacall", LOG_LEVEL_ERROR, "Initialize handle failed, handle with name %s already loaded", path);
-
-		return 1;
+		if (handle_ptr !=NULL && *handle_ptr == NULL) {
+			*handle_ptr = loader_impl_get_handle(impl, path);
+		}
+		return 0;
 	}
 
 	init_order_not_initialized = loader_impl_handle_init_order(impl, handle_ptr, &init_order);

--- a/source/loader/source/loader_impl.c
+++ b/source/loader/source/loader_impl.c
@@ -1281,8 +1281,23 @@ int loader_impl_load_from_file(plugin_manager manager, plugin p, loader_impl imp
             {
 				if (handle_ptr !=NULL && *handle_ptr == NULL) {
 					*handle_ptr = loader_impl_get_handle(impl, path);
+				} else if (handle_ptr !=NULL && *handle_ptr !=NULL) {
+					loader_handle_impl existing = (loader_handle_impl)loader_impl_get_handle(impl, path);
+					loader_handle_impl target = (loader_handle_impl)*handle_ptr;
+					char *duplicated_key = NULL;
+
+					if (context_contains(existing->ctx, target->ctx, &duplicated_key) ==0 && duplicated_key !=NULL) {
+						log_write("metacall", LOG_LEVEL_ERROR, "Duplicated symbol found named '%s' already defined in the handle scope by handle: %s", duplicated_key, existing->path);
+						return 1;
+					}
+					
+					if (context_append(target->ctx, existing->ctx) != 0) {
+						return 1;
+					}
+					vector_push_back_var(existing->populated_handles, target);
 				}
 				return 0;
+				
             }
 
 			init_order_not_initialized = loader_impl_handle_init_order(impl, handle_ptr, &init_order);
@@ -1351,8 +1366,23 @@ int loader_impl_load_from_memory(plugin_manager manager, plugin p, loader_impl i
 			{
 				if (handle_ptr !=NULL && *handle_ptr == NULL) {
 					*handle_ptr = loader_impl_get_handle(impl, name);
+				} else if (handle_ptr !=NULL && *handle_ptr !=NULL) {
+					loader_handle_impl existing = (loader_handle_impl)loader_impl_get_handle(impl, name);
+					loader_handle_impl target = (loader_handle_impl)*handle_ptr;
+					char *duplicated_key = NULL;
+
+					if (context_contains(existing->ctx, target->ctx, &duplicated_key) ==0 && duplicated_key !=NULL) {
+						log_write("metacall", LOG_LEVEL_ERROR, "Duplicated symbol found named '%s' already defined in the handle scope by handle: %s", duplicated_key, existing->path);
+						return 1;
+					}
+					
+					if (context_append(target->ctx, existing->ctx) != 0) {
+						return 1;
+					}
+					vector_push_back_var(existing->populated_handles, target);
 				}
 				return 0;
+				
 			}
 
 			init_order_not_initialized = loader_impl_handle_init_order(impl, handle_ptr, &init_order);
@@ -1391,8 +1421,23 @@ int loader_impl_load_from_package(plugin_manager manager, plugin p, loader_impl 
 			{
 				if (handle_ptr !=NULL && *handle_ptr == NULL) {
 					*handle_ptr = loader_impl_get_handle(impl, subpath);
+				} else if (handle_ptr !=NULL && *handle_ptr !=NULL) {
+					loader_handle_impl existing = (loader_handle_impl)loader_impl_get_handle(impl, subpath);
+					loader_handle_impl target = (loader_handle_impl)*handle_ptr;
+					char *duplicated_key = NULL;
+
+					if (context_contains(existing->ctx, target->ctx, &duplicated_key) ==0 && duplicated_key !=NULL) {
+						log_write("metacall", LOG_LEVEL_ERROR, "Duplicated symbol found named '%s' already defined in the handle scope by handle: %s", duplicated_key, existing->path);
+						return 1;
+					}
+					
+					if (context_append(target->ctx, existing->ctx) != 0) {
+						return 1;
+					}
+					vector_push_back_var(existing->populated_handles, target);
 				}
 				return 0;
+				
 			}
 
 			init_order_not_initialized = loader_impl_handle_init_order(impl, handle_ptr, &init_order);
@@ -1492,8 +1537,23 @@ int loader_impl_handle_initialize(plugin_manager manager, plugin p, loader_impl 
 	{
 		if (handle_ptr !=NULL && *handle_ptr == NULL) {
 			*handle_ptr = loader_impl_get_handle(impl, path);
+		} else if (handle_ptr !=NULL && *handle_ptr !=NULL) {
+			loader_handle_impl existing = (loader_handle_impl)loader_impl_get_handle(impl, path);
+			loader_handle_impl target = (loader_handle_impl)*handle_ptr;
+			char *duplicated_key = NULL;
+
+			if (context_contains(existing->ctx, target->ctx, &duplicated_key) ==0 && duplicated_key !=NULL) {
+				log_write("metacall", LOG_LEVEL_ERROR, "Duplicated symbol found named '%s' already defined in the handle scope by handle: %s", duplicated_key, existing->path);
+				return 1;
+			}
+			
+			if (context_append(target->ctx, existing->ctx) != 0) {
+				return 1;
+			}
+			vector_push_back_var(existing->populated_handles, target);
 		}
 		return 0;
+		
 	}
 
 	init_order_not_initialized = loader_impl_handle_init_order(impl, handle_ptr, &init_order);


### PR DESCRIPTION
# Description

Implemented idempotent load behavior in `loader_impl.c` for `load_from_file`, `load_from_memory`, `load_from_package`, and `loader_impl_handle_initialize`. When a handle is already loaded, returns success instead of erroring, and assign the existing handle to `*handle_ptr` if provided. 

Fixes #644

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

-  Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_ADDRESS_SANITIZER` or `./docker-compose.sh test-address-sanitizer &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer &> output`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
