### PR TITLE
fix(node_loader): Windows IAT hook restoration and lifecycle safety

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,3 +17,4 @@ onkardahale <dahaleonkar@gmail.com>
 Akshit Garg <garg.akshit@gmail.com>
 burnerlee <avi.aviral140@gmail.com>
 Praveen Kumar <pkspyder007@gmail.com>
+Khaled Alam <khaled.alam5602@gmail.com>

--- a/source/loaders/node_loader/source/node_loader_impl.cpp
+++ b/source/loaders/node_loader/source/node_loader_impl.cpp
@@ -3596,6 +3596,12 @@ static BOOL node_loader_is_caller_node_extension(void *return_addr)
 {
 	HMODULE mod = NULL;
 
+	/* Guard: trampoline not yet initialized (early setup window before ExW hook is installed) */
+	if (get_module_handle_ex_w_ptr == NULL)
+	{
+		return FALSE;
+	}
+
 	if (get_module_handle_ex_w_ptr(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
 									   GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
 			(LPCWSTR)return_addr, &mod) == TRUE)
@@ -3868,6 +3874,31 @@ void *node_loader_impl_register(void *node_impl_ptr, void *env_ptr, void *functi
 
 		detour d = detour_create(metacall_detour());
 
+		/* Hook GetModuleHandleExW first: get_module_handle_ex_w_ptr must be non-NULL
+		   before GetModuleHandleA/W hooks fire, since node_loader_is_caller_node_extension()
+		   depends on it */
+		node_module_handle_ex_w_handle = detour_load_file(d, "kernel32.dll");
+
+		if (node_module_handle_ex_w_handle == NULL)
+		{
+			napi_throw_type_error(env, nullptr, "Invalid creation of the detour handle for hooking node extension load mechanism (GetModuleHandleExW)");
+		}
+		else
+		{
+			typedef BOOL(WINAPI * get_module_handle_ex_w_type)(_In_ DWORD, _In_opt_ LPCWSTR, _Outptr_result_maybenull_ HMODULE *);
+
+			union
+			{
+				get_module_handle_ex_w_type *trampoline;
+				void (**ptr)(void);
+			} cast_ex_w = { &get_module_handle_ex_w_ptr };
+
+			if (detour_replace(d, node_module_handle_ex_w_handle, "GetModuleHandleExW", (void (*)(void))(&get_module_handle_ex_w_hook), cast_ex_w.ptr) != 0)
+			{
+				napi_throw_type_error(env, nullptr, "Invalid replacement of GetModuleHandleExW for hooking node extension load mechanism");
+			}
+		}
+
 		node_module_handle_a_handle = detour_load_file(d, "kernel32.dll");
 
 		if (node_module_handle_a_handle == NULL)
@@ -3910,29 +3941,6 @@ void *node_loader_impl_register(void *node_impl_ptr, void *env_ptr, void *functi
 			if (detour_replace(d, node_module_handle_w_handle, "GetModuleHandleW", (void (*)(void))(&get_module_handle_w_hook), cast_w.ptr) != 0)
 			{
 				napi_throw_type_error(env, nullptr, "Invalid replacement of GetModuleHandleW for hooking node extension load mechanism");
-			}
-		}
-
-		/* Hook GetModuleHandleExW for libloading::os::windows::Library::this() used by napi-rs */
-		node_module_handle_ex_w_handle = detour_load_file(d, "kernel32.dll");
-
-		if (node_module_handle_ex_w_handle == NULL)
-		{
-			napi_throw_type_error(env, nullptr, "Invalid creation of the detour handle for hooking node extension load mechanism (GetModuleHandleExW)");
-		}
-		else
-		{
-			typedef BOOL(WINAPI * get_module_handle_ex_w_type)(_In_ DWORD, _In_opt_ LPCWSTR, _Outptr_result_maybenull_ HMODULE *);
-
-			union
-			{
-				get_module_handle_ex_w_type *trampoline;
-				void (**ptr)(void);
-			} cast_ex_w = { &get_module_handle_ex_w_ptr };
-
-			if (detour_replace(d, node_module_handle_ex_w_handle, "GetModuleHandleExW", (void (*)(void))(&get_module_handle_ex_w_hook), cast_ex_w.ptr) != 0)
-			{
-				napi_throw_type_error(env, nullptr, "Invalid replacement of GetModuleHandleExW for hooking node extension load mechanism");
 			}
 		}
 
@@ -4922,28 +4930,87 @@ int node_loader_impl_destroy(loader_impl impl)
 	{
 		detour d = detour_create(metacall_detour());
 
-		if (node_module_handle_ex_a_handle != NULL)
-		{
-			detour_unload(d, node_module_handle_ex_a_handle);
-			node_module_handle_ex_a_handle = NULL;
-		}
+		/* Restore IAT entries and unload in reverse-dependency order:
+		   A and W depend on get_module_handle_ex_w_ptr, so ExW must be last.
+		   Restoring each IAT entry before unloading prevents stale function
+		   pointers into the unloaded node_loader.dll from causing a SEGFAULT
+		   during process cleanup (e.g. CRT calling GetModuleHandleW in __scrt_is_managed_app). */
 
-		if (node_module_handle_ex_w_handle != NULL)
+		if (node_module_handle_a_handle != NULL)
 		{
-			detour_unload(d, node_module_handle_ex_w_handle);
-			node_module_handle_ex_w_handle = NULL;
+			if (get_module_handle_a_ptr != NULL)
+			{
+				typedef HMODULE (*get_module_handle_a_type)(_In_opt_ LPCSTR);
+
+				union
+				{
+					get_module_handle_a_type fn;
+					void (*vfn)(void);
+				} restore_a = { get_module_handle_a_ptr };
+
+				void (*prev_a)(void) = NULL;
+				detour_replace(d, node_module_handle_a_handle, "GetModuleHandleA", restore_a.vfn, &prev_a);
+			}
+			detour_unload(d, node_module_handle_a_handle);
+			node_module_handle_a_handle = NULL;
 		}
 
 		if (node_module_handle_w_handle != NULL)
 		{
+			if (get_module_handle_w_ptr != NULL)
+			{
+				typedef HMODULE (*get_module_handle_w_type)(_In_opt_ LPCWSTR);
+
+				union
+				{
+					get_module_handle_w_type fn;
+					void (*vfn)(void);
+				} restore_w = { get_module_handle_w_ptr };
+
+				void (*prev_w)(void) = NULL;
+				detour_replace(d, node_module_handle_w_handle, "GetModuleHandleW", restore_w.vfn, &prev_w);
+			}
 			detour_unload(d, node_module_handle_w_handle);
 			node_module_handle_w_handle = NULL;
 		}
 
-		if (node_module_handle_a_handle != NULL)
+		if (node_module_handle_ex_a_handle != NULL)
 		{
-			detour_unload(d, node_module_handle_a_handle);
-			node_module_handle_a_handle = NULL;
+			if (get_module_handle_ex_a_ptr != NULL)
+			{
+				typedef BOOL(WINAPI * get_module_handle_ex_a_type)(_In_ DWORD, _In_opt_ LPCSTR, _Outptr_result_maybenull_ HMODULE *);
+
+				union
+				{
+					get_module_handle_ex_a_type fn;
+					void (*vfn)(void);
+				} restore_ex_a = { get_module_handle_ex_a_ptr };
+
+				void (*prev_ex_a)(void) = NULL;
+				detour_replace(d, node_module_handle_ex_a_handle, "GetModuleHandleExA", restore_ex_a.vfn, &prev_ex_a);
+			}
+			detour_unload(d, node_module_handle_ex_a_handle);
+			node_module_handle_ex_a_handle = NULL;
+		}
+
+		/* ExW unloaded last: keeps get_module_handle_ex_w_ptr valid while A/W/ExA hooks were torn down */
+		if (node_module_handle_ex_w_handle != NULL)
+		{
+			if (get_module_handle_ex_w_ptr != NULL)
+			{
+				typedef BOOL(WINAPI * get_module_handle_ex_w_type)(_In_ DWORD, _In_opt_ LPCWSTR, _Outptr_result_maybenull_ HMODULE *);
+
+				union
+				{
+					get_module_handle_ex_w_type fn;
+					void (*vfn)(void);
+				} restore_ex_w = { get_module_handle_ex_w_ptr };
+
+				void (*prev_ex_w)(void) = NULL;
+				detour_replace(d, node_module_handle_ex_w_handle, "GetModuleHandleExW", restore_ex_w.vfn, &prev_ex_w);
+			}
+			detour_unload(d, node_module_handle_ex_w_handle);
+			node_module_handle_ex_w_handle = NULL;
 		}
 	}
 #endif


### PR DESCRIPTION

This PR fixes a critical SEGFAULT on Windows that occurs during process teardown (specifically during CRT cleanup) after `node_loader.dll` has been unloaded. 

The root cause was that `detour_unload` (which uses `plthook`) does not automatically restore patched IAT entries. When the loader was destroyed and the DLL unmapped, the process IAT still contained pointers to the now-unmapped hook functions. Subsequent calls to `GetModuleHandleW` by the CRT triggered a jump to invalid memory.

Additionally, this PR addresses latent lifecycle bugs identified in the hook initialization sequence:
1. **NULL Guard:** Added to `node_loader_is_caller_node_extension` to prevent crashes if A/W hooks fire before the ExW trampoline is ready.
2. **Setup Reordering:** `GetModuleHandleExW` is now installed first so its trampoline is available for the other hooks.
3. **Teardown Reordering:** Hooks are removed in reverse-dependency order (A/W first, ExW last).

Fixes #695 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [x] I have tested the tests implicated (if any) by my own code and they pass (`metacall-node-call-bench`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_ADDRESS_SANITIZER` or `./docker-compose.sh test-address-sanitizer &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer &> output`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [x] I have run `make clang-format` in order to format my code and my code follows the style guidelines.