### PR TITLE
Fix macOS library discovery in "next" metacall-sys 0.1.5

### DIFF
--- a/source/ports/rs_port/Cargo.toml
+++ b/source/ports/rs_port/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 metacall-inline = { version = "0.2.0", path = "./inline" }
 
 [build-dependencies]
-metacall-sys = { version = "0.1.4", path = "./sys" }
+metacall-sys = { version = "0.1.5", path = "./sys" }
 bindgen = "0.72.1"
 
 [workspace]

--- a/source/ports/rs_port/sys/Cargo.toml
+++ b/source/ports/rs_port/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metacall-sys"
-version = "0.1.4"
+version = "0.1.5"
 repository = "https://github.com/metacall/core/tree/develop/source/ports/rs_port/sys"
 keywords = ["ffi", "bindings", "metacall"]
 edition = "2021"

--- a/source/ports/rs_port/sys/src/lib.rs
+++ b/source/ports/rs_port/sys/src/lib.rs
@@ -10,6 +10,7 @@ use std::{
 // Provide helpful error messages when things aren't found
 
 /// Represents the install paths for a platform
+#[derive(Debug, PartialEq, Eq)]
 struct InstallPath {
     paths: Vec<PathBuf>,
     names: Vec<&'static str>,
@@ -94,20 +95,22 @@ fn platform_install_paths() -> Result<InstallPath, Box<dyn std::error::Error>> {
 
 /// Get search paths, checking for custom installation path first
 fn get_search_config() -> Result<InstallPath, Box<dyn std::error::Error>> {
-    // First, check if user specified a custom path
+    // First, check if user specified a non-empty custom path
     if let Ok(custom_path) = env::var("METACALL_INSTALL_PATH") {
-        // For custom paths, we need to search for any metacall library variant
-        return Ok(InstallPath {
-            paths: vec![PathBuf::from(custom_path)],
-            names: vec![
-                "libmetacall.so",
-                "libmetacalld.so",
-                "libmetacall.dylib",
-                "libmetacalld.dylib",
-                "metacall.lib",
-                "metacalld.lib",
-            ],
-        });
+        if !custom_path.is_empty() {
+            // For custom paths, we need to search for any metacall library variant
+            return Ok(InstallPath {
+                paths: vec![PathBuf::from(custom_path)],
+                names: vec![
+                    "libmetacall.so",
+                    "libmetacalld.so",
+                    "libmetacall.dylib",
+                    "libmetacalld.dylib",
+                    "metacall.lib",
+                    "metacalld.lib",
+                ],
+            });
+        }
     }
 
     // Fall back to platform-specific paths
@@ -378,5 +381,64 @@ pub fn build() {
                 std::process::exit(1);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn with_metacall_install_path<T>(value: Option<&str>, callback: impl FnOnce() -> T) -> T {
+        let _guard = env_lock().lock().unwrap();
+        let previous = env::var_os("METACALL_INSTALL_PATH");
+
+        match value {
+            Some(path) => env::set_var("METACALL_INSTALL_PATH", path),
+            None => env::remove_var("METACALL_INSTALL_PATH"),
+        }
+
+        let result = callback();
+
+        match previous {
+            Some(path) => env::set_var("METACALL_INSTALL_PATH", path),
+            None => env::remove_var("METACALL_INSTALL_PATH"),
+        }
+
+        result
+    }
+
+    #[test]
+    fn ignores_empty_custom_install_path() {
+        with_metacall_install_path(Some(""), || {
+            let config = get_search_config().unwrap();
+            assert_eq!(config, platform_install_paths().unwrap());
+        });
+    }
+
+    #[test]
+    fn honors_non_empty_custom_install_path() {
+        with_metacall_install_path(Some("/tmp/metacall"), || {
+            let config = get_search_config().unwrap();
+            assert_eq!(config.paths, vec![PathBuf::from("/tmp/metacall")]);
+            assert!(config.names.contains(&"libmetacall.dylib"));
+            assert!(config.names.contains(&"libmetacalld.dylib"));
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_searches_release_and_debug_dylibs() {
+        let config = platform_install_paths().unwrap();
+
+        assert_eq!(
+            config.names,
+            vec!["libmetacall.dylib", "libmetacalld.dylib"]
+        );
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes two bugs in `metacall-sys` that affect Cargo-based MetaCall consumers on macOS and in CI environments.

### Root Cause

The investigation started from repeated macOS CI failures in metassr and traced the problem back to `metacall-sys` behavior.

Two issues were identified:

- `METACALL_INSTALL_PATH=""` was treated as a real custom path instead of being ignored
- macOS library discovery needed regression coverage to guarantee both release and debug dylib names remain searchable

In affected consumers, this could cause library discovery to fail and eventually fall back to linking `-lmetacall` even when only the debug dylib was installed.

### Changes

- ignore empty `METACALL_INSTALL_PATH` values and fall back to the normal platform-specific search paths
- add regression tests covering:
  - empty custom install path fallback
  - non-empty custom install path override
  - macOS release/debug dylib name matching
- bump `metacall-sys` version from `0.1.4` to `0.1.5`
- update the local `metacall` Rust port to depend on `metacall-sys 0.1.5`

### Validation

- `cargo test -p metacall-sys`
- `cargo check -p metacall-sys`

### Impact

This release unblocks downstream Cargo consumers that rely on explicit library path injection in CI, especially on macOS where only the debug MetaCall dylib may be installed so after releasing and re-evaluating we can clean the CI.
