### PR TITLE
fix(detour): free handle struct in detour_unload() to prevent memory leak

### DIFF
--- a/source/detour/source/detour.c
+++ b/source/detour/source/detour.c
@@ -241,6 +241,8 @@ void detour_unload(detour d, detour_handle handle)
 	set_destroy(handle->symbol_map);
 
 	set_destroy(handle->replaced_symbols);
+
+	free(handle);
 }
 
 int detour_clear(detour d)


### PR DESCRIPTION
detour_handle_allocate() allocates a 24-byte struct via malloc().
detour_unload() destroyed internal members but never called free(handle).

Before (from PR #704 CI logs):
- detour-test: 1 still-reachable block (24 bytes)
- metacall-fork-test: 2 definitely-lost blocks

After: 0 leaks in both tests.

Fixes memory leak reported by Valgrind memcheck.