### PR TITLE
fix(c_loader): fall back to env paths when package has no directory component

### DIFF
--- a/source/loaders/c_loader/source/c_loader_impl.cpp
+++ b/source/loaders/c_loader/source/c_loader_impl.cpp
@@ -43,6 +43,7 @@
 #include <vector>
 
 #include <cassert>
+#include <cstdlib>
 #include <cstring>
 
 /* LibFFI */
@@ -404,6 +405,37 @@ public:
 				if (this->lib != NULL && header_found == true)
 				{
 					return true;
+				}
+			}
+
+			/* Fallback: when package name has no directory (e.g. "loadtest"), search in
+			 * LOADER_SCRIPT_PATH and LOADER_LIBRARY_PATH from environment so that C packages
+			 * built to script path (e.g. tests) are found even if execution_paths were not
+			 * populated for this loader.
+			 */
+			if (library_directory_size == 0 || (library_directory_size == 1 && library_directory[0] == '\0'))
+			{
+				const char *env_paths[] = { "LOADER_SCRIPT_PATH", "LOADER_LIBRARY_PATH" };
+				for (const char *env_name : env_paths)
+				{
+					const char *env_value = getenv(env_name);
+					if (env_value == NULL || env_value[0] == '\0')
+					{
+						continue;
+					}
+					size_t env_len = strnlen(env_value, PORTABILITY_PATH_SIZE - 1);
+					if (this->lib == NULL)
+					{
+						this->load_dynlink(env_value, env_len + 1, library_name);
+					}
+					if (header_found == false)
+					{
+						header_found = this->add_header(env_value, env_len + 1, library_name, library_name_size);
+					}
+					if (this->lib != NULL && header_found == true)
+					{
+						return true;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
# Description

Fixes #631

> **AI assistance disclosure**: This fix was developed with AI assistance (Claude) and reviewed, tested, and submitted by @devs6186.

The C loader's `load_from_package` fails silently when given a bare package name like `loadtest` (no directory path component) and `execution_paths` is not populated for the loader — which is the common situation in test environments.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Problem

`metacall-c-lib-test` exercises `load_from_package("loadtest")`. The implementation splits the path into a directory part and a filename, then for relative paths it loops through `c_impl->execution_paths` and joins them with the (empty) directory to produce a search path. If `execution_paths` is empty the loop body never runs, so the `.so` and header are never found and the function returns `false` with no indication of what went wrong.

## Root Cause

`portability_path_get_directory` on a bare name returns an empty string (size 0 or 1). The subsequent loop over `execution_paths` only has something to join if that vector is non-empty. When it is empty (e.g. in test environments that rely on environment variables instead of programmatic execution path registration), the loop is a no-op and the fallback path is missing.

## Solution

After the `execution_paths` loop, check if `library_directory_size` is 0 (or contains only a null terminator). If so, iterate `LOADER_SCRIPT_PATH` and `LOADER_LIBRARY_PATH` from the environment and attempt to load the `.so` and find the header there. Both `getenv` names are the documented environment variables for this purpose. The fallback exits early on the first combination that finds both the library and the header.

## Changes Made

**`source/loaders/c_loader/source/c_loader_impl.cpp`**
- Added `#include <cstdlib>` for `getenv`.
- Added a fallback block after the `execution_paths` loop inside the relative-path branch of `initialize()`. The block is gated on `library_directory_size == 0` (bare package name), tries `LOADER_SCRIPT_PATH` then `LOADER_LIBRARY_PATH`, and returns `true` as soon as both the dynlink and header are resolved.

## Testing

Built with `cmake -DOPTION_BUILD_LOADERS_C=On ..` and ran `ctest -VV -R metacall-c`. With `LOADER_SCRIPT_PATH` set to the directory containing the test-compiled `.so` and `.h`, the bare `loadtest` package resolves correctly. Without the fix, the same invocation returns `false`.

## Edge Cases

- If both env variables are unset or empty the fallback is a no-op; behaviour is identical to before.
- If only one of the library or header is found in a given path the loop continues to the next env path (mirrors the existing exec_paths logic).
- Paths longer than `PORTABILITY_PATH_SIZE - 1` are truncated by `strnlen`; `portability_path_join` then bounds-checks within its own buffer, consistent with all other path operations in this file.