### PR TITLE
rs_port: fix c_long type mismatch on Windows

### DIFF
--- a/source/ports/rs_port/src/types/metacall_value.rs
+++ b/source/ports/rs_port/src/types/metacall_value.rs
@@ -165,7 +165,7 @@ impl MetaCallValue for i64 {
         Ok(value as i64)
     }
     fn into_metacall_raw(self) -> *mut c_void {
-        unsafe { metacall_value_create_long(self) }
+        unsafe { metacall_value_create_long(self as std::os::raw::c_long) }
     }
 }
 /// Equivalent to MetaCall float type.


### PR DESCRIPTION
## Summary

Fixes the Windows CI build failure where `metacall_value_create_long()` expects `c_long` (which is `i32` on Windows) but receives `i64`.

## Root Cause

On Windows, `std::os::raw::c_long` is `i32` (32-bit), while on Linux/macOS it is `i64` (64-bit). The [MetaCallValue](cci:2://file:///c:/Users/harsh/OneDrive/Desktop/nihal%20101/core/source/ports/rs_port/src/types/metacall_value.rs:73:0-99:1) implementation for `i64` was passing `self` directly to `metacall_value_create_long()`, which compiles on Linux but fails on Windows due to the type mismatch.

## Fix

Added explicit cast in `source/ports/rs_port/src/types/metacall_value.rs`:

```diff
-        unsafe { metacall_value_create_long(self) }
+        unsafe { metacall_value_create_long(self as std::os::raw::c_long) }
