### PR TITLE
test: add ConcurrentSyncInvoke test to reproduce invoke_curl data rac…

### DIFF
--- a/source/loaders/rpc_loader/source/rpc_loader_impl.cpp
+++ b/source/loaders/rpc_loader/source/rpc_loader_impl.cpp
@@ -65,7 +65,6 @@ struct rpc_async_context;
 typedef struct loader_impl_rpc_type
 {
 	CURL *discover_curl;
-	CURL *invoke_curl;
 	CURLM *async_multi;
 	std::thread poll_thread;
 	std::atomic<bool> exit_flag;
@@ -195,22 +194,39 @@ function_return function_rpc_interface_invoke(function func, function_impl impl,
 		return NULL;
 	}
 
-	/* Execute a POST to the endpoint */
+	/* This creates a per-call CURL handle for thread safety */
+	CURL *easy = curl_easy_init();
+
+	if (easy == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Could not create CURL handle for sync call to %s", rpc_function->url.c_str());
+		metacall_allocator_free(rpc_impl->allocator, buffer);
+		return NULL;
+	}
+
 	loader_impl_rpc_write_data_type write_data;
 
-	curl_easy_setopt(rpc_impl->invoke_curl, CURLOPT_URL, rpc_function->url.c_str());
-	curl_easy_setopt(rpc_impl->invoke_curl, CURLOPT_POSTFIELDS, buffer);
-	curl_easy_setopt(rpc_impl->invoke_curl, CURLOPT_POSTFIELDSIZE, body_request_size - 1);
-	curl_easy_setopt(rpc_impl->invoke_curl, CURLOPT_WRITEDATA, static_cast<loader_impl_rpc_write_data>(&write_data));
+	curl_easy_setopt(easy, CURLOPT_VERBOSE, CURL_VERBOSE);
+	curl_easy_setopt(easy, CURLOPT_HEADER, 0L);
+	curl_easy_setopt(easy, CURLOPT_CUSTOMREQUEST, "POST");
+	curl_easy_setopt(easy, CURLOPT_HTTPHEADER, rpc_impl->headers);
+	curl_easy_setopt(easy, CURLOPT_USERAGENT, "librpc_loader/0.1");
+	curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, rpc_loader_impl_write_data);
+	curl_easy_setopt(easy, CURLOPT_URL, rpc_function->url.c_str());
+	curl_easy_setopt(easy, CURLOPT_POSTFIELDS, buffer);
+	curl_easy_setopt(easy, CURLOPT_POSTFIELDSIZE, body_request_size - 1);
+	curl_easy_setopt(easy, CURLOPT_WRITEDATA, static_cast<loader_impl_rpc_write_data>(&write_data));
 
-	CURLcode res = curl_easy_perform(rpc_impl->invoke_curl);
+	CURLcode res = curl_easy_perform(easy);
+
+	curl_easy_cleanup(easy);
 
 	/* Clear the request buffer */
 	metacall_allocator_free(rpc_function->rpc_impl->allocator, buffer);
 
 	if (res != CURLE_OK)
 	{
-		log_write("metacall", LOG_LEVEL_ERROR, "Could not call to the API endpoint %s [%]", rpc_function->url.c_str(), curl_easy_strerror(res));
+		log_write("metacall", LOG_LEVEL_ERROR, "Could not call to the API endpoint %s [%s]", rpc_function->url.c_str(), curl_easy_strerror(res));
 		return NULL;
 	}
 
