### PR TITLE
fix(py_loader,rs_port): bootstrap Python home on Windows to prevent CPython init_fs_encoding failures

### DIFF
--- a/source/loaders/py_loader/CMakeLists.txt
+++ b/source/loaders/py_loader/CMakeLists.txt
@@ -294,12 +294,34 @@ endif()
 # Configuration
 #
 
+set(PY_LOADER_CONFIG_TEMPLATE "${CMAKE_CURRENT_SOURCE_DIR}/data/py_loader.json.in")
+
+set(PYTHON_HOME "")
+set(Python3_LIBRARY_SEARCH_PATHS "")
+
+if(PROJECT_OS_FAMILY STREQUAL win32)
+	# Prefer the interpreter directory as Python home for development builds.
+	set(PYTHON_HOME_DEVELOPMENT "${Python3_ROOT_DIR}")
+
+	# On installed layouts we place Python runtime artifacts under INSTALL_LIB.
+	set(PYTHON_HOME_INSTALL "${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB}")
+
+	set(Python3_LIBRARY_SEARCH_PATHS_DEVELOPMENT
+		"${Python3_ROOT_DIR};${Python3_ROOT_DIR}/DLLs;${Python3_ROOT_DIR}/libs")
+	set(Python3_LIBRARY_SEARCH_PATHS_INSTALL
+		"${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB};${CMAKE_INSTALL_PREFIX}/${INSTALL_BIN}")
+endif()
+
 # Development
-loader_configuration_begin(py_loader)
+loader_configuration_begin(py_loader "${PY_LOADER_CONFIG_TEMPLATE}")
+set(PYTHON_HOME "${PYTHON_HOME_DEVELOPMENT}")
+loader_configuration_paths("${Python3_LIBRARY_SEARCH_PATHS_DEVELOPMENT}")
 loader_configuration_deps(python "${Python3_LIBRARY_DEVELOPMENT}")
 loader_configuartion_end_development()
 
 # Install
-loader_configuration_begin(py_loader)
+loader_configuration_begin(py_loader "${PY_LOADER_CONFIG_TEMPLATE}")
+set(PYTHON_HOME "${PYTHON_HOME_INSTALL}")
+loader_configuration_paths("${Python3_LIBRARY_SEARCH_PATHS_INSTALL}")
 loader_configuration_deps(python "${Python3_LIBRARY_INSTALL}")
 loader_configuartion_end_install()

--- a/source/loaders/py_loader/data/py_loader.json.in
+++ b/source/loaders/py_loader/data/py_loader.json.in
@@ -1,0 +1,7 @@
+{
+	"python_home": "@PYTHON_HOME@",
+	"search_paths": [ @LOADER_SEARCH_PATHS@ ],
+	"dependencies": {
+		@LOADER_DEPENDENCIES@
+	}
+}

--- a/source/loaders/py_loader/source/py_loader_impl.c
+++ b/source/loaders/py_loader/source/py_loader_impl.c
@@ -190,6 +190,45 @@ static int py_loader_impl_finalize(loader_impl_py py_impl, const int host);
 
 static PyObject *py_loader_impl_load_from_memory_compile(loader_impl_py py_impl, const loader_name name, const char *buffer);
 
+#if defined(WIN32) || defined(_WIN32)
+static int py_loader_impl_initialize_python_home(configuration config)
+{
+	value python_home_value;
+	const char *python_home;
+	const char *python_home_env = getenv("PYTHONHOME");
+
+	/* Respect user-provided PYTHONHOME when present. */
+	if (python_home_env != NULL && python_home_env[0] != '\0')
+	{
+		return 0;
+	}
+
+	python_home_value = configuration_value_type(config, "python_home", TYPE_STRING);
+
+	if (python_home_value == NULL)
+	{
+		return 0;
+	}
+
+	python_home = value_to_string(python_home_value);
+
+	if (python_home == NULL || python_home[0] == '\0')
+	{
+		return 0;
+	}
+
+	if (_putenv_s("PYTHONHOME", python_home) != 0)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Python loader failed to set PYTHONHOME to: %s", python_home);
+		return 1;
+	}
+
+	log_write("metacall", LOG_LEVEL_DEBUG, "Python loader configured PYTHONHOME to: %s", python_home);
+
+	return 0;
+}
+#endif
+
 /* Implements: if __name__ == "__main__": */
 static int py_loader_impl_run_main = 1;
 static char *py_loader_impl_main_module = NULL;
