### PR TITLE
Add support for char in rust loader

### DIFF
--- a/source/loaders/rs_loader/rust/compiler/src/wrapper/class.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/wrapper/class.rs
@@ -506,9 +506,12 @@ impl ToMetaResult for bool {
 impl ToMetaResult for char {
     fn to_meta_result(self) -> Result<MetacallValue> {
         let s = self.to_string();
-        let cstring = CString::new(s.clone()).unwrap();
-        let ptr = cstring.as_ptr();
-        Ok(unsafe { metacall_value_create_string(ptr, s.len()) })
+        let cstring = CString::new(s).unwrap();
+        let len = cstring.to_bytes().len();
+
+        Ok(unsafe {
+            metacall_value_create_string(cstring.as_ptr(), len)
+        })
     }
 }
 

--- a/source/loaders/rs_loader/rust/test/file.rs
+++ b/source/loaders/rs_loader/rust/test/file.rs
@@ -2,9 +2,12 @@
 pub fn multiply(a: i32, b: i32) -> i32 {
     a * b
 }
-pub fn echo_char() -> char {
-    'a'
+pub fn echo_char1(a: char) -> char {
+    a
 }
-pub fn unicode_char() -> char {
-    'é'
+pub fn _char() -> char{
+    '😊'
+}
+pub fn echo_char2(a: String) -> String {
+    a
 }


### PR DESCRIPTION
I have implemented char support in the rust loader by adding the corresponding handling in PrimitiveMetacallProtocolTypes, FromMeta<char>, ToMetaResult<char>, and the convert_to! macro.