### PR TITLE
fix(metacall): fix broken if/else chain in type dispatch for variadic functions

### DIFF
--- a/source/metacall/source/metacall.c
+++ b/source/metacall/source/metacall.c
@@ -683,7 +683,7 @@ void *metacallt(const char *name, const enum metacall_value_id ids[], ...)
 			{
 				args[iterator] = value_create_bool((boolean)va_arg(va, unsigned int));
 			}
-			if (id == TYPE_CHAR)
+			else if (id == TYPE_CHAR)
 			{
 				args[iterator] = value_create_char((char)va_arg(va, int));
 			}
@@ -782,7 +782,7 @@ void *metacallt_s(const char *name, const enum metacall_value_id ids[], size_t s
 			{
 				args[iterator] = value_create_bool((boolean)va_arg(va, unsigned int));
 			}
-			if (id == TYPE_CHAR)
+			else if (id == TYPE_CHAR)
 			{
 				args[iterator] = value_create_char((char)va_arg(va, int));
 			}
@@ -888,7 +888,7 @@ void *metacallht_s(void *handle, const char *name, const enum metacall_value_id 
 			{
 				args[iterator] = value_create_bool((boolean)va_arg(va, unsigned int));
 			}
-			if (id == TYPE_CHAR)
+			else if (id == TYPE_CHAR)
 			{
 				args[iterator] = value_create_char((char)va_arg(va, int));
 			}
@@ -1195,7 +1195,7 @@ void *metacallf(void *func, ...)
 			{
 				args[iterator] = value_create_bool((boolean)va_arg(va, unsigned int));
 			}
-			if (id == TYPE_CHAR)
+			else if (id == TYPE_CHAR)
 			{
 				args[iterator] = value_create_char((char)va_arg(va, int));
 			}


### PR DESCRIPTION
# Description

Fix broken `if`/`else if` type dispatch chain in four variadic call functions: `metacallt()`, `metacallt_s()`, `metacallht()`, and `metacallht_s()`.

The `TYPE_CHAR` branch incorrectly uses `if` instead of `else if`, breaking the exclusive dispatch chain after `TYPE_BOOL`. The correct pattern already exists in `metacall()` (line 570). This is a copy-paste bug from when the variadic functions were duplicated.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have tested the tests implicated by my own code and they pass.
- [x] I have run `make clang-format` in order to format my code.