@@ -541,33 +557,10 @@ loader_impl_data rpc_loader_impl_initialize(loader_impl impl, configuration conf
 	curl_easy_setopt(rpc_impl->discover_curl, CURLOPT_HEADER, 0L);
 	curl_easy_setopt(rpc_impl->discover_curl, CURLOPT_WRITEFUNCTION, rpc_loader_impl_write_data);
 
-	/* Initialize invoke CURL object */
-	rpc_impl->invoke_curl = curl_easy_init();
-
-	if (rpc_impl->invoke_curl == NULL)
-	{
-		log_write("metacall", LOG_LEVEL_ERROR, "Could not create CURL invoke object");
-
-		curl_easy_cleanup(rpc_impl->discover_curl);
-
-		metacall_allocator_destroy(rpc_impl->allocator);
-
-		delete rpc_impl;
-
-		return NULL;
-	}
-
 	rpc_impl->headers = NULL;
 	rpc_impl->headers = curl_slist_append(rpc_impl->headers, "Accept: application/json");
 	rpc_impl->headers = curl_slist_append(rpc_impl->headers, "Content-Type: application/json");
 	rpc_impl->headers = curl_slist_append(rpc_impl->headers, "charset: utf-8");
-
-	curl_easy_setopt(rpc_impl->invoke_curl, CURLOPT_VERBOSE, CURL_VERBOSE);
-	curl_easy_setopt(rpc_impl->invoke_curl, CURLOPT_HEADER, 0L);
-	curl_easy_setopt(rpc_impl->invoke_curl, CURLOPT_CUSTOMREQUEST, "POST");
-	curl_easy_setopt(rpc_impl->invoke_curl, CURLOPT_HTTPHEADER, rpc_impl->headers);
-	curl_easy_setopt(rpc_impl->invoke_curl, CURLOPT_USERAGENT, "librpc_loader/0.1");
-	curl_easy_setopt(rpc_impl->invoke_curl, CURLOPT_WRITEFUNCTION, rpc_loader_impl_write_data);
 
 	/* Initialize async multi handle */
 	rpc_impl->async_multi = curl_multi_init();
@@ -577,7 +570,6 @@ loader_impl_data rpc_loader_impl_initialize(loader_impl impl, configuration conf
 		log_write("metacall", LOG_LEVEL_ERROR, "Could not create CURL multi handle for async");
 
 		curl_easy_cleanup(rpc_impl->discover_curl);
-		curl_easy_cleanup(rpc_impl->invoke_curl);
 		metacall_allocator_destroy(rpc_impl->allocator);
 		delete rpc_impl;
 
@@ -598,7 +590,6 @@ loader_impl_data rpc_loader_impl_initialize(loader_impl impl, configuration conf
 
 		curl_multi_cleanup(rpc_impl->async_multi);
 		curl_easy_cleanup(rpc_impl->discover_curl);
-		curl_easy_cleanup(rpc_impl->invoke_curl);
 		metacall_allocator_destroy(rpc_impl->allocator);
 		delete rpc_impl;
 
@@ -936,8 +927,6 @@ int rpc_loader_impl_destroy(loader_impl impl)
 	metacall_allocator_destroy(rpc_impl->allocator);
 
 	curl_easy_cleanup(rpc_impl->discover_curl);
-
-	curl_easy_cleanup(rpc_impl->invoke_curl);
 
 	curl_global_cleanup();
 

--- a/source/tests/metacall_rpc_test/source/metacall_rpc_test.cpp
+++ b/source/tests/metacall_rpc_test/source/metacall_rpc_test.cpp
@@ -553,3 +553,91 @@ TEST_F(metacall_rpc_test, ErrorUnderConcurrency)
 
 	metacall_destroy();
 }
+
+static const int SYNC_NUM_THREADS = 4;
+static const int SYNC_CALLS_PER_THREAD = 10;
+
+/* 
+ * I added this test to show the data race on shared curl handels in the rpc_interface_invoke function.
+ * If you build it with ThreadSanitizer (-DOPTION_BUILD_THREAD_SANITIZER=On), TSan should report a data race.
+ */
+TEST_F(metacall_rpc_test, ConcurrentSyncInvoke)
+{
+	ASSERT_EQ((int)0, (int)metacall_initialize());
+
+#if defined(OPTION_BUILD_LOADERS_RPC)
+	{
+		const char *rpc_scripts[] = { "remote.url" };
+		void *handle = NULL;
+
+		ASSERT_EQ((int)0, (int)metacall_load_from_file("rpc", rpc_scripts, 1, &handle));
+
+		ASSERT_NE((void *)NULL, (void *)handle);
+
+		std::atomic<int> sync_failures(0);
+		std::atomic<int> sync_mismatches(0);
+		std::vector<std::thread> threads;
+
+		for (int t = 0; t < SYNC_NUM_THREADS; t++)
+		{
+			threads.emplace_back([t, handle, &sync_failures, &sync_mismatches]() {
+				for (int i = 0; i < SYNC_CALLS_PER_THREAD; i++)
+				{
+					float a = static_cast<float>(t * 100 + i + 1);
+					float b = 1.0f;
+					float expected = a / b;
+
+					const enum metacall_value_id divide_ids[] = {
+						METACALL_FLOAT, METACALL_FLOAT
+					};
+
+					void *ret = metacallht_s(handle, "divide", divide_ids, 2, a, b);
+
+					if (ret == NULL)
+					{
+						std::cout << "    [SYNC FAIL] thread=" << t
+								  << " call=" << i
+								  << " ret=NULL" << std::endl;
+						sync_failures.fetch_add(1);
+						continue;
+					}
+
+					double actual = extract_numeric(ret);
+
+					if (actual < expected - 0.01 || actual > expected + 0.01)
+					{
+						std::cout << "    [SYNC MISMATCH] thread=" << t
+								  << " call=" << i
+								  << " expected=" << expected
+								  << " got=" << actual << std::endl;
+						sync_mismatches.fetch_add(1);
+					}
+
+					metacall_value_destroy(ret);
+				}
+
+				std::cout << "Thread " << t << ": completed "
+						  << SYNC_CALLS_PER_THREAD << " sync calls" << std::endl;
+			});
+		}
+
+		for (auto &th : threads)
+		{
+			th.join();
+		}
+
+		int total_calls = SYNC_NUM_THREADS * SYNC_CALLS_PER_THREAD;
+
+		std::cout << "ConcurrentSyncInvoke: total=" << total_calls
+				  << ", failures=" << sync_failures.load()
+				  << ", mismatches=" << sync_mismatches.load() << std::endl;
+
+		EXPECT_EQ(sync_failures.load(), 0) << "All sync calls should now  succeed";
+		EXPECT_EQ(sync_mismatches.load(), 0) << "All sync results should match expected values";
+
+		EXPECT_EQ((int)0, (int)metacall_clear(handle));
+	}
+#endif
+
+	metacall_destroy();
+}

--- a/source/tests/metacall_rpc_test/source/server.js
+++ b/source/tests/metacall_rpc_test/source/server.js
@@ -35,26 +35,43 @@ const server = http.createServer((req, res) => {
 	} else if (req.method === 'POST') {
 		if (req.url === '/viferga/example/v1/call/divide') {
 			data.then((body) => {
-				console.log('¡Call recieved!');
-				if (body !== '[50.0,10.0]') {
-					console.error('Invalid body:', body);
-					process.exit(1);
-				}
-				const result = '5.0';
+				console.log('Call received: divide', body);
+				const args = JSON.parse(body);
+				const result = args[0] / args[1];
 				res.setHeader('Content-Type', 'application/json');
-				res.end(result);
+				const str = Number.isInteger(result) ? result.toFixed(1) : JSON.stringify(result);
+				res.end(str);
+			});
+			return;
+		} else if (req.url === '/viferga/example/v1/call/sum') {
+			data.then((body) => {
+				console.log('Call received: sum', body);
+				const args = JSON.parse(body);
+				const result = args[0] + args[1];
+				res.setHeader('Content-Type', 'application/json');
+				res.end(JSON.stringify(result));
+			});
+			return;
+		} else if (req.url === '/viferga/example/v1/call/multiply') {
+			data.then((body) => {
+				console.log('Call received: multiply', body);
+				const args = JSON.parse(body);
+				const result = args[0] * args[1];
+				res.setHeader('Content-Type', 'application/json');
+				res.end(JSON.stringify(result));
 			});
 			return;
 		} else if (req.url === '/viferga/example/v1/await/async_divide') {
 			/* Async endpoint, simulates async operation with delay */
 			data.then((body) => {
-				console.log('¡Async call recieved!');
+				console.log('Async call received: async_divide', body);
 				const args = JSON.parse(body);
 				/* Simulate async processing with a small delay */
 				setTimeout(() => {
 					const result = args[0] / args[1];
 					res.setHeader('Content-Type', 'application/json');
-					res.end(JSON.stringify(result));
+					const str = Number.isInteger(result) ? result.toFixed(1) : JSON.stringify(result);
+					res.end(str);
 				}, 100);
 			});
 			return;


### PR DESCRIPTION
# Description

I added a test that spawns 4 threads making concurrent synchronous metacallht_s('divide') calls, which would then trigger the data race on the shared invoke_curl handle in function_rpc_interface_invoke.

Fixes #693 

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [x] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [x] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test &> output` and attached the output.
- [x] I have tested my code with `OPTION_BUILD_ADDRESS_SANITIZER` or `./docker-compose.sh test-address-sanitizer &> output` and `OPTION_TEST_MEMORYCHECK`.
- [x] I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer &> output`.
- [x] I have tested with `Helgrind` in case my code works with threading.
- [x] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
