### PR TITLE
rs_loader: fix lifecycle UB & rs_port: fix c_long type mismatch on Windows

### DIFF
--- a/source/loaders/rs_loader/rust/src/lifecycle/clear.rs
+++ b/source/loaders/rs_loader/rust/src/lifecycle/clear.rs
@@ -5,10 +5,19 @@ use compiler::api;
 
 #[no_mangle]
 pub extern "C" fn rs_loader_impl_clear(loader_impl: *mut c_void, handle: *mut c_void) -> c_int {
+    if loader_impl.is_null() || handle.is_null() {
+        eprintln!("rs_loader_impl_clear: received null pointer");
+        return 1_i32;
+    }
+
     let loader_lifecycle_state = unsafe {
-        api::get_loader_lifecycle_state(loader_impl)
-            .as_mut()
-            .expect("Unable to get loader state")
+        match api::get_loader_lifecycle_state(loader_impl).as_mut() {
+            Some(state) => state,
+            None => {
+                eprintln!("rs_loader_impl_clear: unable to get loader state");
+                return 1_i32;
+            }
+        }
     };
     let methods = unsafe { Box::from_raw(handle as *mut Vec<LoadingMethod>) };
     for loading_method in *methods {

--- a/source/loaders/rs_loader/rust/src/lifecycle/destroy.rs
+++ b/source/loaders/rs_loader/rust/src/lifecycle/destroy.rs
@@ -4,7 +4,17 @@ use compiler::api;
 
 #[no_mangle]
 pub extern "C" fn rs_loader_impl_destroy(loader_impl: *mut c_void) -> c_int {
+    if loader_impl.is_null() {
+        eprintln!("rs_loader_impl_destroy: received null loader_impl pointer");
+        return 1_i32;
+    }
+
     let loader_lifecycle_state = api::get_loader_lifecycle_state(loader_impl);
+
+    if loader_lifecycle_state.is_null() {
+        eprintln!("rs_loader_impl_destroy: lifecycle state is null");
+        return 1_i32;
+    }
 
     // unload children, prevent memory leaks
     api::loader_lifecycle_unload_children(loader_impl);

--- a/source/loaders/rs_loader/rust/src/lifecycle/discover.rs
+++ b/source/loaders/rs_loader/rust/src/lifecycle/discover.rs
@@ -13,6 +13,11 @@ pub extern "C" fn rs_loader_impl_discover(
     handle: *mut c_void,
     ctx: *mut c_void,
 ) -> c_int {
+    if handle.is_null() {
+        eprintln!("rs_loader_impl_discover: received null handle pointer");
+        return 1_i32;
+    }
+
     let handle_shared_objects = unsafe { Box::from_raw(handle as *mut Vec<LoadingMethod>) };
 
     for handle_shared_object in handle_shared_objects.iter() {

--- a/source/loaders/rs_loader/rust/src/lifecycle/execution_path.rs
+++ b/source/loaders/rs_loader/rust/src/lifecycle/execution_path.rs
@@ -4,18 +4,37 @@ use std::os::raw::{c_char, c_int, c_void};
 use std::path::PathBuf;
 
 /// # Safety
+///
+/// This function is called from C code. Both `loader_impl` and `path` must be
+/// valid, non-null pointers. `path` must point to a null-terminated C string
+/// containing valid UTF-8.
 #[no_mangle]
 pub unsafe extern "C" fn rs_loader_impl_execution_path(
     loader_impl: *mut c_void,
     path: *const c_char,
 ) -> c_int {
-    let loader_lifecycle_state = api::get_loader_lifecycle_state(loader_impl)
-        .as_mut()
-        .expect("Unable to get lifecycle state.");
+    if loader_impl.is_null() || path.is_null() {
+        eprintln!("rs_loader_impl_execution_path: received null pointer");
+        return 1_i32;
+    }
+
+    let loader_lifecycle_state = match api::get_loader_lifecycle_state(loader_impl).as_mut() {
+        Some(state) => state,
+        None => {
+            eprintln!("rs_loader_impl_execution_path: unable to get lifecycle state");
+            return 1_i32;
+        }
+    };
 
     let c_path: &CStr = CStr::from_ptr(path);
 
-    let path_slice: &str = c_path.to_str().expect("Unable to cast CStr to str");
+    let path_slice: &str = match c_path.to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            eprintln!("rs_loader_impl_execution_path: path is not valid UTF-8");
+            return 1_i32;
+        }
+    };
     loader_lifecycle_state
         .execution_paths
         .push(PathBuf::from(path_slice));

--- a/source/loaders/rs_loader/rust/src/lifecycle/initialize.rs
+++ b/source/loaders/rs_loader/rust/src/lifecycle/initialize.rs
@@ -8,7 +8,16 @@ pub extern "C" fn rs_loader_impl_initialize(
     _config: *mut c_void,
 ) -> *mut c_void {
     // Add current_dir to execution path to allow relative search path
-    let search_paths = vec![std::env::current_dir().expect("Unable to get current dir")];
+    let search_paths = match std::env::current_dir() {
+        Ok(dir) => vec![dir],
+        Err(e) => {
+            eprintln!(
+                "rs_loader_impl_initialize: unable to get current dir: {}, using empty search paths",
+                e
+            );
+            vec![]
+        }
+    };
     let boxed_loader_lifecycle_state = Box::new(api::LoaderLifecycleState::new(search_paths));
 
     compiler::initialize();
@@ -41,41 +50,6 @@ pub extern "C" fn rs_loader_impl_initialize(
         std::ptr::null_mut::<c_void>(),
         std::ptr::null_mut::<c_void>(),
     );
-    // api::define_type(
-    //     loader_impl,
-    //     "Usize",
-    //     PrimitiveMetacallProtocolTypes::Int,
-    //     0 as c_int as *mut c_void,
-    //     0 as c_int as *mut c_void,
-    // );
-    // api::define_type(
-    //     loader_impl,
-    //     "U8",
-    //     PrimitiveMetacallProtocolTypes::Char,
-    //     0 as c_int as *mut c_void,
-    //     0 as c_int as *mut c_void,
-    // );
-    // api::define_type(
-    //     loader_impl,
-    //     "U16",
-    //     PrimitiveMetacallProtocolTypes::Short,
-    //     0 as c_int as *mut c_void,
-    //     0 as c_int as *mut c_void,
-    // );
-    // api::define_type(
-    //     loader_impl,
-    //     "U32",
-    //     PrimitiveMetacallProtocolTypes::Int,
-    //     0 as c_int as *mut c_void,
-    //     0 as c_int as *mut c_void,
-    // );
-    // api::define_type(
-    //     loader_impl,
-    //     "U64",
-    //     PrimitiveMetacallProtocolTypes::Long,
-    //     0 as c_int as *mut c_void,
-    //     0 as c_int as *mut c_void,
-    // );
     api::define_type(
         loader_impl,
         "f32",

--- a/source/loaders/rs_loader/rust/src/lifecycle/load_from_memory.rs
+++ b/source/loaders/rs_loader/rust/src/lifecycle/load_from_memory.rs
@@ -4,6 +4,9 @@ use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
 
 /// # Safety
+///
+/// This function is called from C code. Both `name` and `buffer` must be valid,
+/// non-null pointers to null-terminated C strings containing valid UTF-8.
 #[no_mangle]
 pub unsafe extern "C" fn rs_loader_impl_load_from_memory(
     _loader_impl: *mut c_void,
@@ -11,24 +14,38 @@ pub unsafe extern "C" fn rs_loader_impl_load_from_memory(
     buffer: *const c_char,
     _size: usize,
 ) -> *mut c_void {
-    let name = CStr::from_ptr(name)
-        .to_str()
-        .expect("Unable to cast CStr to str")
-        .to_owned();
-    let code = CStr::from_ptr(buffer)
-        .to_str()
-        .expect("Unable to cast CStr to str")
-        .to_owned();
-    let instance = LoadingMethod::Memory(match MemoryRegistration::new(name, code) {
-        Ok(instance) => instance,
-        Err(error) => match error {
-            RegistrationError::CompilationError(analysis_error) => {
-                return loader::load_on_error(analysis_error);
+    let result = std::panic::catch_unwind(|| {
+        if name.is_null() || buffer.is_null() {
+            eprintln!("rs_loader_impl_load_from_memory: received null pointer for name or buffer");
+            return std::ptr::null_mut();
+        }
+
+        let name = match CStr::from_ptr(name).to_str() {
+            Ok(s) => s.to_owned(),
+            Err(_) => {
+                eprintln!("rs_loader_impl_load_from_memory: name is not valid UTF-8");
+                return std::ptr::null_mut();
             }
-            RegistrationError::DynlinkError(dynlink_error) => {
-                return loader::load_on_error(dynlink_error);
+        };
+        let code = match CStr::from_ptr(buffer).to_str() {
+            Ok(s) => s.to_owned(),
+            Err(_) => {
+                eprintln!("rs_loader_impl_load_from_memory: buffer is not valid UTF-8");
+                return std::ptr::null_mut();
             }
-        },
+        };
+        let instance = LoadingMethod::Memory(match MemoryRegistration::new(name, code) {
+            Ok(instance) => instance,
+            Err(error) => match error {
+                RegistrationError::CompilationError(analysis_error) => {
+                    return loader::load_on_error(analysis_error);
+                }
+                RegistrationError::DynlinkError(dynlink_error) => {
+                    return loader::load_on_error(dynlink_error);
+                }
+            },
+        });
+        Box::into_raw(Box::new(vec![instance])) as *mut c_void
     });
-    Box::into_raw(Box::new(vec![instance])) as *mut c_void
+    result.unwrap_or(std::ptr::null_mut())
 }

--- a/source/loaders/rs_loader/rust/src/lifecycle/loader.rs
+++ b/source/loaders/rs_loader/rust/src/lifecycle/loader.rs
@@ -70,10 +70,19 @@ pub fn load<T>(
 where
     T: OnPathBufClosure,
 {
+    if loader_impl.is_null() || loadable_path.is_null() {
+        eprintln!("rs_loader load: received null pointer for loader_impl or loadable_path");
+        return std::ptr::null_mut();
+    }
+
     let loader_lifecycle_state = unsafe {
-        api::get_loader_lifecycle_state(loader_impl)
-            .as_mut()
-            .expect("Unable to get lifecycle state.")
+        match api::get_loader_lifecycle_state(loader_impl).as_mut() {
+            Some(state) => state,
+            None => {
+                eprintln!("rs_loader load: unable to get lifecycle state");
+                return std::ptr::null_mut();
+            }
+        }
     };
     let mut execution_paths_iterator = loader_lifecycle_state.execution_paths.iter();
 
@@ -88,9 +97,14 @@ where
             path = loadable_path as *const i8;
         }
 
-        let path_slice = unsafe { CStr::from_ptr(path) }
-            .to_str()
-            .expect("Unable to cast CStr to str");
+        let path_slice = match unsafe { CStr::from_ptr(path) }.to_str() {
+            Ok(s) => s,
+            Err(_) => {
+                return load_on_error(String::from(
+                    "rs_loader load: path is not valid UTF-8",
+                ));
+            }
+        };
         let mut path_buf = PathBuf::from(path_slice);
 
         if !path_buf.is_absolute() {
@@ -102,7 +116,7 @@ where
                     Some(original_execution_path) => {
                         let mut execution_path = original_execution_path.clone();
                         let mut execution_path_as_str =
-                            execution_path.to_str().expect("Unable to cast CStr to str");
+                            execution_path.to_str().unwrap_or("<invalid path>");
 
                         if !execution_path_as_str.ends_with('/') {
                             execution_path =
@@ -110,13 +124,13 @@ where
 
                             // Reassign the execution_path_as_str since the execution_path got changed
                             execution_path_as_str =
-                                execution_path.to_str().expect("Unable to cast CStr to str");
+                                execution_path.to_str().unwrap_or("<invalid path>");
                         }
 
                         path_buf = PathBuf::from(format!(
                             "{}{}",
                             execution_path_as_str,
-                            path_buf.to_str().expect("Unable to cast CStr to str")
+                            path_buf.to_str().unwrap_or("<invalid path>")
                         ));
 
                         if !path_buf.exists() || !path_buf.is_file() {
@@ -130,7 +144,7 @@ where
                             "Rs_loader was unable to find '{}' in the list of execution_paths.",
                             original_path_buf
                                 .to_str()
-                                .expect("Unable to cast CStr to str")
+                                .unwrap_or("<invalid path>")
                         ))
                     }
                 };
@@ -143,7 +157,7 @@ where
         if !path_buf.exists() || !path_buf.is_file() {
             return load_on_error(format!(
                 "The file or path '{}' does not exist.",
-                path_buf.to_str().expect("Unable to cast CStr to str")
+                path_buf.to_str().unwrap_or("<invalid path>")
             ));
         }
 

--- a/source/ports/rs_port/src/types/metacall_value.rs
+++ b/source/ports/rs_port/src/types/metacall_value.rs
@@ -165,7 +165,7 @@ impl MetaCallValue for i64 {
         Ok(value as i64)
     }
     fn into_metacall_raw(self) -> *mut c_void {
-        unsafe { metacall_value_create_long(self) }
+        unsafe { metacall_value_create_long(self as std::os::raw::c_long) }
     }
 }
 /// Equivalent to MetaCall float type.


### PR DESCRIPTION
## Summary

This PR contains two fixes:

### 1. rs_port: fix `c_long` type mismatch on Windows

On Windows, `std::os::raw::c_long` is `i32` (32-bit), while on Linux/macOS it is `i64` (64-bit). The [MetaCallValue](cci:2://file:///c:/Users/harsh/OneDrive/Desktop/nihal%20101/core/source/ports/rs_port/src/types/metacall_value.rs:73:0-99:1) impl for `i64` passed `self` directly to `metacall_value_create_long()`, causing a compile error on Windows.

**Fix:** `self as std::os::raw::c_long`

### 2. rs_loader: fix undefined behavior in lifecycle functions

Added null-pointer checks and safe error handling across multiple lifecycle functions:

- **[clear.rs](cci:7://file:///c:/Users/harsh/OneDrive/Desktop/nihal%20101/core/source/loaders/rs_loader/rust/src/lifecycle/clear.rs:0:0-0:0)** — Added null checks for [loader_impl](cci:1://file:///c:/Users/harsh/OneDrive/Desktop/nihal%20101/core/source/loaders/rs_loader/rust/src/lifecycle/clear.rs:5:0-35:1) and `handle` pointers; replaced `expect()` with proper error returns
- **[destroy.rs](cci:7://file:///c:/Users/harsh/OneDrive/Desktop/nihal%20101/core/source/loaders/rs_loader/rust/src/lifecycle/destroy.rs:0:0-0:0)** — Added null check for [loader_impl](cci:1://file:///c:/Users/harsh/OneDrive/Desktop/nihal%20101/core/source/loaders/rs_loader/rust/src/lifecycle/clear.rs:5:0-35:1); added null check for lifecycle state before dereferencing
- **[loader.rs](cci:7://file:///c:/Users/harsh/OneDrive/Desktop/nihal%20101/core/source/loaders/rs_loader/rust/src/lifecycle/loader.rs:0:0-0:0)** — Added null checks for [loader_impl](cci:1://file:///c:/Users/harsh/OneDrive/Desktop/nihal%20101/core/source/loaders/rs_loader/rust/src/lifecycle/clear.rs:5:0-35:1) and `loadable_path`; replaced `.expect()` calls on `CStr::to_str()` and `Path::to_str()` with `.unwrap_or()` to prevent panics across FFI
- **[load_from_memory.rs](cci:7://file:///c:/Users/harsh/OneDrive/Desktop/nihal%20101/core/source/loaders/rs_loader/rust/src/lifecycle/load_from_memory.rs:0:0-0:0)** — Added `# Safety` docs; null checks for `name` and `buffer`; proper UTF-8 validation; wrapped body in `catch_unwind` to prevent panics from unwinding across FFI boundary

## Related

- Fixes the Windows build issue from #714
- Related to #708
