### PR TITLE
docs(reflect): add comprehensive Doxygen documentation to core headers

### DIFF
--- a/source/reflect/include/reflect/reflect_function.h
+++ b/source/reflect/include/reflect/reflect_function.h
@@ -62,32 +62,187 @@ typedef struct function_interface_type
 
 typedef function_interface (*function_impl_interface_singleton)(void);
 
+/**
+*  @brief
+*    Create a new function with the given name and argument count
+*
+*  @param[in] name
+*    Name identifier for the function
+*  @param[in] args_count
+*    Number of arguments the function accepts
+*  @param[in] impl
+*    Pointer to the language-specific function implementation
+*  @param[in] singleton
+*    Singleton accessor for the function interface (create, invoke, await, destroy)
+*
+*  @return
+*    Pointer to the newly created function on success, NULL on failure
+*/
 REFLECT_API function function_create(const char *name, size_t args_count, function_impl impl, function_impl_interface_singleton singleton);
 
+/**
+*  @brief
+*    Increment the reference count of a function
+*
+*  @param[in] func
+*    Pointer to the function
+*
+*  @return
+*    Zero on success, different from zero on failure
+*/
 REFLECT_API int function_increment_reference(function func);
 
+/**
+*  @brief
+*    Decrement the reference count of a function
+*
+*  @param[in] func
+*    Pointer to the function
+*
+*  @return
+*    Zero on success, different from zero on failure
+*/
 REFLECT_API int function_decrement_reference(function func);
 
+/**
+*  @brief
+*    Set the async behavior of a function
+*
+*  @param[in] func
+*    Pointer to the function
+*  @param[in] async
+*    Async identifier specifying the async behavior
+*/
 REFLECT_API void function_async(function func, enum async_id async);
 
+/**
+*  @brief
+*    Get the async identifier of a function
+*
+*  @param[in] func
+*    Pointer to the function
+*
+*  @return
+*    Async identifier of the function
+*/
 REFLECT_API enum async_id function_async_id(function func);
 
+/**
+*  @brief
+*    Bind closure data to a function
+*
+*  @param[in] func
+*    Pointer to the function
+*  @param[in] data
+*    Opaque pointer to closure data
+*/
 REFLECT_API void function_bind(function func, void *data);
 
+/**
+*  @brief
+*    Get the closure data bound to a function
+*
+*  @param[in] func
+*    Pointer to the function
+*
+*  @return
+*    Opaque pointer to the closure data, or NULL if none is bound
+*/
 REFLECT_API void *function_closure(function func);
 
+/**
+*  @brief
+*    Get the name of a function
+*
+*  @param[in] func
+*    Pointer to the function
+*
+*  @return
+*    String containing the function name, or NULL if func is NULL
+*    or no name was provided at creation time
+*/
 REFLECT_API const char *function_name(function func);
 
+/**
+*  @brief
+*    Get the signature of a function (argument types and return type)
+*
+*  @param[in] func
+*    Pointer to the function
+*
+*  @return
+*    Pointer to the function's signature
+*/
 REFLECT_API signature function_signature(function func);
 
+/**
+*  @brief
+*    Generate a metadata representation of the function
+*
+*  @param[in] func
+*    Pointer to the function
+*
+*  @return
+*    Value containing the metadata map, or NULL on failure
+*/
 REFLECT_API value function_metadata(function func);
 
+/**
+*  @brief
+*    Invoke a function synchronously with the given arguments
+*
+*  @param[in] func
+*    Pointer to the function to call
+*  @param[in] args
+*    Array of value arguments to pass to the function
+*  @param[in] size
+*    Number of arguments in the args array
+*
+*  @return
+*    Return value of the function call, or NULL on failure
+*/
 REFLECT_API function_return function_call(function func, function_args args, size_t size);
 
+/**
+*  @brief
+*    Invoke a function asynchronously with resolve and reject callbacks
+*
+*  @param[in] func
+*    Pointer to the function to call
+*  @param[in] args
+*    Array of value arguments to pass to the function
+*  @param[in] size
+*    Number of arguments in the args array
+*  @param[in] resolve_callback
+*    Callback invoked when the async operation completes successfully
+*  @param[in] reject_callback
+*    Callback invoked when the async operation fails
+*  @param[in] context
+*    Opaque pointer passed to both callbacks
+*
+*  @return
+*    Return value (typically a future), or NULL on failure
+*/
 REFLECT_API function_return function_await(function func, function_args args, size_t size, function_resolve_callback resolve_callback, function_reject_callback reject_callback, void *context);
 
+/**
+*  @brief
+*    Print debug statistics about function allocations and usage
+*
+*  @note
+*    Only produces output when the memory tracker is enabled
+*    (OPTION_MEMORY_TRACKER=ON at build time)
+*/
 REFLECT_API void function_stats_debug(void);
 
