### PR TITLE
fix(type-check): replace try_into in rs_loader and rs_port

### DIFF
--- a/source/loaders/rs_loader/rust/compiler/src/wrapper/class.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/wrapper/class.rs
@@ -542,7 +542,13 @@ impl ToMetaResult for i64 {
         // Meanwhile as a workaround, we just panic if it does not fit.
         // Here the error is wrose than in rs_port because the bindings.rs are hardcoded,
         // and not regenerated for each target platform so they will break ABI when using this.
-        Ok(unsafe { metacall_value_create_long(self).try_into().unwrap() })
+        #[cfg(any(target_pointer_width = "32", windows))]
+        {
+            if self < c_long::MIN as i64 || self > c_long::MAX as i64{
+                panic!("i64 does not fit into c_long on this platform");
+            }
+        }
+        Ok(unsafe { metacall_value_create_long(self) })
     }
 }
 

--- a/source/ports/rs_port/src/types/metacall_value.rs
+++ b/source/ports/rs_port/src/types/metacall_value.rs
@@ -174,9 +174,14 @@ impl MetaCallValue for i64 {
             if self < std::os::raw::c_long::MIN as i64 || self > std::os::raw::c_long::MAX as i64 {
                 panic!("i64 does not fit into c_long on this platform");
             }
+
+            return unsafe { metacall_value_create_long(self as std::os::raw::c_long) };
         }
 
-        unsafe { metacall_value_create_long(self) }
+        #[cfg(not(any(target_pointer_width = "32", windows)))]
+        {
+            unsafe { metacall_value_create_long(self) }
+        }
 
     }
 }

--- a/source/ports/rs_port/src/types/metacall_value.rs
+++ b/source/ports/rs_port/src/types/metacall_value.rs
@@ -168,8 +168,16 @@ impl MetaCallValue for i64 {
         // TODO: This issue happens because we do not have a clear type definition in the Core
         // We are not sure yet if we should use fixed sizes in the core, or adapt all the loaders
         // and ports to the standard C int type definition. We should define this but it's not yet.
-        // Meanwhile as a workaround, we just panic if it does not fit.
-        unsafe { metacall_value_create_long(self).try_into().unwrap() }
+        // Meanwhile as a workaround, we just panic if it does not fit.        
+        #[cfg(any(target_pointer_width = "32", windows))]
+        {
+            if self < std::os::raw::c_long::MIN as i64 || self > std::os::raw::c_long::MAX as i64 {
+                panic!("i64 does not fit into c_long on this platform");
+            }
+        }
+
+        unsafe { metacall_value_create_long(self) }
+
     }
 }
 /// Equivalent to MetaCall float type.


### PR DESCRIPTION
# Description

Replaces the previous try_into workaround in rs_loader and rs_port with an explicit bounds check for i64 values before using MetaCall long.

This is a corrective workaround for the current type mismatch. On Linux 64-bit systems, it works normally. On Windows and Linux 32-bit systems, it panics explicitly when the i64 value does not fit into c_long, instead of allowing an invalid conversion.

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
