### PR TITLE
Fix FFI undefined behavior and panics in rs_loader entry points

### DIFF
--- a/source/loaders/rs_loader/rust/src/lifecycle/clear.rs
+++ b/source/loaders/rs_loader/rust/src/lifecycle/clear.rs
@@ -1,27 +1,37 @@
 use super::loader::LoadingMethod;
 use std::os::raw::{c_int, c_void};
-
 use compiler::api;
 
+///# Safety
 #[no_mangle]
-pub extern "C" fn rs_loader_impl_clear(loader_impl: *mut c_void, handle: *mut c_void) -> c_int {
-    let loader_lifecycle_state = unsafe {
-        api::get_loader_lifecycle_state(loader_impl)
-            .as_mut()
-            .expect("Unable to get loader state")
-    };
-    let methods = unsafe { Box::from_raw(handle as *mut Vec<LoadingMethod>) };
-    for loading_method in *methods {
-        match loading_method.consume_dlib() {
-            Ok(lib) => {
-                // Extend the lifetime of library
-                loader_lifecycle_state.destroy_list.push(lib);
-            }
-            Err(err) => {
-                eprintln!("{}", err);
-                return 1_i32;
+pub unsafe extern "C" fn rs_loader_impl_clear(loader_impl: *mut c_void, handle: *mut c_void) -> c_int {
+    let result = std::panic::catch_unwind(|| {
+
+		if loader_impl.is_null() || handle.is_null() {
+            return 1_i32;
+        }
+		
+        let loader_lifecycle_state = match api::get_loader_lifecycle_state(loader_impl).as_mut() {
+            Some(state) => state,
+            None => return 1_i32,
+        };
+
+        let methods = Box::from_raw(handle as *mut Vec<LoadingMethod>);
+
+        for loading_method in *methods {
+            match loading_method.consume_dlib() {
+                Ok(lib) => {
+                    loader_lifecycle_state.destroy_list.push(lib);
+                }
+                Err(err) => {
+                    eprintln!("Error consuming dlib: {}", err);
+                    return 1_i32;
+                }
             }
         }
-    }
-    0_i32
+        
+        0_i32
+    });
+
+	result.unwrap_or(1_i32)
 }

--- a/source/loaders/rs_loader/rust/src/lifecycle/discover.rs
+++ b/source/loaders/rs_loader/rust/src/lifecycle/discover.rs
@@ -3,39 +3,48 @@ use std::fmt::Display;
 use std::os::raw::{c_int, c_void};
 
 pub fn discover_on_error<T: Display>(error: T) -> c_int {
-    eprintln!("{}", error);
+    eprintln!("Discovery error: {}", error);
     1_i32
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn rs_loader_impl_discover(
+pub unsafe extern "C" fn rs_loader_impl_discover(
     loader_impl: *mut c_void,
     handle: *mut c_void,
     ctx: *mut c_void,
 ) -> c_int {
-    let handle_shared_objects = unsafe { Box::from_raw(handle as *mut Vec<LoadingMethod>) };
+    let result = std::panic::catch_unwind(|| {
+    
+        if loader_impl.is_null() || handle.is_null() || ctx.is_null() {
+            return 1_i32;
+        }
 
-    for handle_shared_object in handle_shared_objects.iter() {
-        match handle_shared_object {
-            LoadingMethod::File(file_registration) => {
-                if let Err(error) = file_registration.discover(loader_impl, ctx) {
-                    return discover_on_error(error);
+
+        let handle_shared_objects = &*(handle as *const Vec<LoadingMethod>);
+
+        for handle_shared_object in handle_shared_objects.iter() {
+            match handle_shared_object {
+                LoadingMethod::File(file_registration) => {
+                    if let Err(error) = file_registration.discover(loader_impl, ctx) {
+                        return discover_on_error(error);
+                    }
                 }
-            }
-            LoadingMethod::Memory(memory_registration) => {
-                if let Err(error) = memory_registration.discover(loader_impl, ctx) {
-                    return discover_on_error(error);
+                LoadingMethod::Memory(memory_registration) => {
+                    if let Err(error) = memory_registration.discover(loader_impl, ctx) {
+                        return discover_on_error(error);
+                    }
                 }
-            }
-            LoadingMethod::Package(package_registration) => {
-                if let Err(error) = package_registration.discover(loader_impl, ctx) {
-                    return discover_on_error(error);
+                LoadingMethod::Package(package_registration) => {
+                    if let Err(error) = package_registration.discover(loader_impl, ctx) {
+                        return discover_on_error(error);
+                    }
                 }
             }
         }
-    }
 
-    // Avoid dropping handle_shared_objects
-    std::mem::forget(handle_shared_objects);
-    0_i32
+        0_i32 
+    });
+
+    result.unwrap_or(1_i32)
 }

--- a/source/loaders/rs_loader/rust/src/lifecycle/execution_path.rs
+++ b/source/loaders/rs_loader/rust/src/lifecycle/execution_path.rs
@@ -9,16 +9,27 @@ pub unsafe extern "C" fn rs_loader_impl_execution_path(
     loader_impl: *mut c_void,
     path: *const c_char,
 ) -> c_int {
-    let loader_lifecycle_state = api::get_loader_lifecycle_state(loader_impl)
-        .as_mut()
-        .expect("Unable to get lifecycle state.");
+    let result = std::panic::catch_unwind(|| {
+        if loader_impl.is_null() || path.is_null() {
+            return 1_i32; 
+        }
 
-    let c_path: &CStr = CStr::from_ptr(path);
+        let loader_lifecycle_state = match api::get_loader_lifecycle_state(loader_impl).as_mut() {
+            Some(state) => state,
+            None => return 1_i32,
+        };
 
-    let path_slice: &str = c_path.to_str().expect("Unable to cast CStr to str");
-    loader_lifecycle_state
-        .execution_paths
-        .push(PathBuf::from(path_slice));
+        let path_slice = match CStr::from_ptr(path).to_str() {
+            Ok(s) => s,
+            Err(_) => return 1_i32,
+        };
 
-    0_i32
+        loader_lifecycle_state
+            .execution_paths
+            .push(PathBuf::from(path_slice));
+
+        0_i32 
+    });
+
+    result.unwrap_or(1_i32)
 }

--- a/source/loaders/rs_loader/rust/src/lifecycle/load_from_file.rs
+++ b/source/loaders/rs_loader/rust/src/lifecycle/load_from_file.rs
@@ -1,6 +1,7 @@
 use super::loader::{self, LoadingMethod};
 use std::os::raw::{c_char, c_void};
 use std::path::PathBuf;
+use std::panic::catch_unwind;
 
 use compiler::{file::FileRegistration, RegistrationError};
 
@@ -10,25 +11,33 @@ pub extern "C" fn rs_loader_impl_load_from_file(
     paths: *mut *const c_char,
     size: usize,
 ) -> *mut c_void {
-    loader::load(
-        loader_impl,
-        paths,
-        size,
-        true,
-        |path_buf: PathBuf,
-         load_on_error: loader::LoadOnErrorPointer|
-         -> Result<LoadingMethod, *mut c_void> {
-            Ok(LoadingMethod::File(match FileRegistration::new(path_buf) {
-                Ok(instance) => instance,
-                Err(error) => match error {
-                    RegistrationError::CompilationError(analysis_error) => {
-                        return Err(load_on_error(analysis_error))
-                    }
-                    RegistrationError::DynlinkError(dynlink_error) => {
-                        return Err(load_on_error(dynlink_error))
-                    }
-                },
-            }))
-        },
-    )
+    let result = catch_unwind(|| {
+        if paths.is_null() {
+            return std::ptr::null_mut();
+        }
+
+        loader::load(
+            loader_impl,
+            paths,
+            size,
+            true,
+            |path_buf: PathBuf,
+             load_on_error: loader::LoadOnErrorPointer|
+             -> Result<LoadingMethod, *mut c_void> {
+                Ok(LoadingMethod::File(match FileRegistration::new(path_buf) {
+                    Ok(instance) => instance,
+                    Err(error) => match error {
+                        RegistrationError::CompilationError(analysis_error) => {
+                            return Err(load_on_error(analysis_error))
+                        }
+                        RegistrationError::DynlinkError(dynlink_error) => {
+                            return Err(load_on_error(dynlink_error))
+                        }
+                    },
+                }))
+            },
+        )
+    });
+
+    result.unwrap_or(std::ptr::null_mut())
 }

--- a/source/loaders/rs_loader/rust/src/lifecycle/load_from_memory.rs
+++ b/source/loaders/rs_loader/rust/src/lifecycle/load_from_memory.rs
@@ -2,6 +2,7 @@ use super::loader::{self, LoadingMethod};
 use compiler::{memory::MemoryRegistration, RegistrationError};
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
+use std::panic::catch_unwind;
 
 /// # Safety
 #[no_mangle]
@@ -11,24 +12,33 @@ pub unsafe extern "C" fn rs_loader_impl_load_from_memory(
     buffer: *const c_char,
     _size: usize,
 ) -> *mut c_void {
-    let name = CStr::from_ptr(name)
-        .to_str()
-        .expect("Unable to cast CStr to str")
-        .to_owned();
-    let code = CStr::from_ptr(buffer)
-        .to_str()
-        .expect("Unable to cast CStr to str")
-        .to_owned();
-    let instance = LoadingMethod::Memory(match MemoryRegistration::new(name, code) {
-        Ok(instance) => instance,
-        Err(error) => match error {
-            RegistrationError::CompilationError(analysis_error) => {
-                return loader::load_on_error(analysis_error);
+    let result = catch_unwind(|| {
+        if name.is_null() || buffer.is_null() {
+            return std::ptr::null_mut();
+        }
+
+        let name_str = match CStr::from_ptr(name).to_str() {
+            Ok(s) => s.to_owned(),
+            Err(_) => return std::ptr::null_mut(),
+        };
+
+        let code_str = match CStr::from_ptr(buffer).to_str() {
+            Ok(s) => s.to_owned(),
+            Err(_) => return std::ptr::null_mut(),
+        };
+
+        let instance = match MemoryRegistration::new(name_str, code_str) {
+            Ok(inst) => LoadingMethod::Memory(inst),
+            Err(error) => {
+                return match error {
+                    RegistrationError::CompilationError(e) => loader::load_on_error(e),
+                    RegistrationError::DynlinkError(e) => loader::load_on_error(e),
+                };
             }
-            RegistrationError::DynlinkError(dynlink_error) => {
-                return loader::load_on_error(dynlink_error);
-            }
-        },
+        };
+
+        Box::into_raw(Box::new(vec![instance])) as *mut c_void
     });
-    Box::into_raw(Box::new(vec![instance])) as *mut c_void
+
+    result.unwrap_or(std::ptr::null_mut())
 }

--- a/source/loaders/rs_loader/rust/src/lifecycle/load_from_package.rs
+++ b/source/loaders/rs_loader/rust/src/lifecycle/load_from_package.rs
@@ -2,6 +2,7 @@ use super::loader::{self, LoadingMethod};
 use compiler::{package::PackageRegistration, RegistrationError};
 use std::os::raw::{c_char, c_void};
 use std::path::PathBuf;
+
 #[no_mangle]
 pub extern "C" fn rs_loader_impl_load_from_package(
     loader_impl: *mut c_void,
@@ -12,22 +13,13 @@ pub extern "C" fn rs_loader_impl_load_from_package(
         path,
         1,
         false,
-        |path_buf: PathBuf,
-         load_on_error: loader::LoadOnErrorPointer|
-         -> Result<LoadingMethod, *mut c_void> {
-            Ok(LoadingMethod::Package(
-                match PackageRegistration::new(path_buf) {
-                    Ok(instance) => instance,
-                    Err(error) => match error {
-                        RegistrationError::CompilationError(analysis_error) => {
-                            return Err(load_on_error(analysis_error))
-                        }
-                        RegistrationError::DynlinkError(dynlink_error) => {
-                            return Err(load_on_error(dynlink_error))
-                        }
-                    },
-                },
-            ))
+        |path_buf: PathBuf, load_on_error: loader::LoadOnErrorPointer| -> Result<LoadingMethod, *mut c_void> {
+            let instance = PackageRegistration::new(path_buf).map_err(|error| match error {
+                RegistrationError::CompilationError(e) => load_on_error(e),
+                RegistrationError::DynlinkError(e) => load_on_error(e),
+            })?;
+
+            Ok(LoadingMethod::Package(instance))
         },
     )
 }


### PR DESCRIPTION
# Description

## General changes
**A list of the changes I'have applied in more files**

Added `catch_unwind` for wrapping the function, now the C++ process won't crash

Added .is_null() for check if it is null pointer [[source](https://doc.rust-lang.org/std/boxed/index.html#memory-layout)](https://doc.rust-lang.org/std/boxed/index.html#memory-layout)

Changed .expect() to std::ptr::null_mut() for preventing crash and returning the error

return `result.unwrap_or(std::ptr::null_mut())` for returning a null pointer if there is a panic

Added unsafe to the function signature, instead of the unsafe block

If there is panic now return `1_i32`, based on the [[loader_impl_interface.h](https://github.com/metacall/core/blob/develop/source/loader/include/loader/loader_impl_interface.h)](https://github.com/metacall/core/blob/develop/source/loader/include/loader/loader_impl_interface.h), the endpoint are defined to return a standard int, so if there is a panic it return a non-zero code, following the the C++ standard and is also used in [[clear.rs](https://github.com/metacall/core/blob/develop/source/loaders/rs_loader/rust/src/lifecycle/clear.rs)](https://github.com/metacall/core/blob/develop/source/loaders/rs_loader/rust/src/lifecycle/clear.rs), preventing crash.
## Specific changes
**A list of the changes only in the indicated file**
### load_from_package.rs

Fixed the [[arrow anti-pattern](https://wiki.c2.com/?ArrowAntiPattern)](https://wiki.c2.com/?ArrowAntiPattern) using .map_err() and the ? operator
### discover.rs

Fixed the actual box management base on this [source](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.from_raw)s:

[source](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.from_raw )

"Any resources the value manages, such as heap memory or a file handle, will linger forever in an unreachable state. However, it does not guarantee that pointers to this memory will remain valid." [[source](https://doc.rust-lang.org/std/mem/fn.forget.html)](https://doc.rust-lang.org/std/mem/fn.forget.html)

"Also of course you can get all of the functionality of these functions using raw pointer casts or `union`s, but without any of the lints or other basic sanity checks. Raw pointer casts and `union`s do not magically avoid the above rules." [[source](https://doc.rust-lang.org/nomicon/transmutes.html)](https://doc.rust-lang.org/nomicon/transmutes.html)

Fixes #708 

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ ] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings.

