### PR TITLE
modernize python release workflow with oidc (#14)

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -1,40 +1,40 @@
 name: Release Python Package
 
 on:
-  workflow_dispatch:
-  pull_request:
+  workflow_dispatch: # Allow manual triggers for testing or emergency releases
   push:
-    branches: [ master, develop ]
-    paths:
-      - '.github/workflows/release-python.yml'
-      - 'source/ports/py_port/**'
+    tags:
+      - 'v*' # Only trigger on version tags (e.g., v0.5.5)
 
 permissions:
-  id-token: write
+  id-token: write # Required for OIDC Trusted Publishing to PyPI
   contents: read
 
+# Ensure only one release runs at a time. Do not cancel a release mid-flight.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   test:
     name: Python Port Tests
     runs-on: ${{ matrix.os }}
     strategy:
-        fail-fast: false
+        # Collect results from all platforms even if one fails
+        fail-fast: false 
         matrix:
           os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+
       - name: Install MetaCall Unix
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         run: curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
+
       - name: Install MetaCall Windows
         if: matrix.os == 'windows-latest'
+        # Force TLS 1.2 because older Windows runners can default to TLS 1.0/1.1
         run: powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
 
       - name: Set up Python
@@ -44,6 +44,7 @@ jobs:
 
       - name: Install Python Port
         working-directory: source/ports/py_port
+        # Using editable install for testing against the local source
         run: pip install -e .
 
       - name: Test the Python Port
@@ -54,12 +55,26 @@ jobs:
     name: Release Python Port
     runs-on: ubuntu-latest
     needs: test
-    if: ${{ github.event_name != 'pull_request' }}
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-      - name: Release the port
+          # Full history needed for potential tag-based version detection during build
+          fetch-depth: 0 
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Build package
         working-directory: source/ports/py_port
-        run: ./upload.sh
+        run: |
+          pip install build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: source/ports/py_port/dist/

--- a/source/ports/py_port/upload.sh
+++ b/source/ports/py_port/upload.sh
@@ -6,18 +6,22 @@
 #
 #	Copyright (C) 2016 - 2026 Vicente Eduardo Ferrer Garcia <vic798@gmail.com>
 #
-#	Licensed under the Apache License, Version 2.0 (the "License");
-#	you may not use this file except in compliance with the License.
-#	You may obtain a copy of the License at
+#       Licensed under the Apache License, Version 2.0 (the "License");
+#       you may not use this file except in compliance with the License.
+#       You may obtain a copy of the License at
 #
-#		http://www.apache.org/licenses/LICENSE-2.0
+#               http://www.apache.org/licenses/LICENSE-2.0
 #
-#	Unless required by applicable law or agreed to in writing, software
-#	distributed under the License is distributed on an "AS IS" BASIS,
-#	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#	See the License for the specific language governing permissions and
-#	limitations under the License.
+#       Unless required by applicable law or agreed to in writing, software
+#       distributed under the License is distributed on an "AS IS" BASIS,
+#       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#       See the License for the specific language governing permissions and
+#       limitations under the License.
 #
+
+# NOTE: This script is deprecated for CI/CD usage. 
+# Automated releases are now handled by .github/workflows/release-python.yml
+# using OIDC (Trusted Publishing).
 
 set -exuo pipefail
 


### PR DESCRIPTION
Fixes #14 

Hi Vicente,
The python port release workflow was broken after PyPI deprecated api token auth in their update. this fixes it

changes :
- switch auth to OIDC trusted publishing (eliminates the need for stored PyPI secrets)
- trigger only on version tags, not every push. PyPI rejects duplicate version uploads so the old trigger caused noise.
- use 'python -m build' instead of the old setup.py direct call.
- fix concurrency group (previous group used pr number which is always empty on tag pushes)

One thing you'll need to do on PyPI side : add metacall/core as a trusted publisher for release-python.yml. https://docs.pypi.org/trusted-publishers/adding-a-publisher/

let me know if anything looks off