@@ -2454,6 +2493,13 @@ loader_impl_data py_loader_impl_initialize(loader_impl impl, configuration confi
 
 	if (host == 0)
 	{
+	#if defined(WIN32) || defined(_WIN32)
+		if (py_loader_impl_initialize_python_home(config) != 0)
+		{
+			goto error_init_py;
+		}
+	#endif
+
 		Py_InitializeEx(0);
 
 		if (Py_IsInitialized() == 0)
@@ -3725,7 +3771,7 @@ static int py_loader_impl_validate_object(loader_impl impl, PyObject *obj, objec
 			log_write("metacall", LOG_LEVEL_DEBUG, "Discover object member %s, type %s",
 					  PyUnicode_AsUTF8(dict_key),
 					  type_id_name(py_loader_impl_capi_to_value_type(dict_val)));
-			
+
 		}
 	}
 

--- a/source/ports/rs_port/src/init.rs
+++ b/source/ports/rs_port/src/init.rs
@@ -2,9 +2,43 @@ use crate::{
     bindings::{metacall_destroy, metacall_initialize, metacall_is_initialized},
     types::MetaCallInitError,
 };
-use std::ptr;
+use std::{env, ptr};
 
 pub struct MetaCallDestroy(unsafe extern "C" fn());
+
+#[cfg(target_os = "windows")]
+fn ensure_python_home() {
+    use std::path::Path;
+
+    if env::var_os("PYTHONHOME").is_some() {
+        return;
+    }
+
+    let Some(configured_home) = option_env!("METACALL_PYTHONHOME") else {
+        return;
+    };
+
+    if configured_home.is_empty() {
+        return;
+    }
+
+    let configured_home_path = Path::new(configured_home);
+    let runtime_python_from_config = configured_home_path.join("runtimes").join("python");
+    let runtime_python_from_parent = configured_home_path
+        .parent()
+        .map(|p| p.join("runtimes").join("python"));
+
+    let selected_home = if runtime_python_from_config.is_dir() {
+        runtime_python_from_config.as_os_str()
+    } else if let Some(runtime_python) = runtime_python_from_parent.as_ref().filter(|p| p.is_dir())
+    {
+        runtime_python.as_os_str()
+    } else {
+        configured_home_path.as_os_str()
+    };
+
+    env::set_var("PYTHONHOME", selected_home);
+}
 
 impl Drop for MetaCallDestroy {
     fn drop(&mut self) {
@@ -22,6 +56,9 @@ impl Drop for MetaCallDestroy {
 ///
 /// ```
 pub fn initialize() -> Result<MetaCallDestroy, MetaCallInitError> {
+    #[cfg(target_os = "windows")]
+    ensure_python_home();
+
     let code = unsafe { metacall_initialize() };
 
     if code != 0 {

--- a/source/ports/rs_port/sys/src/lib.rs
+++ b/source/ports/rs_port/sys/src/lib.rs
@@ -365,6 +365,14 @@ pub fn build() {
                     define_library_search_path(ENV_VAR, SEPARATOR, &lib_path.search)
                 );
 
+                #[cfg(target_os = "windows")]
+                {
+                    println!(
+                        "cargo:rustc-env=METACALL_PYTHONHOME={}",
+                        lib_path.search.display()
+                    );
+                }
+
                 println!(
                     "cargo:warning=Library {} found in: {} with runtime search path: {}",
                     lib_path.library,


### PR DESCRIPTION
## Description

This PR fixes Windows CI instability in the Rust port caused by Python embedded initialization failing with:

- `Fatal Python error: init_fs_encoding`
- `ModuleNotFoundError: No module named 'encodings'`

The fix ensures Python home/bootstrap paths are resolved consistently when running `cargo test` against installed MetaCall binaries on Windows.

### Root cause

`rs_port` tests were running against installed MetaCall artifacts (from the install script) where runtime Python bootstrap context was not guaranteed at process startup. In this context, embedded Python could initialize without a valid `PYTHONHOME`, causing stdlib bootstrap failure.

### What changed

#### 1) Python loader configuration (proper loader-side fix)
- Added `source/loaders/py_loader/data/py_loader.json.in`.
- Added `python_home` to py_loader configuration.
- Wired `py_loader` CMake to use this custom template.
- Added Windows `search_paths` generation for development/install configs.

Files:
- `source/loaders/py_loader/data/py_loader.json.in`
- `source/loaders/py_loader/CMakeLists.txt`

#### 2) Python loader runtime bootstrap
- Added Windows-only initialization hook in `py_loader` that:
  - reads `python_home` from loader config,
  - respects user-provided `PYTHONHOME` if already set,
  - sets `PYTHONHOME` before `Py_InitializeEx(0)`.

File:
- `source/loaders/py_loader/source/py_loader_impl.c`

#### 3) Rust port compatibility fallback (for older installed packages)
- Added Windows runtime fallback in `rs_port` init path:
  - if `PYTHONHOME` is unset, infer it from `METACALL_PYTHONHOME` and runtime layout,
  - prefer `.../runtimes/python` when present.
- Exposed `METACALL_PYTHONHOME` from `metacall-sys` build metadata on Windows.

Files:
- `source/ports/rs_port/src/init.rs`
- `source/ports/rs_port/sys/src/lib.rs`

## Why this approach

- Fixes the issue at the loader level (correct long-term boundary).
- Keeps compatibility with currently installed/distributed Windows artifacts via Rust-side fallback.
- Avoids fragile workflow-only environment hacks.

## Validation

- Reproduced and analyzed failing Windows CI behavior (`inlines_test` before fix).
- Verified post-fix behavior where:
  - `inlines_test` passes,
  - full Rust test suite completes successfully.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [x] I have tested the tests implicated (if any) by my own code and they pass.
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_ADDRESS_SANITIZER` or `./docker-compose.sh test-address-sanitizer` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [x] I have run `make clang-format` in order to format my code and my code follows the style guidelines.
