### PR TITLE
fix(rs_port): exit on missing library instead of silently warning

### DIFF
--- a/source/ports/rs_port/sys/src/lib.rs
+++ b/source/ports/rs_port/sys/src/lib.rs
@@ -374,13 +374,8 @@ pub fn build() {
             }
             Err(e) => {
                 // Print the error
-                println!(
-                    "cargo:warning=Failed to find MetaCall library with: {e} \
-                    Still trying to link in case the library is in system paths"
-                );
-
-                // Still try to link in case the library is in system paths
-                println!("cargo:rustc-link-lib=dylib=metacall")
+                println!("cargo:warning={e}");
+                std::process::exit(1);
             }
         }
     }


### PR DESCRIPTION
# Description


<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

When `find_metacall_library()` failed, the `Err` branch only emitted a warning and still passed `cargo:rustc-link-lib=dylib=metacall`, letting the linker try an implicit fallback.

This could hide the real configuration issue because the build would continue even after explicit library detection had already failed.

Now it exits immediately with an error instead.


Before:
<img width="1434" height="285" alt="Screenshot from 2026-03-25 20-26-27" src="https://github.com/user-attachments/assets/234df954-5c8e-4343-9dc5-3aee34df78bb" />

After:
<img width="1548" height="700" alt="image" src="https://github.com/user-attachments/assets/2dfbfdaa-1609-4c58-800d-7e682361105f" />


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
