### PR TITLE
fix(node_loader): fix crash and memory leak in metacall_inspect port

### DIFF
--- a/source/loaders/node_loader/source/node_loader_port.cpp
+++ b/source/loaders/node_loader/source/node_loader_port.cpp
@@ -1019,7 +1019,22 @@ napi_value node_loader_port_metacall_load_from_configuration_export(napi_env env
 	return v_exports;
 }
 
-/* TODO: Add documentation */
+/**
+*  @brief
+*    Inspects the loaded scripts and returns a JSON string
+*    describing all registered functions, their signatures,
+*    and metadata across all active loaders
+*
+*  @param[in] env
+*    N-API reference to the environment
+*
+*  @param[in] info
+*    Reference to the call information (no arguments expected)
+*
+*  @return
+*    N-API string value containing the MetaCall inspect JSON,
+*    or throws a TypeError and returns nullptr on failure
+*/
 napi_value node_loader_port_metacall_inspect(napi_env env, napi_callback_info)
 {
 	size_t size = 0;
@@ -1027,20 +1042,21 @@ napi_value node_loader_port_metacall_inspect(napi_env env, napi_callback_info)
 	void *allocator = metacall_allocator_create(METACALL_ALLOCATOR_STD, (void *)&std_ctx);
 	char *inspect_str = metacall_inspect(&size, allocator);
 
-	if (!(inspect_str != NULL && size != 0))
+	if (inspect_str == NULL || size == 0)
 	{
 		napi_throw_error(env, nullptr, "Invalid MetaCall inspect string");
+		metacall_allocator_destroy(allocator);
+		return nullptr;
 	}
 
 	napi_value result;
 	napi_status status = napi_create_string_utf8(env, inspect_str, size - 1, &result);
 
-	node_loader_impl_exception(env, status);
-
 	metacall_allocator_free(allocator, inspect_str);
 
 	metacall_allocator_destroy(allocator);
 
+	node_loader_impl_exception(env, status);
 	return result;
 }
 


### PR DESCRIPTION
## Summary

`node_loader_port_metacall_inspect` had three bugs that could cause a crash, a memory leak, and a potential resource leak.

## Bugs Fixed

**1. Missing `return` after error → crash**
When `metacall_inspect()` returns `NULL` or `size == 0`, `napi_throw_error` was called but execution continued into:

    napi_create_string_utf8(env, NULL, size - 1, &result)

Passing `NULL` as the string argument to N-API is undefined behaviour and causes a crash. Added `return nullptr` to stop execution after throw.

Condition also simplified from `if (!(inspect_str != NULL && size != 0))` to `if (inspect_str == NULL || size == 0)` for readability.

**2. Allocator never destroyed on error path → memory leak**
`metacall_allocator_destroy(allocator)` was only reachable on the happy path. Added it to the error branch before returning.

**3. Wrong operation order on happy path → potential `inspect_str` leak**
`node_loader_impl_exception` was called before `metacall_allocator_free(allocator, inspect_str)`. If the N-API status was an error, exception handling could skip the free and leak `inspect_str`. Reordered to `free → destroy → exception_check`.

**4. Added Doxygen documentation**
Replaced `/* TODO: Add documentation */` with a proper doc block.

## How to Test
```sh
mkdir -p build && cd build
cmake -DOPTION_BUILD_LOADERS_NODE=On -DOPTION_BUILD_TESTS=On ..
cmake --build . --target install
ctest -VV -R "metacall-inspect-test|metacall-node-test"
```