+/**
+*  @brief
+*    Destroy a function and free all associated resources.
+*    Passing NULL is safe and has no effect.
+*
+*  @param[in] func
+*    Pointer to the function to destroy
+*/
 REFLECT_API void function_destroy(function func);
 
 #ifdef __cplusplus

--- a/source/reflect/include/reflect/reflect_scope.h
+++ b/source/reflect/include/reflect/reflect_scope.h
@@ -36,34 +36,204 @@ typedef size_t scope_stack_ptr;
 
 typedef struct scope_type *scope;
 
+/**
+*  @brief
+*    Create a new scope with the given name
+*
+*  @param[in] name
+*    Name identifier for the scope (e.g. "global_namespace").
+*    The name string is copied internally; the caller does not need
+*    to keep it alive after this call.
+*
+*  @return
+*    Pointer to the newly created scope on success, NULL on failure
+*/
 REFLECT_API scope scope_create(const char *name);
 
+/**
+*  @brief
+*    Get the number of objects registered in the scope
+*
+*  @param[in] sp
+*    Pointer to the scope
+*
+*  @return
+*    Number of objects (functions, classes, objects) in the scope
+*/
 REFLECT_API size_t scope_size(scope sp);
 
+/**
+*  @brief
+*    Register a named object (function, class, or object) into the scope
+*
+*  @param[in] sp
+*    Pointer to the scope
+*  @param[in] key
+*    Name under which the object will be registered
+*  @param[in] obj
+*    Value to register in the scope
+*
+*  @return
+*    Zero on success, different from zero on failure
+*/
 REFLECT_API int scope_define(scope sp, const char *key, value obj);
 
+/**
+*  @brief
+*    Generate a metadata representation of the scope and its contents
+*
+*  @param[in] sp
+*    Pointer to the scope
+*
+*  @return
+*    Value containing the metadata map, or NULL on failure
+*/
 REFLECT_API value scope_metadata(scope sp);
 
+/**
+*  @brief
+*    Export the scope contents as a serializable value
+*
+*  @param[in] sp
+*    Pointer to the scope
+*
+*  @return
+*    Value containing the exported scope data, or NULL on failure
+*/
 REFLECT_API value scope_export(scope sp);
 
+/**
+*  @brief
+*    Retrieve a registered object from the scope by name
+*
+*  @param[in] sp
+*    Pointer to the scope
+*  @param[in] key
+*    Name of the object to retrieve
+*
+*  @return
+*    Value associated with the key, or NULL if not found
+*/
 REFLECT_API value scope_get(scope sp, const char *key);
 
+/**
+*  @brief
+*    Remove a registered object from the scope by name
+*
+*  @param[in] sp
+*    Pointer to the scope
+*  @param[in] key
+*    Name of the object to undefine
+*
+*  @return
+*    Value that was removed, or NULL if not found
+*/
 REFLECT_API value scope_undef(scope sp, const char *key);
 
+/**
+*  @brief
+*    Append all objects from source scope into destination scope
+*
+*  @param[in] dest
+*    Destination scope to append into
+*  @param[in] src
+*    Source scope whose objects will be copied
+*
+*  @return
+*    Zero on success, different from zero on failure
+*/
 REFLECT_API int scope_append(scope dest, scope src);
 
+/**
+*  @brief
+*    Check if any objects in source scope already exist in destination scope
+*
+*  @param[in] dest
+*    Destination scope to check against
+*  @param[in] src
+*    Source scope to check for duplicates
+*  @param[out] duplicated
+*    Pointer to receive the name of the first duplicate found, if any
+*
+*  @return
+*    Zero if a duplicate key is found, different from zero if the scopes
+*    are disjoint or an error occurs
+*/
 REFLECT_API int scope_contains(scope dest, scope src, char **duplicated);
 
+/**
+*  @brief
+*    Remove all objects that exist in source scope from destination scope
+*
+*  @param[in] dest
+*    Destination scope to remove from
+*  @param[in] src
+*    Source scope whose objects will be removed from dest
+*
+*  @return
+*    Zero on success, different from zero on failure
+*/
 REFLECT_API int scope_remove(scope dest, scope src);
 
+/**
+*  @brief
+*    Get a pointer to the scope's internal return stack size
+*
+*  @param[in] sp
+*    Pointer to the scope
+*
+*  @return
+*    Pointer to the stack return size value
+*/
 REFLECT_API size_t *scope_stack_return(scope sp);
 
+/**
+*  @brief
+*    Push a block of memory onto the scope's internal stack
+*
+*  @param[in] sp
+*    Pointer to the scope
+*  @param[in] bytes
+*    Number of bytes to allocate on the stack
+*
+*  @return
+*    Stack pointer offset to the allocated block
+*/
 REFLECT_API scope_stack_ptr scope_stack_push(scope sp, size_t bytes);
 
+/**
+*  @brief
+*    Retrieve a pointer to data at the given stack position
+*
+*  @param[in] sp
+*    Pointer to the scope
+*  @param[in] stack_ptr
+*    Stack pointer offset returned by scope_stack_push
+*
+*  @return
+*    Pointer to the data at the given stack position, or NULL on failure
+*/
 REFLECT_API void *scope_stack_get(scope sp, scope_stack_ptr stack_ptr);
 
+/**
+*  @brief
+*    Pop the last pushed block from the scope's internal stack
+*
+*  @param[in] sp
+*    Pointer to the scope
+*
+*  @return
+*    Zero on success, different from zero on failure
+*/
 REFLECT_API int scope_stack_pop(scope sp);
 
+/**
+*  @brief
+*    Destroy the scope and free all associated resources
+*
+*  @param[in] sp
+*    Pointer to the scope to destroy
+*/
 REFLECT_API void scope_destroy(scope sp);
 
 #ifdef __cplusplus

--- a/source/reflect/include/reflect/reflect_type.h
+++ b/source/reflect/include/reflect/reflect_type.h
@@ -51,19 +51,82 @@ typedef struct type_interface_type
 
 typedef type_interface (*type_impl_interface_singleton)(void);
 
+/**
+*  @brief
+*    Create a new type representation
+*
+*  @param[in] id
+*    Numeric type identifier (e.g. TYPE_INT, TYPE_STRING)
+*  @param[in] name
+*    Human-readable name of the type (e.g. "Integer", "String")
+*  @param[in] impl
+*    Pointer to the language-specific type implementation
+*  @param[in] singleton
+*    Singleton accessor for the type interface (create, destroy)
+*
+*  @return
+*    Pointer to the newly created type on success, NULL on failure
+*/
 REFLECT_API type type_create(type_id id, const char *name, type_impl impl, type_impl_interface_singleton singleton);
 
+/**
+*  @brief
+*    Get the numeric identifier of a type
+*
+*  @param[in] t
+*    Pointer to the type
+*
+*  @return
+*    Type identifier (e.g. TYPE_INT, TYPE_STRING)
+*/
 REFLECT_API type_id type_index(type t);
 
+/**
+*  @brief
+*    Get the human-readable name of a type
+*
+*  @param[in] t
+*    Pointer to the type
+*
+*  @return
+*    String containing the type name
+*/
 REFLECT_API const char *type_name(type t);
 
+/**
+*  @brief
+*    Get the language-specific derived implementation of a type
+*
+*  @param[in] t
+*    Pointer to the type
+*
+*  @return
+*    Opaque pointer to the derived type implementation
+*/
 REFLECT_API type_impl type_derived(type t);
 
-// TODO: Subtyping (for handling typed containers like arrays, maps or templates)
-// REFLECT_API vector type_subtype(type t);
+/* TODO: Subtyping (for handling typed containers like arrays, maps or templates) */
+/* REFLECT_API vector type_subtype(type t); */
 
+/**
+*  @brief
+*    Generate a metadata representation of the type
+*
+*  @param[in] t
+*    Pointer to the type
+*
+*  @return
+*    Value containing the metadata map, or NULL on failure
+*/
 REFLECT_API value type_metadata(type t);
 
+/**
+*  @brief
+*    Destroy a type and free all associated resources
+*
+*  @param[in] t
+*    Pointer to the type to destroy
+*/
 REFLECT_API void type_destroy(type t);
 
 #ifdef __cplusplus


### PR DESCRIPTION
# Description

Add comprehensive Doxygen documentation to the core reflect module headers: [reflect_scope.h](cci:7://file:///Users/abhiswantchaudhary/gsoc/core/source/reflect/include/reflect/reflect_scope.h:0:0-0:0), [reflect_function.h](cci:7://file:///Users/abhiswantchaudhary/gsoc/core/source/reflect/include/reflect/reflect_function.h:0:0-0:0), and [reflect_type.h](cci:7://file:///Users/abhiswantchaudhary/gsoc/core/source/reflect/include/reflect/reflect_type.h:0:0-0:0).

This PR provides detailed documentation for 32 public functions, covering:
- Parameter directions (`[in]`, `[out]`)
- Return value semantics (including success/failure and found/not found logic)
- Memory ownership and copy semantics (e.g., [scope_create](cci:1://file:///Users/abhiswantchaudhary/gsoc/core/source/reflect/source/reflect_scope.c:45:0-137:1))
- Null-safety considerations
- Build-time dependencies for debug statistics

Also converts C++ style `//` comments to C style `/* */` in `reflect_type.h` for consistency with the rest of the MetaCall C codebase.

## Type of change

- [x] Documentation update

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the tests implicated by my own code and they pass.
