### PR TITLE
docs: fix spelling errors in public API headers and documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 When contributing to this repository, please first discuss the change you wish to make via issue,
-email, or any other method with the owners of this repository before making a change. Here is an examplary process you can follow to create an issue on MetaCall:
+email, or any other method with the owners of this repository before making a change. Here is an exemplary process you can follow to create an issue on MetaCall:
 
 1. Identify a problem or a possible addition to Metacall codebase/operation<br>
 for instance: ```pre-commit-clang-format not working on windows...```

--- a/TODO.md
+++ b/TODO.md
@@ -24,7 +24,7 @@ TODO List
 
   * Loader C/C++:
     - [Clang](http://clang.llvm.org/docs/ExternalClangExamples.html) as a parser for reflect generation for .h and .hpp files.
-    - [Libffi](http://www.chiark.greenend.org.uk/doc/libffi-dev/html/Using-libffi.html) as a foreing function interface caller.
+    - [Libffi](http://www.chiark.greenend.org.uk/doc/libffi-dev/html/Using-libffi.html) as a foreign function interface caller.
     - [LLVM](http://llvm.org/docs/) as a JIT compiler for .c and .cpp files.
     - [Dynlink](source/dynlink) library as a cross-platform library loader.
     - Alternatively use [EmbedCh](https://www.softintegration.com/products/sdk/embedch/).

--- a/source/metacall/include/metacall/metacall.h
+++ b/source/metacall/include/metacall/metacall.h
@@ -60,7 +60,7 @@ struct metacall_initialize_configuration_type;
 struct metacall_initialize_configuration_type
 {
 	const char *tag; /* Tag referring to the loader */
-	void *options;	 /* Value of type Map that will be merged merged into the configuration of the loader */
+	void *options;	 /* Value of type Map that will be merged into the configuration of the loader */
 };
 
 typedef void *(*metacall_await_callback)(void *, void *);
@@ -193,7 +193,7 @@ METACALL_API int metacall_is_initialized(const char *tag);
 *    Amount of function call arguments supported by MetaCall
 *
 *  @return
-*    Number of arguments suported
+*    Number of arguments supported
 */
 METACALL_API size_t metacall_args_size(void);
 
@@ -289,7 +289,7 @@ METACALL_API int metacall_load_from_memory(const char *tag, const char *buffer, 
 
 /**
 *  @brief
-*    Loads a package of scrips from file specified by @path into loader defined by @extension
+*    Loads a package of scripts from file specified by @path into loader defined by @extension
 *
 *  @param[in] tag
 *    Extension of the script
@@ -313,7 +313,7 @@ METACALL_API int metacall_load_from_package(const char *tag, const char *path, v
 
 /**
 *  @brief
-*    Loads a a list of scrips from configuration specified by @path into loader
+*    Loads a a list of scripts from configuration specified by @path into loader
 *    with the following format:
 *        {
 *            "language_id": "<tag>",
@@ -424,7 +424,7 @@ METACALL_API void *metacallhv_s(void *handle, const char *name, void *args[], si
 *    Name of the function
 *
 *  @param[in] va_args
-*    Varidic function parameters
+*    Variadic function parameters
 *
 *  @return
 *    Pointer to value containing the result of the call
@@ -439,10 +439,10 @@ METACALL_API void *metacall(const char *name, ...);
 *    Name of the function
 *
 *  @param[in] ids
-*    Array of types refered to @va_args
+*    Array of types referred to @va_args
 *
 *  @param[in] va_args
-*    Varidic function parameters
+*    Variadic function parameters
 *
 *  @return
 *    Pointer to value containing the result of the call
@@ -457,13 +457,13 @@ METACALL_API void *metacallt(const char *name, const enum metacall_value_id ids[
 *    Name of the function
 *
 *  @param[in] ids
-*    Array of types refered to @va_args
+*    Array of types referred to @va_args
 *
 *  @param[in] size
 *    Number of elements of the call
 *
 *  @param[in] va_args
-*    Varidic function parameters
+*    Variadic function parameters
 *
 *  @return
 *    Pointer to value containing the result of the call
@@ -481,13 +481,13 @@ METACALL_API void *metacallt_s(const char *name, const enum metacall_value_id id
 *    Name of the function
 *
 *  @param[in] ids
-*    Array of types refered to @va_args
+*    Array of types referred to @va_args
 *
 *  @param[in] size
 *    Number of elements of the call
 *
 *  @param[in] va_args
-*    Varidic function parameters
+*    Variadic function parameters
 *
 *  @return
 *    Pointer to value containing the result of the call
@@ -568,7 +568,7 @@ METACALL_API void *metacall_handle_function(void *handle, const char *name);
 *    The parameter type id that will be returned
 *
 *  @return
-*    Return 0 if the @parameter index exists and @func is valid, 1 otherwhise
+*    Return 0 if the @parameter index exists and @func is valid, 1 otherwise
 */
 METACALL_API int metacall_function_parameter_type(void *func, size_t parameter, enum metacall_value_id *id);
 
@@ -584,19 +584,19 @@ METACALL_API int metacall_function_parameter_type(void *func, size_t parameter, 
 *    The value id of the return type of the function @func
 *
 *  @return
-*    Return 0 if the @func is valid, 1 otherwhise
+*    Return 0 if the @func is valid, 1 otherwise
 */
 METACALL_API int metacall_function_return_type(void *func, enum metacall_value_id *id);
 
 /**
 *  @brief
-*    Get minimun mumber of arguments accepted by function @func
+*    Get minimum number of arguments accepted by function @func
 *
 *  @param[in] func
 *    Function reference
 *
 *  @return
-*    Return mumber of arguments
+*    Return number of arguments
 */
 METACALL_API size_t metacall_function_size(void *func);
 
@@ -608,7 +608,7 @@ METACALL_API size_t metacall_function_size(void *func);
 *    Function reference
 *
 *  @return
-*    Return 0 if it is syncrhonous, 1 if it is asynchronous and -1 if the function is NULL
+*    Return 0 if it is synchronous, 1 if it is asynchronous and -1 if the function is NULL
 */
 METACALL_API int metacall_function_async(void *func);
 

--- a/source/metacall/include/metacall/metacall_value.h
+++ b/source/metacall/include/metacall/metacall_value.h
@@ -77,7 +77,7 @@ enum metacall_value_id
 *    Boolean will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_bool(boolean b);
 
@@ -89,7 +89,7 @@ METACALL_API void *metacall_value_create_bool(boolean b);
 *    Character will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_char(char c);
 
@@ -101,7 +101,7 @@ METACALL_API void *metacall_value_create_char(char c);
 *    Short will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_short(short s);
 
@@ -113,7 +113,7 @@ METACALL_API void *metacall_value_create_short(short s);
 *    Integer will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_int(int i);
 
@@ -125,7 +125,7 @@ METACALL_API void *metacall_value_create_int(int i);
 *    Long integer will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_long(long l);
 
@@ -137,7 +137,7 @@ METACALL_API void *metacall_value_create_long(long l);
 *    Float will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_float(float f);
 
@@ -149,7 +149,7 @@ METACALL_API void *metacall_value_create_float(float f);
 *    Double will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_double(double d);
 
@@ -164,7 +164,7 @@ METACALL_API void *metacall_value_create_double(double d);
 *    Length of the constant string
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_string(const char *str, size_t length);
 
@@ -179,7 +179,7 @@ METACALL_API void *metacall_value_create_string(const char *str, size_t length);
 *    Size in bytes of data contained in the array
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_buffer(const void *buffer, size_t size);
 
@@ -194,7 +194,7 @@ METACALL_API void *metacall_value_create_buffer(const void *buffer, size_t size)
 *    Number of elements contained in the array
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_array(const void *values[], size_t size);
 
@@ -209,7 +209,7 @@ METACALL_API void *metacall_value_create_array(const void *values[], size_t size
 *    Number of elements contained in the map
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_map(const void *tuples[], size_t size);
 
@@ -221,7 +221,7 @@ METACALL_API void *metacall_value_create_map(const void *tuples[], size_t size);
 *    Pointer to constant data will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_ptr(const void *ptr);
 
@@ -233,7 +233,7 @@ METACALL_API void *metacall_value_create_ptr(const void *ptr);
 *    Pointer to constant data will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_future(void *f);
 
@@ -245,7 +245,7 @@ METACALL_API void *metacall_value_create_future(void *f);
 *    Pointer to constant data will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_function(void *f);
 
@@ -260,7 +260,7 @@ METACALL_API void *metacall_value_create_function(void *f);
 *    Pointer to closure that will be binded into function @f
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_function_closure(void *f, void *c);
 
@@ -269,7 +269,7 @@ METACALL_API void *metacall_value_create_function_closure(void *f, void *c);
 *    Create a value of type null
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_null(void);
 
@@ -281,7 +281,7 @@ METACALL_API void *metacall_value_create_null(void);
 *    Pointer to constant data will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_class(void *c);
 
@@ -293,7 +293,7 @@ METACALL_API void *metacall_value_create_class(void *c);
 *    Pointer to constant data will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_object(void *o);
 
@@ -305,7 +305,7 @@ METACALL_API void *metacall_value_create_object(void *o);
 *    Pointer to constant data will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_exception(void *ex);
 
@@ -317,7 +317,7 @@ METACALL_API void *metacall_value_create_exception(void *ex);
 *    Pointer to constant data will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 METACALL_API void *metacall_value_create_throwable(void *th);
 

--- a/source/reflect/include/reflect/reflect_type_id.h
+++ b/source/reflect/include/reflect/reflect_type_id.h
@@ -75,7 +75,7 @@ REFLECT_API const char *type_id_name(type_id id);
 *    Type id to be checked
 *
 *  @return
-*    Returns zero if type is integer, different from zero otherwhise
+*    Returns zero if type is integer, different from zero otherwise
 */
 REFLECT_API int type_id_boolean(type_id id);
 
@@ -99,7 +99,7 @@ REFLECT_API int type_id_char(type_id id);
 *    Type id to be checked
 *
 *  @return
-*    Returns zero if type is integer, different from zero otherwhise
+*    Returns zero if type is integer, different from zero otherwise
 */
 REFLECT_API int type_id_integer(type_id id);
 

--- a/source/reflect/include/reflect/reflect_value.h
+++ b/source/reflect/include/reflect/reflect_value.h
@@ -55,7 +55,7 @@ typedef void (*value_finalizer_cb)(value, void *);
 *    Size in bytes to be allocated
 *
 *  @return
-*    Pointer to uninitialized value if success, null otherwhise
+*    Pointer to uninitialized value if success, null otherwise
 */
 REFLECT_API value value_alloc(size_t bytes);
 
@@ -82,7 +82,7 @@ REFLECT_API value value_create(const void *data, size_t bytes);
 *    Reference of value to be checked
 *
 *  @return
-*    Zero if the value is valid, null otherwhise
+*    Zero if the value is valid, null otherwise
 */
 REFLECT_API int value_validate(value v);
 

--- a/source/reflect/include/reflect/reflect_value_type.h
+++ b/source/reflect/include/reflect/reflect_value_type.h
@@ -55,7 +55,7 @@ extern "C" {
 *    Type of memory block @data
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_type_create(const void *data, size_t bytes, type_id id);
 
@@ -157,7 +157,7 @@ REFLECT_API type_id value_type_id(value v);
 *    Boolean will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_bool(boolean b);
 
@@ -169,7 +169,7 @@ REFLECT_API value value_create_bool(boolean b);
 *    Character will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_char(char c);
 
@@ -181,7 +181,7 @@ REFLECT_API value value_create_char(char c);
 *    Short will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_short(short s);
 
@@ -193,7 +193,7 @@ REFLECT_API value value_create_short(short s);
 *    Integer will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_int(int i);
 
@@ -205,7 +205,7 @@ REFLECT_API value value_create_int(int i);
 *    Long integer will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_long(long l);
 
@@ -217,7 +217,7 @@ REFLECT_API value value_create_long(long l);
 *    Float will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_float(float f);
 
@@ -229,7 +229,7 @@ REFLECT_API value value_create_float(float f);
 *    Double will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_double(double d);
 
@@ -244,7 +244,7 @@ REFLECT_API value value_create_double(double d);
 *    Length of the constant string
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_string(const char *str, size_t length);
 
@@ -259,7 +259,7 @@ REFLECT_API value value_create_string(const char *str, size_t length);
 *    Size in bytes of data contained in the array
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_buffer(const void *buffer, size_t size);
 
@@ -274,7 +274,7 @@ REFLECT_API value value_create_buffer(const void *buffer, size_t size);
 *    Number of elements contained in the array
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_array(const value *values, size_t size);
 
@@ -289,7 +289,7 @@ REFLECT_API value value_create_array(const value *values, size_t size);
 *    Number of elements contained in the map
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_map(const value *tuples, size_t size);
 
@@ -301,7 +301,7 @@ REFLECT_API value value_create_map(const value *tuples, size_t size);
 *    Pointer to constant data will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_ptr(const void *ptr);
 
@@ -313,7 +313,7 @@ REFLECT_API value value_create_ptr(const void *ptr);
 *    Pointer to future will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_future(future f);
 
@@ -325,7 +325,7 @@ REFLECT_API value value_create_future(future f);
 *    Pointer to function will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_function(function f);
 
@@ -340,7 +340,7 @@ REFLECT_API value value_create_function(function f);
 *    Pointer to closure that will be binded into function @f
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_function_closure(function f, void *c);
 
@@ -349,7 +349,7 @@ REFLECT_API value value_create_function_closure(function f, void *c);
 *    Create a value of type null
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_null(void);
 
@@ -361,7 +361,7 @@ REFLECT_API value value_create_null(void);
 *    Pointer to class will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_class(klass c);
 
@@ -373,7 +373,7 @@ REFLECT_API value value_create_class(klass c);
 *    Pointer to object will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_object(object o);
 
@@ -385,7 +385,7 @@ REFLECT_API value value_create_object(object o);
 *    Pointer to exception will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_exception(exception ex);
 
@@ -397,7 +397,7 @@ REFLECT_API value value_create_exception(exception ex);
 *    Pointer to throwable will be copied into value
 *
 *  @return
-*    Pointer to value if success, null otherwhise
+*    Pointer to value if success, null otherwise
 */
 REFLECT_API value value_create_throwable(throwable th);
 

--- a/source/serials/metacall_serial/source/metacall_serial_impl.c
+++ b/source/serials/metacall_serial/source/metacall_serial_impl.c
@@ -120,7 +120,7 @@ value metacall_serial_impl_deserialize_value(const char *buffer, size_t size)
 		}
 	}
 
-	log_write("metacall", LOG_LEVEL_ERROR, "Deserialization unsuported value type in MetaCall Native Format implementation");
+	log_write("metacall", LOG_LEVEL_ERROR, "Deserialization unsupported value type in MetaCall Native Format implementation");
 
 	return NULL;
 }

--- a/source/serials/rapid_json_serial/source/rapid_json_serial_impl.cpp
+++ b/source/serials/rapid_json_serial/source/rapid_json_serial_impl.cpp
@@ -534,7 +534,7 @@ value rapid_json_serial_impl_deserialize_value(const rapidjson::Value *v)
 		return v_map;
 	}
 
-	log_write("metacall", LOG_LEVEL_ERROR, "Unsuported value type in RapidJSON implementation");
+	log_write("metacall", LOG_LEVEL_ERROR, "Unsupported value type in RapidJSON implementation");
 
 	return NULL;
 }

--- a/source/tests/log_custom_test/source/log_custom_test.cpp
+++ b/source/tests/log_custom_test/source/log_custom_test.cpp
@@ -134,7 +134,7 @@ TEST_F(log_custom_test, DefaultConstructor)
 	/* Write simple logs */
 	EXPECT_EQ((int)0, (int)log_write(name, LOG_LEVEL_INFO, "hello world"));
 
-	/* Write varidic log */
+	/* Write variadic log */
 	EXPECT_EQ((int)0, (int)log_write(name, LOG_LEVEL_INFO, "hello world from log %d", 20));
 
 	/* Clear log */

--- a/source/tests/log_test/source/log_test.cpp
+++ b/source/tests/log_test/source/log_test.cpp
@@ -177,7 +177,7 @@ TEST_F(log_test, DefaultConstructor)
 		}
 	}
 
-	/* Write varidic logs */
+	/* Write variadic logs */
 	{
 		size_t iterator;
 

--- a/source/tests/metacall_c_test/CMakeLists.txt
+++ b/source/tests/metacall_c_test/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 find_package(LibFFI)
 
 if(NOT LIBFFI_FOUND)
-	message(SEND_ERROR "Foreing Function Interface library not found")
+	message(SEND_ERROR "Foreign Function Interface library not found")
 	return()
 endif()
 


### PR DESCRIPTION
## Summary

This PR fixes a bunch of spelling mistakes across public API headers and docs.  
No functional changes- just cleaning things up to make the codebase easier to read and more consistent.

---

## What’s Fixed

### Public API Headers

- **`metacall.h`**  
  Cleaned up several typos like `suported`, `scrips`, `Varidic`, etc.

- **`reflect_value_type.h`**, **`metacall_value.h`**, **`reflect_type_id.h`**, **`reflect_value.h`**  
  Fixed repeated misspelling of `otherwhise` → `otherwise`

---

### Documentation

- **`TODO.md`** → fixed `foreing` → `foreign`  
- **`CONTRIBUTING.md`** → fixed `examplary` → `exemplary`

---

### Other Small Fixes

- Corrected a few leftover typos in tests and implementation files  
  (like `unsupported`, `variadic`, etc.)

---

## Impact

- ~80+ typos fixed across 12 files  
- Improves readability in headers and docs  
- Makes things feel a bit more polished overall

---

## Testing

Only spelling changes-no code logic touched.  
Project builds and runs as expected.

---

## Type of Change

- [ ] Bug fix  
- [ ] New feature  
- [x] Documentation update  
- [ ] Breaking change  