### PR TITLE
Renamed pub fn build(source: Source) -> SourceImpl

### DIFF
--- a/source/loaders/rs_loader/rust/compiler/src/file.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/file.rs
@@ -12,7 +12,7 @@ pub struct FileRegistration {
 }
 impl FileRegistration {
     pub fn new(path_to_file: PathBuf) -> Result<FileRegistration, RegistrationError> {
-        let state = match compile(Source::new(Source::File {
+        let state = match compile(Source::build(Source::File {
             path: path_to_file.clone(),
         })) {
             Ok(state) => state,

--- a/source/loaders/rs_loader/rust/compiler/src/lib.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/lib.rs
@@ -86,9 +86,8 @@ pub enum Source {
     Package { path: PathBuf },
 }
 
-#[allow(clippy::new_ret_no_self)]
 impl Source {
-    pub fn new(source: Source) -> SourceImpl {
+    pub fn build(source: Source) -> SourceImpl {
         let library_name = |file_name: &PathBuf| {
             #[cfg(unix)]
             let lib_extension = "so";
@@ -1049,7 +1048,7 @@ mod tests {
     #[test]
     fn test_compile_memory() {
         run_test(|| {
-            match compile(Source::new(Source::Memory {
+            match compile(Source::build(Source::Memory {
                 name: String::from("test.rs"),
                 code: String::from("pub fn add(a: i32, b: i32) -> i32 { a + b }"),
             })) {
@@ -1062,7 +1061,7 @@ mod tests {
     #[test]
     fn test_compile_file() {
         run_test(|| {
-            match compile(Source::new(Source::File {
+            match compile(Source::build(Source::File {
                 path: PathBuf::from(std::env::var("TEST_SOURCE_DIR").unwrap()),
             })) {
                 Err(comp_err) => assert!(false, "compilation failed: {}", comp_err.errors),

--- a/source/loaders/rs_loader/rust/compiler/src/memory.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/memory.rs
@@ -12,7 +12,7 @@ pub struct MemoryRegistration {
 }
 impl MemoryRegistration {
     pub fn new(name: String, code: String) -> Result<MemoryRegistration, RegistrationError> {
-        let state = match compile(Source::new(Source::Memory {
+        let state = match compile(Source::build(Source::Memory {
             name: name.clone(),
             code,
         })) {

--- a/source/loaders/rs_loader/rust/compiler/src/package.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/package.rs
@@ -11,7 +11,7 @@ pub struct PackageRegistration {
 
 impl PackageRegistration {
     pub fn new(path_to_file: PathBuf) -> Result<PackageRegistration, RegistrationError> {
-        let state = match compile(Source::new(Source::Package {
+        let state = match compile(Source::build(Source::Package {
             path: path_to_file.clone(),
         })) {
             Ok(state) => state,

--- a/source/loaders/rs_loader/rust/compiler/src/wrapper/mod.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/wrapper/mod.rs
@@ -167,7 +167,7 @@ pub fn generate_wrapper(callbacks: CompilerCallbacks) -> std::io::Result<Compile
             wrapper_file.write_all(b"mod metacall_class;\nuse metacall_class::*;\n")?;
             wrapper_file.write_all(content.as_bytes())?;
 
-            let mut source = Source::new(Source::Package {
+            let mut source = Source::build(Source::Package {
                 path: path.to_path_buf(),
             });
             source.output = callbacks.source.output;
@@ -210,7 +210,7 @@ pub fn generate_wrapper(callbacks: CompilerCallbacks) -> std::io::Result<Compile
                     wrapper_file.write_all(content.as_bytes())?;
                     let dst = format!("include!({:?});", callbacks.source.input_path);
                     wrapper_file.write_all(dst.as_bytes())?;
-                    let mut source = Source::new(Source::File {
+                    let mut source = Source::build(Source::File {
                         path: temp_dir.join("wrapped_".to_owned() + &source_file),
                     });
                     source.output = callbacks.source.output;
@@ -244,7 +244,7 @@ pub fn generate_wrapper(callbacks: CompilerCallbacks) -> std::io::Result<Compile
                         wrapper_file.write_all(content.as_bytes())?;
                         let dst = format!("include!({:?});", source_path.join("script.rs"));
                         wrapper_file.write_all(dst.as_bytes())?;
-                        let mut source = Source::new(Source::File {
+                        let mut source = Source::build(Source::File {
                             path: source_path.join("wrapped_script.rs"),
                         });
                         source.output = callbacks.source.output;


### PR DESCRIPTION
# Description

Changed `pub fn build(source: Source) -> SourceImpl` to `fn build(source: Source) -> SourceImpl`

Removed #[allow(clippy::new_ret_no_self)] that now is useless

Changed the name every time the function is used

Updated the tests

Fixes #688 

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings.
- [ ] I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer &> output`.

