### PR TITLE
fix(cli): report error and exit when command line argument parsing fails

### DIFF
--- a/source/cli/metacallcli/source/application.cpp
+++ b/source/cli/metacallcli/source/application.cpp
@@ -36,6 +36,12 @@ using namespace metacallcli;
 
 static bool exit_condition = true;
 
+static void print_usage(const char *program)
+{
+	std::cerr << "Usage: " << program << " [options] [scripts...]" << std::endl;
+	std::cerr << "Try '" << program << " --help' for more information." << std::endl;
+}
+
 /* -- Methods -- */
 
 void application::repl()
@@ -298,7 +304,9 @@ application::application(int argc, char *argv[]) :
 		/* Launch the CMD (parse arguments) */
 		if (!cmd(arguments))
 		{
-			/* TODO: Report something? */
+			std::cerr << "Error: failed to parse command line arguments." << std::endl;
+			print_usage(argv[0]);
+			exit(1);
 		}
 	}
 }


### PR DESCRIPTION
# Description

Fixes the TODO comment at `source/cli/metacallcli/source/application.cpp`.

When `cmd()` returns false (e.g. unrecognized argument, plugin load failure), the application previously continued silently with no user-facing message and exited with code 0. This made it impossible for scripts and CI pipelines to detect that argument processing failed.

Changes:
- Added a `print_usage()` helper that prints the program usage to stderr
- Print a clear error message to stderr when `cmd()` fails
- Call `exit(1)` to signal failure to the calling process

This is consistent with how other initialization failures are already handled in the same constructor (`metacall_initialize` failure exits with code 1, `load_path` failure sets `exit_condition` and returns early).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_ADDRESS_SANITIZER` or `./docker-compose.sh test-address-sanitizer &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer &> output`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [x] I have run `make clang-format` in order to format my code and my code follows the style guidelines.