### PR TITLE
Fix clippy deny errors in rs_loader #681.

### DIFF
--- a/source/loaders/rs_loader/rust/compiler/src/api/class.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/api/class.rs
@@ -92,7 +92,7 @@ extern "C" fn class_singleton_static_invoke(
             .expect("Unable to get method name");
         let ret = class.call(name, args);
         std::mem::forget(class);
-        std::mem::forget(name);
+        //std::mem::forget(name);
         ret
     };
     if let Ok(ret) = ret {

--- a/source/loaders/rs_loader/rust/compiler/src/api/object.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/api/object.rs
@@ -44,7 +44,7 @@ extern "C" fn object_singleton_set(
 
         std::mem::forget(class);
         std::mem::forget(obj);
-        std::mem::forget(name);
+    //   std::mem::forget(name);
     };
     0
 }
@@ -66,7 +66,7 @@ extern "C" fn object_singleton_get(
 
         std::mem::forget(class);
         std::mem::forget(obj);
-        std::mem::forget(name);
+        //std::mem::forget(name);
         ret
     };
     if let Ok(ret) = ret {
@@ -96,7 +96,7 @@ extern "C" fn object_singleton_method_invoke(
 
         std::mem::forget(class);
         std::mem::forget(obj);
-        std::mem::forget(name);
+      //  std::mem::forget(name);
         ret
     };
     if let Ok(ret) = ret {

--- a/source/loaders/rs_loader/rust/compiler/src/lib.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/lib.rs
@@ -93,7 +93,7 @@ impl Source {
             let lib_extension = "so";
             #[cfg(windows)]
             let lib_extension = "dll";
-            #[cfg(macos)]
+            #[cfg(target_os = "macos")]
             let lib_extension = "dylib";
 
             let mut lib_name = file_name.clone();
@@ -266,15 +266,16 @@ impl DynlinkLibrary {
         }
     }
 
-    pub fn symbol(&self, symbol_name: &str) -> Result<DynlinkSymbolAddr, String> {
+pub fn symbol(&self, symbol_name: &str) -> Result<DynlinkSymbolAddr, String> {
         let c_symbol_name = CString::new(symbol_name).expect("CString::new failed");
 
         unsafe {
-            let mut symbol_address: DynlinkSymbolAddr = std::mem::transmute(std::ptr::null::<DynlinkSymbolAddr>());
-            let result = dynlink_symbol(self.instance, c_symbol_name.as_ptr(), &mut symbol_address);
+            let mut symbol_address = std::mem::MaybeUninit::<DynlinkSymbolAddr>::uninit();
+
+            let result = dynlink_symbol(self.instance, c_symbol_name.as_ptr(), symbol_address.as_mut_ptr());
 
             if result == 0 {
-                Ok(symbol_address)
+                Ok(symbol_address.assume_init())
             } else {
                 Err(format!("Failed to find symbol: {}", symbol_name))
             }
@@ -590,7 +591,7 @@ impl rustc_driver::Callbacks for CompilerCallbacks {
                 let mut wrapped_script = std::fs::File::create(&wrapped_script_path)
                     .expect("unable to create wrapped script");
                 wrapped_script
-                    .write("extern crate metacall_package;\n".as_bytes())
+                    .write_all("extern crate metacall_package;\n".as_bytes())
                     .expect("Unablt to write wrapped script");
             }
 


### PR DESCRIPTION
Resolves #681 

The PR fixes the hard compiler error listed in the Issue.

### Changes
**mismatched_target_os**:  changed #[cfg(macos)] to the correct #[cfg(target_os = "macos")]

**unused_io_amount**: Changed .write() to .write_all() 

**transmuting_null**:  Changed  symbol_address to symbol_address.assume_init()

**forget_ref**:  commented all the "std::mem::forget(name)" on a &str

### Source

https://rust-lang.github.io/rust-clippy/master/index.html#transmuting_null
https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount