### PR TITLE
fix(rb_loader): wrap rb_define_module and capitalize in rb_protect during load

### DIFF
--- a/source/loaders/rb_loader/source/rb_loader_impl.c
+++ b/source/loaders/rb_loader/source/rb_loader_impl.c
@@ -110,6 +110,11 @@ typedef struct loader_impl_rb_discover_module_protect_type
 	context ctx;
 } * loader_impl_rb_discover_module_protect;
 
+typedef struct loader_impl_rb_define_module_protect_type
+{
+	const char *name;
+} * loader_impl_rb_define_module_protect;
+
 static class_interface rb_class_interface_singleton(void);
 static object_interface rb_object_interface_singleton(void);
 static void rb_loader_impl_discover_methods(klass c, VALUE cls, const char *class_name_str, enum class_visibility_id visibility, const char *method_type_str, VALUE methods, int (*register_method)(klass, method));
@@ -327,6 +332,13 @@ static VALUE rb_loader_impl_funcallv_protect(VALUE args)
 	loader_impl_rb_funcall_protect protect = (loader_impl_rb_funcall_protect)args;
 
 	return rb_funcallv(protect->module_instance, protect->id, protect->argc, protect->argv);
+}
+
+static VALUE rb_loader_impl_define_module_protect(VALUE args)
+{
+	loader_impl_rb_define_module_protect protect = (loader_impl_rb_define_module_protect)args;
+
+	return rb_define_module(protect->name);
 }
 
 static VALUE rb_loader_impl_funcall2_protect(VALUE args)
@@ -1251,11 +1263,36 @@ loader_impl_rb_module rb_loader_impl_create_module(VALUE name_capitalized, VALUE
 
 loader_impl_rb_module rb_loader_impl_load_from_file_module(loader_impl impl, const loader_path path, const loader_name name)
 {
+	struct loader_impl_rb_funcall_protect_type capitalize_protect;
+	struct loader_impl_rb_define_module_protect_type define_protect;
+	int state;
+
 	VALUE name_value = rb_str_new_cstr(name);
 
-	VALUE name_capitalized = rb_funcallv(name_value, rb_intern("capitalize"), 0, NULL);
+	capitalize_protect.argc = 0;
+	capitalize_protect.argv = NULL;
+	capitalize_protect.module_instance = name_value;
+	capitalize_protect.id = rb_intern("capitalize");
 
-	VALUE module = rb_define_module(RSTRING_PTR(name_capitalized));
+	VALUE name_capitalized = rb_protect(rb_loader_impl_funcallv_protect, (VALUE)&capitalize_protect, &state);
+
+	if (state != 0)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Ruby failed to capitalize module name for '%s'", name);
+		rb_set_errinfo(Qnil);
+		return NULL;
+	}
+
+	define_protect.name = RSTRING_PTR(name_capitalized);
+
+	VALUE module = rb_protect(rb_loader_impl_define_module_protect, (VALUE)&define_protect, &state);
+
+	if (state != 0)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Ruby failed to define module '%s'", define_protect.name);
+		rb_set_errinfo(Qnil);
+		return NULL;
+	}
 
 	if (module != Qnil)
 	{


### PR DESCRIPTION
# Description

When `rb_loader_impl_load_from_file_module` runs, it calls `rb_funcallv` (for `String#capitalize`) and `rb_define_module` without `rb_protect` coverage. If either raises — `rb_define_module` raises `NameError` for invalid constant names, and both can raise in unexpected Ruby runtime states — the exception unwinds via `longjmp` through C stack frames that have no `setjmp` guard. On Windows with Python also loaded, this triggers Ruby's fatal signal handler (`rb_bug_for_fatal_signal`) and aborts the process.

Fixes #563

## Root Cause

The standard Ruby embedding contract requires that any Ruby API call capable of raising an exception must be wrapped in `rb_protect` when called from C code that does not have a Ruby-managed `setjmp` frame on the stack. `rb_loader_impl_module_eval` (further down the call chain) correctly uses `rb_protect`, but the two calls before it did not.

`rb_define_module` specifically can raise `NameError: wrong constant name` if the module name does not begin with an uppercase letter. The `capitalize` call should prevent this in normal usage, but `capitalize` itself runs unprotected and can raise if the Ruby runtime is in an unexpected state (which is more likely when multiple runtimes like Python are loaded simultaneously on Windows).

The stack trace in the issue — `rb_raise → rb_bug_for_fatal_signal → abort` — is consistent with an unprotected `rb_raise` being called from within a signal handler path, which only happens when `rb_raise` cannot find a valid setjmp frame to unwind to.

## Solution

Add `loader_impl_rb_define_module_protect_type` (holding `const char *name`) and a corresponding `rb_loader_impl_define_module_protect` callback, following the identical pattern used by `rb_loader_impl_module_eval_protect` and the funcallv wrappers throughout the file.

In `rb_loader_impl_load_from_file_module`:
- Wrap `rb_funcallv("capitalize")` using the existing `rb_loader_impl_funcallv_protect` callback (argc=0)
- Wrap `rb_define_module` using the new callback
- On `state != 0`, log the error, clear `rb_errinfo` with `rb_set_errinfo(Qnil)`, and return NULL so `rb_loader_impl_load_from_file` can continue to the next path in the list

## Changes Made

- `source/loaders/rb_loader/source/rb_loader_impl.c`
  - Added `loader_impl_rb_define_module_protect_type` typedef struct
  - Added `rb_loader_impl_define_module_protect` static callback
  - Replaced the two unprotected Ruby calls in `rb_loader_impl_load_from_file_module` with `rb_protect`-wrapped equivalents

## Testing

The `metacall_ruby_fail_test` covers the case where loading an invalid Ruby file returns an error rather than crashing. The crash from issue #563 is Windows-specific (Python + Ruby loaded together), but the defensive `rb_protect` wrapping is correct on all platforms and is consistent with how every other Ruby API call in this file is handled. The fix prevents abort in cases where the module name would cause `rb_define_module` to raise.

## Edge Cases

- If `capitalize` raises for any reason, the error is caught, logged, and the module returns NULL — the load fails cleanly without crashing
- If `rb_define_module` raises (e.g., name starting with lowercase after capitalize fails silently), the error is caught and logged. The `rb_set_errinfo(Qnil)` call ensures subsequent Ruby operations in the same session are not affected by the pending exception
- The rest of the load path (`rb_loader_impl_load_data`, `rb_loader_impl_module_eval`) was already protected by `rb_protect`; this change fills the gap at the beginning of the function

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

# Checklist

- [x] Self-review performed
- [x] Code commented in hard-to-understand areas
- [x] No new warnings
- [x] Tests: metacall_ruby_fail_test exercises the load-failure path; the specific Windows crash requires Python+Ruby environment to reproduce

> Assisted with CLAUDE.md