### PR TITLE
fix(memcheck): add ruby suppression and remove duplicate wasm suppression

### DIFF
--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -85,7 +85,7 @@ if(OPTION_TEST_MEMORYCHECK)
 	set(MEMORYCHECK_COMMAND_OPTIONS "${MEMORYCHECK_COMMAND_OPTIONS} --suppressions=${CMAKE_SOURCE_DIR}/source/tests/memcheck/valgrind-python.supp")
 	set(MEMORYCHECK_COMMAND_OPTIONS "${MEMORYCHECK_COMMAND_OPTIONS} --suppressions=${CMAKE_SOURCE_DIR}/source/tests/memcheck/valgrind-node.supp")
 	set(MEMORYCHECK_COMMAND_OPTIONS "${MEMORYCHECK_COMMAND_OPTIONS} --suppressions=${CMAKE_SOURCE_DIR}/source/tests/memcheck/valgrind-wasm.supp")
-	set(MEMORYCHECK_COMMAND_OPTIONS "${MEMORYCHECK_COMMAND_OPTIONS} --suppressions=${CMAKE_SOURCE_DIR}/source/tests/memcheck/valgrind-wasm.supp")
+	set(MEMORYCHECK_COMMAND_OPTIONS "${MEMORYCHECK_COMMAND_OPTIONS} --suppressions=${CMAKE_SOURCE_DIR}/source/tests/memcheck/valgrind-ruby.supp")
 
 	# TODO: Implement automatic detection for valgrind suppressions and create a proper test suite for the CI
 	set(MEMORYCHECK_ADDITIONAL_SUPPRESSIONS

--- a/source/tests/memcheck/valgrind-ruby.supp
+++ b/source/tests/memcheck/valgrind-ruby.supp
@@ -218,3 +218,29 @@
     fun:*try_statx*
     ...
 }
+{
+    strscan_do_scan in strscan.c will sometimes replace the ptr of the regex, which can be reported as a memory leak if the regex is stored in an iseq. https://github.com/ruby/ruby/pull/8136
+    Memcheck:Leak
+    ...
+    fun:rb_reg_prepare_re
+    fun:strscan_do_scan
+    ...
+}
+{
+    The callcache table (RCLASS_CC_TBL) is lazily created, so it is allocated when the first method that gets cached. If this happens in a native extension, it may be reported as a memory leak.
+    Memcheck:Leak
+    ...
+    fun:rb_id_table_create
+    ...
+    fun:rb_callable_method_entry
+    ...
+}
+{
+    The date library lazily initializes Regexps using static local variables through the function `regcomp`. The Regexp will end up being reported as a memory leak.
+    Memcheck:Leak
+    ...
+    fun:rb_enc_reg_new
+    ...
+    fun:date__parse
+    ...
+}


### PR DESCRIPTION
## Changes

- Replaced duplicate `valgrind-wasm.supp` line with `valgrind-ruby.supp` in `cmake/CompileOptions.cmake`
- Added 3 missing suppressions to `valgrind-ruby.supp` from Shopify's ruby_memcheck reference:
  - `strscan_do_scan` (regex leak in strscan.c)
  - `rb_callable_method_entry` (lazy callcache table creation)
  - `date__parse` (lazy Regexp initialization in date library)

## Context

`valgrind-ruby.supp` already existed in `source/tests/memcheck/` but was never referenced in `CompileOptions.cmake`. The duplicate `valgrind-wasm.supp` line on L88 was replaced with the ruby suppression.

Closes #722