### PR TITLE
Automated Ruby Gem release pipeline and Cross Platform CI fixes 

### DIFF
--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -31,70 +31,27 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install & Detect MetaCall (Unix)
+      - name: Install MetaCall (Unix)
         if: matrix.os != 'windows-latest'
         shell: bash
         run: |
           set +o pipefail
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
-          sudo mkdir -p /usr/local/lib
           
-          SEARCH_DIRS="$HOME /usr/local /opt"
-          [ -d "/gnu/store" ] && SEARCH_DIRS="$SEARCH_DIRS /gnu/store"
-          [ -d "/opt/homebrew" ] && SEARCH_DIRS="$SEARCH_DIRS /opt/homebrew"
-          
-          RAW_DIRS=$(find $SEARCH_DIRS -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)$' | xargs dirname 2>/dev/null | sort -u)
-          COMBINED_PATHS=$(echo "$RAW_DIRS" | paste -sd ":" - | sed 's/:$//')
-          
-          LIB_FILE=$(find $RAW_DIRS -name "libmetacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)$' | head -n 1)
-          LIB_DIR=$(dirname "$LIB_FILE")
-          
-          echo "METACALL_LIB_FILE=$LIB_FILE" >> $GITHUB_ENV
-          echo "METACALL_INSTALL_PATH=$LIB_DIR" >> $GITHUB_ENV
-          echo "LOADER_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
-          echo "SERIAL_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
-          echo "DETECTOR_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
-          echo "DYLD_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
-          echo "$LIB_DIR" >> $GITHUB_PATH
-          
-          sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.so" || true
-          sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.dylib" || true
-          [ "${{ matrix.os }}" == "ubuntu-latest" ] && sudo ldconfig "$LIB_DIR" || true
+          # We use the standard install path for Unix
+          echo "/usr/local/lib" >> $GITHUB_PATH
+          [ "${{ matrix.os }}" == "ubuntu-latest" ] && sudo ldconfig /usr/local/lib || true
 
-      - name: Install & Detect MetaCall (Windows)
+      - name: Install MetaCall (Windows)
         if: matrix.os == 'windows-latest'
         shell: powershell
         run: |
           [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
           &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))
           
-          $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
-          
-          $CoreFile = Get-ChildItem -Path $METACALL_DIR -Filter "metacall.dll" -Recurse | Select-Object -First 1
-          $RbLoader = Get-ChildItem -Path $METACALL_DIR -Filter "rb_loader.dll" -Recurse | Select-Object -First 1
-          $RubyRuntime = Get-ChildItem -Path $METACALL_DIR -Filter "x64-vcruntime140-ruby*.dll" -Recurse | Select-Object -First 1
-          
-          $PyHome = Join-Path $METACALL_DIR "runtimes\python"
-          if (-not (Test-Path $PyHome)) {
-             $LibDir = Get-ChildItem -Path $METACALL_DIR -Directory -Filter "Lib" -Recurse | Select-Object -First 1
-             $PyHome = if ($LibDir) { $LibDir.Parent.FullName } else { "$METACALL_DIR\lib" }
-          }
-          
-          $InstallDir = if ($CoreFile) { $CoreFile.DirectoryName } else { "$METACALL_DIR\lib" }
-          $LoaderDir  = if ($RbLoader) { $RbLoader.DirectoryName } else { $InstallDir }
-          
-          Add-Content -Path $env:GITHUB_ENV -Value "METACALL_LIB_FILE=$($CoreFile.FullName)" -Encoding Ascii
-          Add-Content -Path $env:GITHUB_ENV -Value "METACALL_INSTALL_PATH=$InstallDir" -Encoding Ascii
-          Add-Content -Path $env:GITHUB_ENV -Value "LOADER_LIBRARY_PATH=$LoaderDir" -Encoding Ascii
-          Add-Content -Path $env:GITHUB_ENV -Value "SERIAL_LIBRARY_PATH=$InstallDir" -Encoding Ascii
-          Add-Content -Path $env:GITHUB_ENV -Value "DETECTOR_LIBRARY_PATH=$InstallDir" -Encoding Ascii
-          Add-Content -Path $env:GITHUB_ENV -Value "PYTHONHOME=$PyHome" -Encoding Ascii
-          Add-Content -Path $env:GITHUB_ENV -Value "PYTHONPATH=$InstallDir" -Encoding Ascii
-          
-          Add-Content -Path $env:GITHUB_PATH -Value "$InstallDir" -Encoding Ascii
-          if ($RubyRuntime) { Add-Content -Path $env:GITHUB_PATH -Value "$($RubyRuntime.DirectoryName)" -Encoding Ascii }
-          Add-Content -Path $env:GITHUB_PATH -Value "$PyHome" -Encoding Ascii
+          # Add standard MetaCall installation directory to PATH
+          $METACALL_INSTALL_PATH = "$HOME\AppData\Local\MetaCall\metacall"
+          Add-Content -Path $env:GITHUB_PATH -Value "$METACALL_INSTALL_PATH" -Encoding Ascii
 
       - name: Set up Ruby Environment (Unix)
         if: matrix.os != 'windows-latest'
@@ -117,11 +74,6 @@ jobs:
         working-directory: source/ports/rb_port/test
         shell: pwsh
         run: |
-          $metacallDirs = Get-ChildItem "$env:USERPROFILE\AppData\Local\MetaCall" -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
-          $env:PATH = ($metacallDirs -join ";") + ";" + $env:PATH
-          $env:PYTHONHOME = "$env:PYTHONHOME"
-          $env:PYTHONPATH = "$env:PYTHONPATH"
-          
           $PyFile = Get-ChildItem -Path "../../../" -Filter "example.py" -Recurse | Select-Object -First 1
           $RbFile = Get-ChildItem -Path "../../../" -Filter "hello.rb" -Recurse | Select-Object -First 1
           if ($PyFile) { Copy-Item $PyFile.FullName . }

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -40,6 +40,7 @@ jobs:
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           sudo mkdir -p /usr/local/lib
           
+          echo "[DETECTION] Constructing Safe Search Paths..."
           SEARCH_DIRS="$HOME /usr/local /opt"
           [ -d "/gnu/store" ] && SEARCH_DIRS="$SEARCH_DIRS /gnu/store"
           [ -d "/opt/homebrew" ] && SEARCH_DIRS="$SEARCH_DIRS /opt/homebrew"
@@ -74,36 +75,38 @@ jobs:
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
           echo "[DETECTION] Hunting for components in $METACALL_DIR"
           
-          # ARCHITECTURAL FIX (Strategy: Find specific files then use paths)
+          # ARCHITECTURAL FIX: Use specific hunt for dependencies
           $CoreFile = Get-ChildItem -Path $METACALL_DIR -Filter "metacall.dll" -Recurse | Select-Object -First 1
           $RbLoader = Get-ChildItem -Path $METACALL_DIR -Filter "rb_loader.dll" -Recurse | Select-Object -First 1
-          $Serial   = Get-ChildItem -Path $METACALL_DIR -Filter "*serial.dll" -Recurse | Select-Object -First 1
+          
+          # Find MetaCall's bundled Ruby runtime directory (The "Friend" needed to fix Error 126)
+          $RubyRuntime = Get-ChildItem -Path $METACALL_DIR -Filter "x64-vcruntime140-ruby*.dll" -Recurse | Select-Object -First 1
           
           $InstallDir = if ($CoreFile) { $CoreFile.DirectoryName } else { "$METACALL_DIR\lib" }
           $LoaderDir  = if ($RbLoader) { $RbLoader.DirectoryName } else { $InstallDir }
-          $SerialDir  = if ($Serial)   { $Serial.DirectoryName }   else { $InstallDir }
           
-          # Find all unique DLL folders for the System PATH
-          $ALL_DIRS = Get-ChildItem -Path $METACALL_DIR -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
-          
-          echo "[DETECTION] SUCCESS: Core -> $InstallDir, Loader -> $LoaderDir"
+          echo "[DETECTION] SUCCESS: Core found at $InstallDir"
           
           # Export to GITHUB_ENV using ASCII
           Add-Content -Path $env:GITHUB_ENV -Value "METACALL_LIB_FILE=$($CoreFile.FullName)" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "METACALL_INSTALL_PATH=$InstallDir" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "LOADER_LIBRARY_PATH=$LoaderDir" -Encoding Ascii
-          Add-Content -Path $env:GITHUB_ENV -Value "SERIAL_LIBRARY_PATH=$SerialDir" -Encoding Ascii
+          Add-Content -Path $env:GITHUB_ENV -Value "SERIAL_LIBRARY_PATH=$InstallDir" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "DETECTOR_LIBRARY_PATH=$InstallDir" -Encoding Ascii
           
-          # Inject EVERY house into the Windows System PATH
-          foreach ($dir in $ALL_DIRS) {
-            Add-Content -Path $env:GITHUB_PATH -Value "$dir" -Encoding Ascii
+          # Inject the primary lib dir and the bundled Ruby runtime into PATH
+          Add-Content -Path $env:GITHUB_PATH -Value "$InstallDir" -Encoding Ascii
+          if ($RubyRuntime) {
+              $RubyRuntimeDir = $RubyRuntime.DirectoryName
+              echo "[DETECTION] Found MetaCall Ruby runtime at: $RubyRuntimeDir"
+              Add-Content -Path $env:GITHUB_PATH -Value "$RubyRuntimeDir" -Encoding Ascii
           }
 
       - name: "[FORENSIC] Step 2: Set up Ruby Environment"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          # Match MetaCall's bundled version for Windows to resolve transitive dependencies
+          ruby-version: ${{ matrix.os == 'windows-latest' && '3.5' || '3.2' }}
           bundler-cache: true
 
       - name: "[FORENSIC] Step 3: Global Environment Audit"
@@ -136,6 +139,10 @@ jobs:
         working-directory: source/ports/rb_port/test
         shell: pwsh
         run: |
+          # FORCE RE-INJECTION of all DLL folders into PATH to bypass flush issues
+          $metacallDirs = Get-ChildItem "$env:USERPROFILE\AppData\Local\MetaCall" -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
+          $env:PATH = ($metacallDirs -join ";") + ";" + $env:PATH
+          
           echo "[EXECUTION] Starting Windows Integration Tests..."
           cp ../../../scripts/python/example/source/example.py .
           cp ../../../scripts/ruby/hello/source/hello.rb .

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -37,34 +37,63 @@ jobs:
           echo "[DETECTION] Starting MetaCall Installation..."
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           
-          echo "[DETECTION] Locating MetaCall library files..."
-          # Find the actual library file (versioned)
-          LIB_FILE=$(find /usr/local/lib -name "libmetacall.so.*" -o -name "libmetacall.dylib.*" | head -n 1)
+          echo "[DETECTION] Locating MetaCall via Binary Beacon..."
+          METACALL_PATH=$(which metacall || echo "")
+          
+          if [ -z "$METACALL_PATH" ]; then
+            echo "WARNING: 'metacall' binary not in PATH. Searching in common locations..."
+            METACALL_PATH=$(find $HOME /usr/local/bin /opt -name "metacall" -type f -executable 2>/dev/null | head -n 1)
+          fi
+
+          if [ -z "$METACALL_PATH" ]; then
+            echo "ERROR: MetaCall binary NOT FOUND!"
+            exit 1
+          fi
+
+          echo "[DETECTION] Binary found at: $METACALL_PATH"
+          
+          # Follow the link to find the real installation root
+          REAL_PATH=$(readlink -f "$METACALL_PATH" 2>/dev/null || realpath "$METACALL_PATH" 2>/dev/null || echo "$METACALL_PATH")
+          INSTALL_ROOT=$(dirname $(dirname "$REAL_PATH"))
+          
+          echo "[DETECTION] Resolved Installation Root: $INSTALL_ROOT"
+          
+          # Find the actual library file within the resolved root
+          LIB_FILE=$(find "$INSTALL_ROOT" -name "libmetacall.so.*" -o -name "libmetacall.dylib.*" | head -n 1)
           
           if [ -z "$LIB_FILE" ]; then
-            echo "ERROR: MetaCall library NOT FOUND after installation!"
-            ls -la /usr/local/lib
+            echo "WARNING: Library not found in root. Performing broad search..."
+            LIB_FILE=$(find "$HOME" "/usr/local" "/opt" -name "libmetacall.so.*" -o -name "libmetacall.dylib.*" 2>/dev/null | head -n 1)
+          fi
+
+          if [ -z "$LIB_FILE" ]; then
+            echo "ERROR: MetaCall library NOT FOUND anywhere!"
             exit 1
           fi
           
-          echo "[DETECTION] Found library at: $LIB_FILE"
-          echo "METACALL_LIB_FILE=$LIB_FILE" >> $GITHUB_ENV
+          LIB_DIR=$(dirname "$LIB_FILE")
+          echo "[DETECTION] Library found at: $LIB_FILE"
+          echo "[DETECTION] Library Directory: $LIB_DIR"
           
-          # ARCHITECTURAL FIX: Force symbolic links
-          sudo ln -sf "$LIB_FILE" /usr/local/lib/libmetacall.so || true
-          sudo ln -sf "$LIB_FILE" /usr/local/lib/libmetacall.dylib || true
+          echo "METACALL_LIB_FILE=$LIB_FILE" >> $GITHUB_ENV
+          echo "METACALL_INSTALL_PATH=$LIB_DIR" >> $GITHUB_ENV
+          
+          # ARCHITECTURAL FIX: Force symbolic links in the detected lib dir
+          sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.so" || true
+          sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.dylib" || true
           
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-            sudo ldconfig
+            sudo ldconfig "$LIB_DIR"
           fi
 
           # Export full environment
-          echo "METACALL_INSTALL_PATH=/usr/local/lib" >> $GITHUB_ENV
-          echo "LOADER_LIBRARY_PATH=/usr/local/lib/metacall" >> $GITHUB_ENV
-          echo "SERIAL_LIBRARY_PATH=/usr/local/lib/metacall" >> $GITHUB_ENV
-          echo "DETECTOR_LIBRARY_PATH=/usr/local/lib/metacall" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
-          echo "DYLD_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
+          echo "$INSTALL_ROOT/bin" >> $GITHUB_PATH
+          echo "$LIB_DIR" >> $GITHUB_PATH
+          echo "LOADER_LIBRARY_PATH=$LIB_DIR/metacall" >> $GITHUB_ENV
+          echo "SERIAL_LIBRARY_PATH=$LIB_DIR/metacall" >> $GITHUB_ENV
+          echo "DETECTOR_LIBRARY_PATH=$LIB_DIR/metacall" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$LIB_DIR" >> $GITHUB_ENV
+          echo "DYLD_LIBRARY_PATH=$LIB_DIR" >> $GITHUB_ENV
 
       - name: "[FORENSIC] Step 1: Install MetaCall Core (Windows)"
         if: matrix.os == 'windows-latest'
@@ -75,7 +104,6 @@ jobs:
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
           echo "[DETECTION] MetaCall Directory: $METACALL_DIR"
           
-          # Verify installation
           if (Test-Path "$METACALL_DIR\lib\metacall.dll") {
             echo "[DETECTION] Found metacall.dll"
           } else {
@@ -101,42 +129,32 @@ jobs:
           echo "=== SYSTEM AUDIT START ==="
           echo "User: $(whoami)"
           echo "OS: ${{ matrix.os }}"
-          echo "Working Directory: $(pwd)"
           echo "Ruby Version: $(ruby -v)"
-          
-          echo "--- MetaCall Detection ---"
-          if [ -f "/usr/local/lib/libmetacall.so" ] || [ -f "/usr/local/lib/libmetacall.dylib" ]; then
-            echo "✅ Core Symbolic Link EXISTS"
-          else
-            echo "❌ Core Symbolic Link MISSING"
-          fi
-          
-          echo "--- Library Details ---"
-          ls -la /usr/local/lib/libmetacall* || echo "No metacall files found in /usr/local/lib"
-          
           echo "--- Environment Variable Check ---"
           echo "METACALL_INSTALL_PATH: $METACALL_INSTALL_PATH"
           echo "METACALL_LIB_FILE: $METACALL_LIB_FILE"
+          echo "LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
           
-          echo "--- Dynamic Linker Audit (Linux) ---"
-          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-            ldconfig -p | grep metacall || echo "Metacall not found in ldconfig cache"
-          fi
+          echo "--- Library Files (Detected Location) ---"
+          ls -la "$METACALL_INSTALL_PATH/libmetacall"* || echo "No metacall files found in detected path"
+          
+          echo "--- Binary Check ---"
+          which metacall
+          metacall --version || echo "metacall binary failed to execute"
           echo "=== SYSTEM AUDIT END ==="
 
-      - name: "[FORENSIC] Step 4: Run Ruby Tests (Direct Injection)"
+      - name: "[FORENSIC] Step 4: Run Ruby Tests (Direct Path Injection)"
         working-directory: source/ports/rb_port/test
         shell: bash
         env:
-          # Use the absolute versioned file path we detected in Step 1
           METACALL_LIBRARY_PATH: ${{ env.METACALL_LIB_FILE }}
         run: |
           echo "[EXECUTION] Starting Ruby Integration Tests..."
-          # Sync resources
           cp ../../../scripts/python/example/source/example.py .
           cp ../../../scripts/ruby/hello/source/hello.rb .
           
-          # Execute with manual library include
+          # Use the detected install path for the Ruby loader
+          export METACALL_INSTALL_PATH="${{ env.METACALL_INSTALL_PATH }}"
           ruby -I../package/lib run.rb
 
   release:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -96,7 +96,8 @@ jobs:
           
           echo "[DETECTION] SUCCESS: Discovered Map -> $COMBINED_PATHS"
           
-          # ARCHITECTURAL FIX: Use a simple loop with AppendAllText to ensure compatibility and NO-BOM UTF8
+          # ARCHITECTURAL FIX: Use Byte Injection to prevent BOM and encoding corruption
+          $Utf8NoBom = New-Object System.Text.UTF8Encoding $false
           $lines = @(
             "METACALL_LIB_FILE=$($LIB_FILE.FullName)",
             "METACALL_INSTALL_PATH=$LIB_DIR",
@@ -104,10 +105,14 @@ jobs:
             "SERIAL_LIBRARY_PATH=$COMBINED_PATHS",
             "DETECTOR_LIBRARY_PATH=$COMBINED_PATHS"
           )
+          
           foreach ($line in $lines) {
-            [System.IO.File]::AppendAllText($env:GITHUB_ENV, "$line`r`n")
+            $bytes = $Utf8NoBom.GetBytes("$line`n")
+            [System.IO.File]::AppendAllBytes($env:GITHUB_ENV, $bytes)
           }
-          [System.IO.File]::AppendAllText($env:GITHUB_PATH, "$LIB_DIR`r`n")
+          
+          $pathBytes = $Utf8NoBom.GetBytes("$LIB_DIR`n")
+          [System.IO.File]::AppendAllBytes($env:GITHUB_PATH, $pathBytes)
 
       - name: "[FORENSIC] Step 2: Set up Ruby Environment"
         uses: ruby/setup-ruby@v1
@@ -135,7 +140,6 @@ jobs:
         shell: bash
         run: |
           echo "[EXECUTION] Starting Integration Tests..."
-          # Reverting to the simple relative paths that worked before
           cp ../../../scripts/python/example/source/example.py . || true
           cp ../../../scripts/ruby/hello/source/hello.rb . || true
           

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -31,64 +31,25 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: "[FORENSIC] Step 1: Install & Detect MetaCall"
+      - name: "[FORENSIC] Step 1a: Install & Detect MetaCall (Unix)"
+        if: matrix.os != 'windows-latest'
         shell: bash
         run: |
-          # Disable strict pipe failures to prevent grep from killing the script
-          set +o pipefail
+          echo "[INSTALL] Starting MetaCall Setup for Unix..."
+          curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
+          sudo mkdir -p /usr/local/lib
           
-          echo "[INSTALL] Starting MetaCall Setup for ${{ matrix.os }}..."
+          echo "[DETECTION] Performing Global Component Hunt..."
+          # Find all unique directories containing MetaCall components
+          RAW_DIRS=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)$' | xargs dirname 2>/dev/null | sort -u)
           
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            powershell.exe -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
-          else
-            curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
-            sudo mkdir -p /usr/local/lib
-          fi
-          
-          echo "[DETECTION] Constructing Search Paths..."
-          SEARCH_DIRS="$HOME /usr/local /opt"
-          [ -d "/gnu/store" ] && SEARCH_DIRS="$SEARCH_DIRS /gnu/store"
-          [ -d "/opt/homebrew" ] && SEARCH_DIRS="$SEARCH_DIRS /opt/homebrew"
-          
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            WIN_PATH=$(cygpath "$USERPROFILE" 2>/dev/null || echo "C:/Users/runneradmin")
-            SEARCH_DIRS="$SEARCH_DIRS $WIN_PATH/AppData/Local/MetaCall"
-          fi
-
-          echo "[DETECTION] Hunting for Components in: $SEARCH_DIRS"
-          
-          # Find directories containing libraries
-          RAW_DIRS=$(find $SEARCH_DIRS -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib|dll)$' | xargs dirname 2>/dev/null | sort -u)
-          
-          if [ -z "$RAW_DIRS" ]; then
-            echo "WARNING: Broad search failed. Trying deep search in INSTALL_ROOT..."
-            METACALL_BIN=$(which metacall || echo "")
-            REAL_BIN=$(readlink -f "$METACALL_BIN" 2>/dev/null || echo "$METACALL_BIN")
-            INSTALL_ROOT=$(dirname $(dirname "$REAL_BIN"))
-            RAW_DIRS=$(find "$INSTALL_ROOT" -name "*metacall*" -type f 2>/dev/null | xargs dirname 2>/dev/null | sort -u)
-          fi
-
-          # Final check - if still empty, we have a real problem
-          if [ -z "$RAW_DIRS" ]; then
-            echo "ERROR: MetaCall components not found!"
-            exit 1
-          fi
-          
+          # Join paths with colons and strip trailing
           COMBINED_PATHS=$(echo "$RAW_DIRS" | paste -sd ":" - | sed 's/:$//')
           echo "[DETECTION] SUCCESS: Discovered Map -> $COMBINED_PATHS"
           
-          # Find the specific Core Library (using the pattern that worked for macOS ARM)
-          LIB_FILE=$(find $RAW_DIRS -name "libmetacall*" -o -name "metacall.dll" -type f 2>/dev/null | grep -E '\.(so|dylib|dll)$' | head -n 1)
-          
-          if [ -z "$LIB_FILE" ]; then
-             # Fallback to the first file in the first dir if exact match fails
-             FIRST_DIR=$(echo "$RAW_DIRS" | head -n 1)
-             LIB_FILE=$(ls "$FIRST_DIR"/*metacall* | head -n 1)
-          fi
-
+          # Find the specific Core Library
+          LIB_FILE=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "libmetacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)$' | head -n 1)
           LIB_DIR=$(dirname "$LIB_FILE")
-          echo "[DETECTION] Core Library: $LIB_FILE"
           
           # Export to GITHUB_ENV
           echo "METACALL_LIB_FILE=$LIB_FILE" >> $GITHUB_ENV
@@ -100,12 +61,41 @@ jobs:
           echo "DYLD_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
           echo "$LIB_DIR" >> $GITHUB_PATH
           
-          # Unix Links
-          if [[ "${{ matrix.os }}" != "windows-latest" ]]; then
-            sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.so" || true
-            sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.dylib" || true
-            [[ "${{ matrix.os }}" == "ubuntu-latest" ]] && sudo ldconfig "$LIB_DIR" || true
-          fi
+          # Link for Ruby
+          sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.so" || true
+          sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.dylib" || true
+          [ "${{ matrix.os }}" == "ubuntu-latest" ] && sudo ldconfig "$LIB_DIR" || true
+
+      - name: "[FORENSIC] Step 1b: Install & Detect MetaCall (Windows)"
+        if: matrix.os == 'windows-latest'
+        shell: powershell
+        run: |
+          echo "[INSTALL] Starting MetaCall Setup for Windows..."
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+          &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))
+          
+          $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
+          echo "[DETECTION] Hunting for components in $METACALL_DIR"
+          
+          # Native PowerShell detection to avoid encoding bugs
+          $LIB_FILE = Get-ChildItem -Path $METACALL_DIR -Filter "*metacall*.dll" -Recurse | Select-Object -First 1
+          $LIB_DIR = $LIB_FILE.DirectoryName
+          
+          # Find all plugin folders
+          $ALL_DIRS = Get-ChildItem -Path $METACALL_DIR -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
+          $COMBINED_PATHS = $ALL_DIRS -join ";"
+          
+          echo "[DETECTION] SUCCESS: Discovered Map -> $COMBINED_PATHS"
+          
+          # Export to GITHUB_ENV using UTF-8 to prevent the "Chinese Characters" bug
+          "METACALL_LIB_FILE=$($LIB_FILE.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "METACALL_INSTALL_PATH=$LIB_DIR" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "LOADER_LIBRARY_PATH=$COMBINED_PATHS" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "SERIAL_LIBRARY_PATH=$COMBINED_PATHS" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "DETECTOR_LIBRARY_PATH=$COMBINED_PATHS" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          
+          # Add to Path
+          $LIB_DIR | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
 
       - name: "[FORENSIC] Step 2: Set up Ruby Environment"
         uses: ruby/setup-ruby@v1
@@ -119,14 +109,12 @@ jobs:
           echo "=== SYSTEM AUDIT START ==="
           echo "OS: ${{ matrix.os }}"
           echo "INSTALL_PATH: $METACALL_INSTALL_PATH"
-          echo "LOADER_PATH: $LOADER_LIBRARY_PATH"
-          echo "--- Directory Verification ---"
-          IFS=':' read -ra ADDR <<< "$LOADER_LIBRARY_PATH"
+          echo "--- Directory Scan ---"
+          # Split path by : or ; depending on OS
+          IFS=$([[ "${{ matrix.os }}" == "windows-latest" ]] && echo ";" || echo ":")
+          read -ra ADDR <<< "$LOADER_LIBRARY_PATH"
           for i in "${ADDR[@]}"; do
-            if [ -d "$i" ]; then
-              echo "Found House: $i"
-              ls -la "$i" | grep -i metacall || true
-            fi
+            [ -d "$i" ] && echo "Found House: $i" && ls -la "$i" | grep -i metacall || true
           done
           echo "=== SYSTEM AUDIT END ==="
 
@@ -135,11 +123,9 @@ jobs:
         shell: bash
         run: |
           echo "[EXECUTION] Starting Integration Tests..."
-          # Standardize resource paths (using find to be safe)
-          PY_SRC=$(find ../../../source/scripts -name "example.py" | head -n 1)
-          RB_SRC=$(find ../../../source/scripts -name "hello.rb" | head -n 1)
-          cp "$PY_SRC" . || true
-          cp "$RB_SRC" . || true
+          # Reverting to the simple CP paths that worked before the regression
+          cp ../../../scripts/python/example/source/example.py . || true
+          cp ../../../scripts/ruby/hello/source/hello.rb . || true
           
           export METACALL_INSTALL_PATH="$METACALL_INSTALL_PATH"
           export LOADER_LIBRARY_PATH="$LOADER_LIBRARY_PATH"

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -35,9 +35,7 @@ jobs:
         if: matrix.os != 'windows-latest'
         shell: bash
         run: |
-          # Disable strict pipe failures to allow empty search results
           set +o pipefail
-          
           echo "[INSTALL] Starting MetaCall Setup for Unix..."
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           sudo mkdir -p /usr/local/lib
@@ -47,23 +45,12 @@ jobs:
           [ -d "/gnu/store" ] && SEARCH_DIRS="$SEARCH_DIRS /gnu/store"
           [ -d "/opt/homebrew" ] && SEARCH_DIRS="$SEARCH_DIRS /opt/homebrew"
           
-          echo "[DETECTION] Hunting for Components in: $SEARCH_DIRS"
-          # Find all unique directories containing MetaCall components
           RAW_DIRS=$(find $SEARCH_DIRS -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)$' | xargs dirname 2>/dev/null | sort -u)
-          
-          if [ -z "$RAW_DIRS" ]; then
-            echo "ERROR: No MetaCall components found!"
-            exit 1
-          fi
-          
           COMBINED_PATHS=$(echo "$RAW_DIRS" | paste -sd ":" - | sed 's/:$//')
-          echo "[DETECTION] SUCCESS: Discovered Map -> $COMBINED_PATHS"
           
-          # Find the specific Core Library
           LIB_FILE=$(find $RAW_DIRS -name "libmetacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)$' | head -n 1)
           LIB_DIR=$(dirname "$LIB_FILE")
           
-          # Export to GITHUB_ENV
           echo "METACALL_LIB_FILE=$LIB_FILE" >> $GITHUB_ENV
           echo "METACALL_INSTALL_PATH=$LIB_DIR" >> $GITHUB_ENV
           echo "LOADER_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
@@ -73,41 +60,31 @@ jobs:
           echo "DYLD_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
           echo "$LIB_DIR" >> $GITHUB_PATH
           
-          # Links for Ruby
           sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.so" || true
           sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.dylib" || true
           [ "${{ matrix.os }}" == "ubuntu-latest" ] && sudo ldconfig "$LIB_DIR" || true
 
       - name: "[FORENSIC] Step 1b: Install & Detect MetaCall (Windows)"
         if: matrix.os == 'windows-latest'
-        shell: pwsh
+        shell: powershell
         run: |
           echo "[INSTALL] Starting MetaCall Setup for Windows..."
           [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
           &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))
           
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
-          echo "[DETECTION] Hunting for components in $METACALL_DIR"
-          
           $LIB_FILE = Get-ChildItem -Path $METACALL_DIR -Filter "*metacall*.dll" -Recurse | Select-Object -First 1
           $LIB_DIR = $LIB_FILE.DirectoryName
           $ALL_DIRS = Get-ChildItem -Path $METACALL_DIR -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
           $COMBINED_PATHS = $ALL_DIRS -join ";"
           
-          echo "[DETECTION] SUCCESS: Discovered Map -> $COMBINED_PATHS"
-          
-          # STRATEGY A: Using pwsh (PowerShell Core) which is BOM-free by default
-          $lines = @(
-            "METACALL_LIB_FILE=$($LIB_FILE.FullName)",
-            "METACALL_INSTALL_PATH=$LIB_DIR",
-            "LOADER_LIBRARY_PATH=$COMBINED_PATHS",
-            "SERIAL_LIBRARY_PATH=$COMBINED_PATHS",
-            "DETECTOR_LIBRARY_PATH=$COMBINED_PATHS"
-          )
-          
-          # Writing to GITHUB_ENV and GITHUB_PATH using modern pwsh Out-File (BOM-less UTF8)
-          $lines | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          $LIB_DIR | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          # Use ASCII to ensure NO-BOM and fix Chinese characters in PowerShell 5.1
+          Add-Content -Path $env:GITHUB_ENV -Value "METACALL_LIB_FILE=$($LIB_FILE.FullName)" -Encoding Ascii
+          Add-Content -Path $env:GITHUB_ENV -Value "METACALL_INSTALL_PATH=$LIB_DIR" -Encoding Ascii
+          Add-Content -Path $env:GITHUB_ENV -Value "LOADER_LIBRARY_PATH=$COMBINED_PATHS" -Encoding Ascii
+          Add-Content -Path $env:GITHUB_ENV -Value "SERIAL_LIBRARY_PATH=$COMBINED_PATHS" -Encoding Ascii
+          Add-Content -Path $env:GITHUB_ENV -Value "DETECTOR_LIBRARY_PATH=$COMBINED_PATHS" -Encoding Ascii
+          Add-Content -Path $env:GITHUB_PATH -Value "$LIB_DIR" -Encoding Ascii
 
       - name: "[FORENSIC] Step 2: Set up Ruby Environment"
         uses: ruby/setup-ruby@v1
@@ -121,7 +98,6 @@ jobs:
           echo "=== SYSTEM AUDIT START ==="
           echo "OS: ${{ matrix.os }}"
           echo "INSTALL_PATH: $METACALL_INSTALL_PATH"
-          echo "LOADER_PATH: $LOADER_LIBRARY_PATH"
           echo "--- Directory Verification ---"
           SEP=$([[ "${{ matrix.os }}" == "windows-latest" ]] && echo ";" || echo ":")
           IFS=$SEP read -ra ADDR <<< "$LOADER_LIBRARY_PATH"
@@ -135,9 +111,9 @@ jobs:
         shell: bash
         run: |
           echo "[EXECUTION] Starting Integration Tests..."
-          # Fix: Include the /source/ prefix in the relative path
-          cp ../../../source/scripts/python/example/source/example.py . || true
-          cp ../../../source/scripts/ruby/hello/source/hello.rb . || true
+          # FIXED: Removed the extra 'source/' from the path
+          cp ../../../scripts/python/example/source/example.py . || true
+          cp ../../../scripts/ruby/hello/source/hello.rb . || true
           
           export METACALL_INSTALL_PATH="$METACALL_INSTALL_PATH"
           export LOADER_LIBRARY_PATH="$LOADER_LIBRARY_PATH"

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -45,40 +45,43 @@ jobs:
           REAL_BIN_PATH=$(readlink -f "$METACALL_BIN" 2>/dev/null || realpath "$METACALL_BIN" 2>/dev/null || echo "$METACALL_BIN")
           echo "[DETECTION] Physical Binary: $REAL_BIN_PATH"
           
-          echo "[DETECTION] Scoping the System for MetaCall Components (Guix Hunter Mode)..."
-          # Find ALL unique directories containing metacall shared objects
-          # We search broadly to find Core, Loaders, Serializers, and Detectors
-          ALL_METACALL_DIRS=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "lib*metacall*.so" -o -name "lib*metacall*.dylib" 2>/dev/null | xargs dirname | sort -u | tr '\n' ':')
+          echo "[DETECTION] Scoping the System for ALL MetaCall Components..."
+          # Find EVERY unique directory containing any MetaCall related library
+          # This catches Core, Loaders (rb, ext, etc), Serializers, and Detectors
+          ALL_METACALL_DIRS=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)' | xargs dirname | sort -u | tr '\n' ':')
           
           if [ -z "$ALL_METACALL_DIRS" ]; then
-            echo "ERROR: No MetaCall components found anywhere on the disk!"
+            echo "ERROR: No MetaCall components found anywhere on the system!"
             exit 1
           fi
           
-          echo "[DETECTION] Discovered MetaCall Component Map: $ALL_METACALL_DIRS"
+          echo "[DETECTION] Discovered Component Map: $ALL_METACALL_DIRS"
           
-          # Find the specific Core Library for the main path
-          LIB_FILE=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "libmetacall.so.*" -o -name "libmetacall.dylib.*" 2>/dev/null | head -n 1)
-          [ -z "$LIB_FILE" ] && LIB_FILE=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "libmetacall.so" -o -name "libmetacall.dylib" 2>/dev/null | head -n 1)
+          # Find the specific Core Library (The Heart) using fuzzy matching
+          # This catches libmetacall.so, libmetacalld.dylib, etc.
+          LIB_FILE=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "libmetacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)' | head -n 1)
+          
+          if [ -z "$LIB_FILE" ]; then
+            echo "ERROR: MetaCall Core Library NOT FOUND!"
+            exit 1
+          fi
           
           LIB_DIR=$(dirname "$LIB_FILE")
-          echo "[DETECTION] Core Library: $LIB_FILE"
-          echo "[DETECTION] Core Directory: $LIB_DIR"
+          echo "[DETECTION] SUCCESS: Found Core at $LIB_FILE"
           
           # Record for downstream
           echo "METACALL_LIB_FILE=$LIB_FILE" >> $GITHUB_ENV
           echo "METACALL_INSTALL_PATH=$LIB_DIR" >> $GITHUB_ENV
           
-          # Aggregate all discovered paths for the loaders
-          # Adding $LIB_DIR/metacall as a standard fallback
-          COMBINED_LOADER_PATHS="${ALL_METACALL_DIRS}${LIB_DIR}/metacall"
-          echo "LOADER_LIBRARY_PATH=$COMBINED_LOADER_PATHS" >> $GITHUB_ENV
-          echo "SERIAL_LIBRARY_PATH=$COMBINED_LOADER_PATHS" >> $GITHUB_ENV
-          echo "DETECTOR_LIBRARY_PATH=$COMBINED_LOADER_PATHS" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=$LIB_DIR" >> $GITHUB_ENV
-          echo "DYLD_LIBRARY_PATH=$LIB_DIR" >> $GITHUB_ENV
+          # CRITICAL FIX: Add both the root dirs AND potential subdirs to the loader path
+          # This forces the engine to check every possible "House"
+          echo "LOADER_LIBRARY_PATH=$ALL_METACALL_DIRS" >> $GITHUB_ENV
+          echo "SERIAL_LIBRARY_PATH=$ALL_METACALL_DIRS" >> $GITHUB_ENV
+          echo "DETECTOR_LIBRARY_PATH=$ALL_METACALL_DIRS" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$ALL_METACALL_DIRS" >> $GITHUB_ENV
+          echo "DYLD_LIBRARY_PATH=$ALL_METACALL_DIRS" >> $GITHUB_ENV
           
-          # Force Link: Create the exact names Ruby expects in the detected Core folder
+          # Link: Satisfy Ruby's find_library logic in the Core folder
           sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.so" || true
           sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.dylib" || true
           
@@ -90,7 +93,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           echo "[DETECTION] Starting MetaCall Installation on Windows..."
-          powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
+          powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
           echo "$METACALL_DIR\lib" >> $GITHUB_PATH
           echo "METACALL_INSTALL_PATH=$METACALL_DIR\lib" >> $GITHUB_ENV
@@ -105,19 +108,18 @@ jobs:
         shell: bash
         run: |
           echo "=== SYSTEM AUDIT START ==="
-          echo "Ruby Version: $(ruby -v)"
-          echo "METACALL_INSTALL_PATH: $METACALL_INSTALL_PATH"
-          echo "LOADER_LIBRARY_PATH: $LOADER_LIBRARY_PATH"
-          echo "--- Loader Verification ---"
-          # Check if the critical loaders exist in the discovered paths
+          echo "Ruby: $(ruby -v)"
+          echo "INSTALL_PATH: $METACALL_INSTALL_PATH"
+          echo "LOADER_PATH: $LOADER_LIBRARY_PATH"
+          echo "--- Directory Scan ---"
           IFS=':' read -ra ADDR <<< "$LOADER_LIBRARY_PATH"
           for i in "${ADDR[@]}"; do
-            echo "Checking: $i"
-            ls -la "$i" | grep -E 'librb_loader|libext_loader' || true
+            echo "Checking House: $i"
+            ls -la "$i" | grep -i metacall || true
           done
           echo "=== SYSTEM AUDIT END ==="
 
-      - name: "[FORENSIC] Step 4: Run Ruby Tests (Aggregated Injection)"
+      - name: "[FORENSIC] Step 4: Run Ruby Tests (Universal Injection)"
         working-directory: source/ports/rb_port/test
         shell: bash
         run: |
@@ -125,11 +127,11 @@ jobs:
           cp ../../../scripts/python/example/source/example.py .
           cp ../../../scripts/ruby/hello/source/hello.rb .
           
-          # Export the environment explicitly for this shell
+          # Inject the discovery map directly into the execution shell
           export METACALL_INSTALL_PATH="$METACALL_INSTALL_PATH"
           export LOADER_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
-          export SERIAL_LIBRARY_PATH="$SERIAL_LIBRARY_PATH"
-          export DETECTOR_LIBRARY_PATH="$DETECTOR_LIBRARY_PATH"
+          export SERIAL_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
+          export DETECTOR_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
           
           ruby -I../package/lib run.rb
 

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -37,64 +37,54 @@ jobs:
           echo "[DETECTION] Starting MetaCall Installation..."
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           
-          # Ensure critical directories exist
+          # Force create common paths
           sudo mkdir -p /usr/local/lib
           
-          echo "[DETECTION] Resolving MetaCall Binary..."
-          METACALL_BIN=$(which metacall || echo "")
-          
-          if [ -z "$METACALL_BIN" ]; then
-            echo "WARNING: Binary not in PATH. Broad search starting..."
-            METACALL_BIN=$(find /usr/local /opt $HOME -name "metacall" -type f -executable 2>/dev/null | head -n 1)
-          fi
-
-          # Follow the trail to the real physical binary (unwrapping symlinks/Guix wrappers)
+          echo "[DETECTION] Resolving MetaCall Binary Beacon..."
+          METACALL_BIN=$(which metacall || find /usr/local /opt $HOME -name "metacall" -type f -executable 2>/dev/null | head -n 1)
           REAL_BIN_PATH=$(readlink -f "$METACALL_BIN" 2>/dev/null || realpath "$METACALL_BIN" 2>/dev/null || echo "$METACALL_BIN")
-          echo "[DETECTION] Target Binary: $METACALL_BIN"
           echo "[DETECTION] Physical Binary: $REAL_BIN_PATH"
           
-          # STRATEGY 1: System Trace (ldd) - Linux Only
-          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-            echo "[DETECTION] Attempting ldd trace on $REAL_BIN_PATH..."
-            # Ask the OS: What library do you load when running this?
-            LIB_FILE=$(ldd "$REAL_BIN_PATH" 2>/dev/null | grep -i metacall | awk '{print $3}' | head -n 1)
-            [ ! -z "$LIB_FILE" ] && echo "[DETECTION] Trace Success: Found via ldd"
-          fi
-
-          # STRATEGY 2: Fuzzy Search Fallback (All Unix)
-          if [ -z "$LIB_FILE" ]; then
-            echo "[DETECTION] Falling back to Fuzzy Search for '*metacall*'..."
-            # Look in binary's own tree first
-            INSTALL_ROOT=$(dirname $(dirname "$REAL_BIN_PATH"))
-            LIB_FILE=$(find "$INSTALL_ROOT" "$HOME" "/usr/local/lib" "/opt" "/gnu/store" -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)' | head -n 1)
-          fi
-
-          if [ -z "$LIB_FILE" ]; then
-            echo "ERROR: MetaCall library NOT FOUND anywhere on the system!"
+          echo "[DETECTION] Scoping the System for MetaCall Components (Guix Hunter Mode)..."
+          # Find ALL unique directories containing metacall shared objects
+          # We search broadly to find Core, Loaders, Serializers, and Detectors
+          ALL_METACALL_DIRS=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "lib*metacall*.so" -o -name "lib*metacall*.dylib" 2>/dev/null | xargs dirname | sort -u | tr '\n' ':')
+          
+          if [ -z "$ALL_METACALL_DIRS" ]; then
+            echo "ERROR: No MetaCall components found anywhere on the disk!"
             exit 1
           fi
           
-          LIB_DIR=$(dirname "$LIB_FILE")
-          echo "[DETECTION] FINAL SUCCESS: Found library at $LIB_FILE"
+          echo "[DETECTION] Discovered MetaCall Component Map: $ALL_METACALL_DIRS"
           
-          # Record the specific detected file and dir
+          # Find the specific Core Library for the main path
+          LIB_FILE=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "libmetacall.so.*" -o -name "libmetacall.dylib.*" 2>/dev/null | head -n 1)
+          [ -z "$LIB_FILE" ] && LIB_FILE=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "libmetacall.so" -o -name "libmetacall.dylib" 2>/dev/null | head -n 1)
+          
+          LIB_DIR=$(dirname "$LIB_FILE")
+          echo "[DETECTION] Core Library: $LIB_FILE"
+          echo "[DETECTION] Core Directory: $LIB_DIR"
+          
+          # Record for downstream
           echo "METACALL_LIB_FILE=$LIB_FILE" >> $GITHUB_ENV
           echo "METACALL_INSTALL_PATH=$LIB_DIR" >> $GITHUB_ENV
           
-          # Force Link: Create the exact name Ruby expects in the detected folder
-          # This satisfies Ruby's strict find_library logic
+          # Aggregate all discovered paths for the loaders
+          # Adding $LIB_DIR/metacall as a standard fallback
+          COMBINED_LOADER_PATHS="${ALL_METACALL_DIRS}${LIB_DIR}/metacall"
+          echo "LOADER_LIBRARY_PATH=$COMBINED_LOADER_PATHS" >> $GITHUB_ENV
+          echo "SERIAL_LIBRARY_PATH=$COMBINED_LOADER_PATHS" >> $GITHUB_ENV
+          echo "DETECTOR_LIBRARY_PATH=$COMBINED_LOADER_PATHS" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$LIB_DIR" >> $GITHUB_ENV
+          echo "DYLD_LIBRARY_PATH=$LIB_DIR" >> $GITHUB_ENV
+          
+          # Force Link: Create the exact names Ruby expects in the detected Core folder
           sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.so" || true
           sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.dylib" || true
           
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
             sudo ldconfig "$LIB_DIR"
           fi
-
-          # Export full environment for downstream steps
-          echo "$LIB_DIR" >> $GITHUB_PATH
-          echo "LD_LIBRARY_PATH=$LIB_DIR" >> $GITHUB_ENV
-          echo "DYLD_LIBRARY_PATH=$LIB_DIR" >> $GITHUB_ENV
-          echo "LOADER_LIBRARY_PATH=$LIB_DIR/metacall" >> $GITHUB_ENV
 
       - name: "[FORENSIC] Step 1: Install MetaCall Core (Windows)"
         if: matrix.os == 'windows-latest'
@@ -111,19 +101,23 @@ jobs:
           ruby-version: '3.2'
           bundler-cache: true
 
-      - name: "[FORENSIC] Step 3: Global Environment Audit"
+      - name: "[FORENSIC] Step 3: Multi-Path Environment Audit"
         shell: bash
         run: |
-          echo "=== AUDIT START ==="
-          echo "Detected Lib File: $METACALL_LIB_FILE"
-          echo "Search Path: $METACALL_INSTALL_PATH"
-          echo "--- Directory Content ---"
-          ls -la "$METACALL_INSTALL_PATH" | grep -i metacall || echo "No metacall files in detected dir"
-          echo "--- Environment ---"
-          env | grep METACALL || true
-          echo "=== AUDIT END ==="
+          echo "=== SYSTEM AUDIT START ==="
+          echo "Ruby Version: $(ruby -v)"
+          echo "METACALL_INSTALL_PATH: $METACALL_INSTALL_PATH"
+          echo "LOADER_LIBRARY_PATH: $LOADER_LIBRARY_PATH"
+          echo "--- Loader Verification ---"
+          # Check if the critical loaders exist in the discovered paths
+          IFS=':' read -ra ADDR <<< "$LOADER_LIBRARY_PATH"
+          for i in "${ADDR[@]}"; do
+            echo "Checking: $i"
+            ls -la "$i" | grep -E 'librb_loader|libext_loader' || true
+          done
+          echo "=== SYSTEM AUDIT END ==="
 
-      - name: "[FORENSIC] Step 4: Run Ruby Tests (Direct Injection)"
+      - name: "[FORENSIC] Step 4: Run Ruby Tests (Aggregated Injection)"
         working-directory: source/ports/rb_port/test
         shell: bash
         run: |
@@ -131,8 +125,12 @@ jobs:
           cp ../../../scripts/python/example/source/example.py .
           cp ../../../scripts/ruby/hello/source/hello.rb .
           
-          # Force the loader to use our detected install path
+          # Export the environment explicitly for this shell
           export METACALL_INSTALL_PATH="$METACALL_INSTALL_PATH"
+          export LOADER_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
+          export SERIAL_LIBRARY_PATH="$SERIAL_LIBRARY_PATH"
+          export DETECTOR_LIBRARY_PATH="$DETECTOR_LIBRARY_PATH"
+          
           ruby -I../package/lib run.rb
 
   release:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -76,27 +76,19 @@ jobs:
           $RbLoader = Get-ChildItem -Path $METACALL_DIR -Filter "rb_loader.dll" -Recurse | Select-Object -First 1
           $RubyRuntime = Get-ChildItem -Path $METACALL_DIR -Filter "x64-vcruntime140-ruby*.dll" -Recurse | Select-Object -First 1
           
-          # ARCHITECTURAL FIX: Locate the TRUE Python Home (not just the DLL dir)
-          $PyHome = Join-Path $METACALL_DIR "runtimes\python"
-          if (-not (Test-Path $PyHome)) {
-             # Fallback to searching for the directory containing 'Lib'
-             $LibDir = Get-ChildItem -Path $METACALL_DIR -Directory -Filter "Lib" -Recurse | Select-Object -First 1
-             $PyHome = if ($LibDir) { $LibDir.Parent.FullName } else { "$METACALL_DIR\lib" }
-          }
+          $PyDll = Get-ChildItem -Path $METACALL_DIR -Filter "python*.dll" -Recurse | Select-Object -First 1
+          $PyHome = if ($PyDll) { $PyDll.DirectoryName } else { "$METACALL_DIR\runtimes\python" }
           
           $InstallDir = if ($CoreFile) { $CoreFile.DirectoryName } else { "$METACALL_DIR\lib" }
           $LoaderDir  = if ($RbLoader) { $RbLoader.DirectoryName } else { $InstallDir }
           
           echo "[DETECTION] SUCCESS: Core -> $InstallDir, PythonHome -> $PyHome"
           
-          # Export to GITHUB_ENV using ASCII
           Add-Content -Path $env:GITHUB_ENV -Value "METACALL_LIB_FILE=$($CoreFile.FullName)" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "METACALL_INSTALL_PATH=$InstallDir" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "LOADER_LIBRARY_PATH=$LoaderDir" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "SERIAL_LIBRARY_PATH=$InstallDir" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "DETECTOR_LIBRARY_PATH=$InstallDir" -Encoding Ascii
-          
-          # FIX: Export correct Python Home boundaries
           Add-Content -Path $env:GITHUB_ENV -Value "PYTHONHOME=$PyHome" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "PYTHONPATH=$InstallDir" -Encoding Ascii
           
@@ -135,9 +127,9 @@ jobs:
         shell: bash
         run: |
           echo "[EXECUTION] Starting Unix Integration Tests..."
-          # Fuzzy resource copy
-          cp $(find ../../../source/scripts -name "example.py" | head -n 1) . || true
-          cp $(find ../../../source/scripts -name "hello.rb" | head -n 1) . || true
+          # REVERTED: Using simple relative paths that worked before
+          cp ../../../scripts/python/example/source/example.py . || true
+          cp ../../../scripts/ruby/hello/source/hello.rb . || true
           ruby -I../package/lib run.rb
 
       - name: "[FORENSIC] Step 4b: Run Ruby Tests (Windows)"
@@ -145,21 +137,17 @@ jobs:
         working-directory: source/ports/rb_port/test
         shell: pwsh
         run: |
-          # FORCE RE-INJECTION of paths
+          # Keep Windows logic exactly as it is (it worked!)
           $metacallDirs = Get-ChildItem "$env:USERPROFILE\AppData\Local\MetaCall" -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
           $env:PATH = ($metacallDirs -join ";") + ";" + $env:PATH
-          
-          # Fix: Match the local shell env to the discovered Python home
           $env:PYTHONHOME = "$env:PYTHONHOME"
           $env:PYTHONPATH = "$env:PYTHONPATH"
           
           echo "[EXECUTION] Starting Windows Integration Tests (Polyglot Fixed)..."
-          # Standard resource copy for Windows
           $PyFile = Get-ChildItem -Path "../../../" -Filter "example.py" -Recurse | Select-Object -First 1
           $RbFile = Get-ChildItem -Path "../../../" -Filter "hello.rb" -Recurse | Select-Object -First 1
           if ($PyFile) { Copy-Item $PyFile.FullName . }
           if ($RbFile) { Copy-Item $RbFile.FullName . }
-          
           ruby -I../package/lib run.rb
 
   release:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -36,17 +36,17 @@ jobs:
         run: |
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           
-          # ARCHITECTURAL FIX: Create a symbolic link to bypass the strict regex in metacall.rb
-          # This maps 'libmetacall.so.0.x.y' to 'libmetacall.so' so the Ruby script can find it.
-          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-            sudo ln -sf /usr/local/lib/libmetacall.so.* /usr/local/lib/libmetacall.so || true
-          else
-            sudo ln -sf /usr/local/lib/libmetacall.dylib.* /usr/local/lib/libmetacall.dylib || true
-          fi
-
+          # ARCHITECTURAL FIX: Force symbolic links for the strict Ruby regex
+          # We search for the versioned file and link it to the plain name
+          sudo find /usr/local/lib -name "libmetacall.so.*" -exec ln -sf {} /usr/local/lib/libmetacall.so \; || true
+          sudo find /usr/local/lib -name "libmetacall.dylib.*" -exec ln -sf {} /usr/local/lib/libmetacall.dylib \; || true
+          
+          # Define the full environment for the MetaCall Core
           echo "/usr/local/lib" >> $GITHUB_PATH
           echo "METACALL_INSTALL_PATH=/usr/local/lib" >> $GITHUB_ENV
-          echo "LOADER_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
+          echo "LOADER_LIBRARY_PATH=/usr/local/lib/metacall" >> $GITHUB_ENV
+          echo "SERIAL_LIBRARY_PATH=/usr/local/lib/metacall" >> $GITHUB_ENV
+          echo "DETECTOR_LIBRARY_PATH=/usr/local/lib/metacall" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
           echo "DYLD_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
 
@@ -54,14 +54,16 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
-          
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
+          
+          # Force the entire MetaCall tree into the Windows Path
           echo "$METACALL_DIR" >> $GITHUB_PATH
           echo "$METACALL_DIR\lib" >> $GITHUB_PATH
           
-          # Set the variables for the Windows Ruby loader
+          # Critical Windows environment variables
           echo "METACALL_INSTALL_PATH=$METACALL_DIR\lib" >> $GITHUB_ENV
           echo "METACALL_PATH=$METACALL_DIR" >> $GITHUB_ENV
+          echo "LOADER_LIBRARY_PATH=$METACALL_DIR\lib" >> $GITHUB_ENV
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -74,6 +76,17 @@ jobs:
         run: |
           cp source/scripts/python/example/source/example.py source/ports/rb_port/test/
           cp source/scripts/ruby/hello/source/hello.rb source/ports/rb_port/test/
+
+      - name: Environment Audit (Debug)
+        shell: bash
+        run: |
+          echo "--- PATH ---"
+          echo $PATH
+          echo "--- MetaCall Version ---"
+          metacall --version || echo "metacall binary not in path"
+          echo "--- Library Files ---"
+          ls /usr/local/lib/libmetacall* || true
+          ls $HOME/AppData/Local/MetaCall/metacall/lib/metacall* || true
 
       - name: Test the Ruby Port
         working-directory: source/ports/rb_port/test

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -35,20 +35,33 @@ jobs:
         if: matrix.os != 'windows-latest'
         shell: bash
         run: |
+          # Disable strict pipe failures to allow empty search results
+          set +o pipefail
+          
           echo "[INSTALL] Starting MetaCall Setup for Unix..."
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           sudo mkdir -p /usr/local/lib
           
-          echo "[DETECTION] Performing Global Component Hunt..."
-          # Find all unique directories containing MetaCall components
-          RAW_DIRS=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)$' | xargs dirname 2>/dev/null | sort -u)
+          echo "[DETECTION] Constructing Safe Search Paths..."
+          SEARCH_DIRS="$HOME /usr/local /opt"
+          [ -d "/gnu/store" ] && SEARCH_DIRS="$SEARCH_DIRS /gnu/store"
+          [ -d "/opt/homebrew" ] && SEARCH_DIRS="$SEARCH_DIRS /opt/homebrew"
           
-          # Join paths with colons and strip trailing
+          echo "[DETECTION] Hunting for Components in: $SEARCH_DIRS"
+          # Find all unique directories containing MetaCall components
+          # We use fuzzy *metacall* to catch debug versions like libmetacalld.dylib
+          RAW_DIRS=$(find $SEARCH_DIRS -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)$' | xargs dirname 2>/dev/null | sort -u)
+          
+          if [ -z "$RAW_DIRS" ]; then
+            echo "ERROR: No MetaCall components found!"
+            exit 1
+          fi
+          
           COMBINED_PATHS=$(echo "$RAW_DIRS" | paste -sd ":" - | sed 's/:$//')
           echo "[DETECTION] SUCCESS: Discovered Map -> $COMBINED_PATHS"
           
           # Find the specific Core Library
-          LIB_FILE=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "libmetacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)$' | head -n 1)
+          LIB_FILE=$(find $RAW_DIRS -name "libmetacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)$' | head -n 1)
           LIB_DIR=$(dirname "$LIB_FILE")
           
           # Export to GITHUB_ENV
@@ -61,7 +74,7 @@ jobs:
           echo "DYLD_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
           echo "$LIB_DIR" >> $GITHUB_PATH
           
-          # Link for Ruby
+          # Links for Ruby
           sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.so" || true
           sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.dylib" || true
           [ "${{ matrix.os }}" == "ubuntu-latest" ] && sudo ldconfig "$LIB_DIR" || true
@@ -77,25 +90,24 @@ jobs:
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
           echo "[DETECTION] Hunting for components in $METACALL_DIR"
           
-          # Native PowerShell detection to avoid encoding bugs
           $LIB_FILE = Get-ChildItem -Path $METACALL_DIR -Filter "*metacall*.dll" -Recurse | Select-Object -First 1
           $LIB_DIR = $LIB_FILE.DirectoryName
-          
-          # Find all plugin folders
           $ALL_DIRS = Get-ChildItem -Path $METACALL_DIR -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
           $COMBINED_PATHS = $ALL_DIRS -join ";"
           
           echo "[DETECTION] SUCCESS: Discovered Map -> $COMBINED_PATHS"
           
-          # Export to GITHUB_ENV using UTF-8 to prevent the "Chinese Characters" bug
-          "METACALL_LIB_FILE=$($LIB_FILE.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          "METACALL_INSTALL_PATH=$LIB_DIR" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          "LOADER_LIBRARY_PATH=$COMBINED_PATHS" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          "SERIAL_LIBRARY_PATH=$COMBINED_PATHS" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          "DETECTOR_LIBRARY_PATH=$COMBINED_PATHS" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          # ARCHITECTURAL FIX: Use UTF-8 WITHOUT BOM to prevent the "Chinese Characters" bug
+          $Utf8NoBom = New-Object System.Text.UTF8Encoding $false
+          [System.IO.File]::AppendAllLines($env:GITHUB_ENV, @(
+            "METACALL_LIB_FILE=$($LIB_FILE.FullName)",
+            "METACALL_INSTALL_PATH=$LIB_DIR",
+            "LOADER_LIBRARY_PATH=$COMBINED_PATHS",
+            "SERIAL_LIBRARY_PATH=$COMBINED_PATHS",
+            "DETECTOR_LIBRARY_PATH=$COMBINED_PATHS"
+          ), $Utf8NoBom)
           
-          # Add to Path
-          $LIB_DIR | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          [System.IO.File]::AppendAllLines($env:GITHUB_PATH, @($LIB_DIR), $Utf8NoBom)
 
       - name: "[FORENSIC] Step 2: Set up Ruby Environment"
         uses: ruby/setup-ruby@v1
@@ -109,10 +121,10 @@ jobs:
           echo "=== SYSTEM AUDIT START ==="
           echo "OS: ${{ matrix.os }}"
           echo "INSTALL_PATH: $METACALL_INSTALL_PATH"
-          echo "--- Directory Scan ---"
-          # Split path by : or ; depending on OS
-          IFS=$([[ "${{ matrix.os }}" == "windows-latest" ]] && echo ";" || echo ":")
-          read -ra ADDR <<< "$LOADER_LIBRARY_PATH"
+          echo "LOADER_PATH: $LOADER_LIBRARY_PATH"
+          echo "--- Directory Verification ---"
+          SEP=$([[ "${{ matrix.os }}" == "windows-latest" ]] && echo ";" || echo ":")
+          IFS=$SEP read -ra ADDR <<< "$LOADER_LIBRARY_PATH"
           for i in "${ADDR[@]}"; do
             [ -d "$i" ] && echo "Found House: $i" && ls -la "$i" | grep -i metacall || true
           done
@@ -123,7 +135,7 @@ jobs:
         shell: bash
         run: |
           echo "[EXECUTION] Starting Integration Tests..."
-          # Reverting to the simple CP paths that worked before the regression
+          # Reverting to the simple relative paths that worked before
           cp ../../../scripts/python/example/source/example.py . || true
           cp ../../../scripts/ruby/hello/source/hello.rb . || true
           

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install MetaCall (Unix)
+      - name: Install & Detect MetaCall (Unix)
         if: matrix.os != 'windows-latest'
         shell: bash
         run: |
@@ -39,7 +39,6 @@ jobs:
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           sudo mkdir -p /usr/local/lib
           
-          # Discovery logic for distributed Guix/Homebrew components
           SEARCH_DIRS="$HOME /usr/local /opt"
           [ -d "/gnu/store" ] && SEARCH_DIRS="$SEARCH_DIRS /gnu/store"
           [ -d "/opt/homebrew" ] && SEARCH_DIRS="$SEARCH_DIRS /opt/homebrew"
@@ -63,7 +62,7 @@ jobs:
           sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.dylib" || true
           [ "${{ matrix.os }}" == "ubuntu-latest" ] && sudo ldconfig "$LIB_DIR" || true
 
-      - name: Install MetaCall (Windows)
+      - name: Install & Detect MetaCall (Windows)
         if: matrix.os == 'windows-latest'
         shell: powershell
         run: |
@@ -71,6 +70,7 @@ jobs:
           &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))
           
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
+          
           $CoreFile = Get-ChildItem -Path $METACALL_DIR -Filter "metacall.dll" -Recurse | Select-Object -First 1
           $RbLoader = Get-ChildItem -Path $METACALL_DIR -Filter "rb_loader.dll" -Recurse | Select-Object -First 1
           $RubyRuntime = Get-ChildItem -Path $METACALL_DIR -Filter "x64-vcruntime140-ruby*.dll" -Recurse | Select-Object -First 1
@@ -108,8 +108,8 @@ jobs:
         working-directory: source/ports/rb_port/test
         shell: bash
         run: |
-          cp $(find ../../../ -name "example.py" | head -n 1) . || true
-          cp $(find ../../../ -name "hello.rb" | head -n 1) . || true
+          cp ../../../scripts/python/example/source/example.py . || true
+          cp ../../../scripts/ruby/hello/source/hello.rb . || true
           ruby -I../package/lib run.rb
 
       - name: Run Integration Tests (Windows)
@@ -117,7 +117,6 @@ jobs:
         working-directory: source/ports/rb_port/test
         shell: pwsh
         run: |
-          # Native pwsh test step to resolve DLL dependencies and avoid Git Bash path issues
           $metacallDirs = Get-ChildItem "$env:USERPROFILE\AppData\Local\MetaCall" -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
           $env:PATH = ($metacallDirs -join ";") + ";" + $env:PATH
           $env:PYTHONHOME = "$env:PYTHONHOME"

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -40,7 +40,6 @@ jobs:
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           sudo mkdir -p /usr/local/lib
           
-          echo "[DETECTION] Constructing Safe Search Paths..."
           SEARCH_DIRS="$HOME /usr/local /opt"
           [ -d "/gnu/store" ] && SEARCH_DIRS="$SEARCH_DIRS /gnu/store"
           [ -d "/opt/homebrew" ] && SEARCH_DIRS="$SEARCH_DIRS /opt/homebrew"
@@ -75,17 +74,15 @@ jobs:
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
           echo "[DETECTION] Hunting for components in $METACALL_DIR"
           
-          # ARCHITECTURAL FIX: Use specific hunt for dependencies
+          # ARCHITECTURAL FIX: Use MetaCall's internal Ruby 3.5 instead of setup-ruby
           $CoreFile = Get-ChildItem -Path $METACALL_DIR -Filter "metacall.dll" -Recurse | Select-Object -First 1
           $RbLoader = Get-ChildItem -Path $METACALL_DIR -Filter "rb_loader.dll" -Recurse | Select-Object -First 1
-          
-          # Find MetaCall's bundled Ruby runtime directory (The "Friend" needed to fix Error 126)
           $RubyRuntime = Get-ChildItem -Path $METACALL_DIR -Filter "x64-vcruntime140-ruby*.dll" -Recurse | Select-Object -First 1
           
           $InstallDir = if ($CoreFile) { $CoreFile.DirectoryName } else { "$METACALL_DIR\lib" }
           $LoaderDir  = if ($RbLoader) { $RbLoader.DirectoryName } else { $InstallDir }
           
-          echo "[DETECTION] SUCCESS: Core found at $InstallDir"
+          echo "[DETECTION] SUCCESS: Core -> $InstallDir"
           
           # Export to GITHUB_ENV using ASCII
           Add-Content -Path $env:GITHUB_ENV -Value "METACALL_LIB_FILE=$($CoreFile.FullName)" -Encoding Ascii
@@ -94,7 +91,7 @@ jobs:
           Add-Content -Path $env:GITHUB_ENV -Value "SERIAL_LIBRARY_PATH=$InstallDir" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "DETECTOR_LIBRARY_PATH=$InstallDir" -Encoding Ascii
           
-          # Inject the primary lib dir and the bundled Ruby runtime into PATH
+          # Ensure both the main lib and the bundled Ruby runtime are in the PATH
           Add-Content -Path $env:GITHUB_PATH -Value "$InstallDir" -Encoding Ascii
           if ($RubyRuntime) {
               $RubyRuntimeDir = $RubyRuntime.DirectoryName
@@ -102,11 +99,11 @@ jobs:
               Add-Content -Path $env:GITHUB_PATH -Value "$RubyRuntimeDir" -Encoding Ascii
           }
 
-      - name: "[FORENSIC] Step 2: Set up Ruby Environment"
+      - name: "[FORENSIC] Step 2: Set up Ruby Environment (Unix Only)"
+        if: matrix.os != 'windows-latest'
         uses: ruby/setup-ruby@v1
         with:
-          # Match MetaCall's bundled version for Windows to resolve transitive dependencies
-          ruby-version: ${{ matrix.os == 'windows-latest' && '3.5' || '3.2' }}
+          ruby-version: '3.2'
           bundler-cache: true
 
       - name: "[FORENSIC] Step 3: Global Environment Audit"
@@ -139,11 +136,11 @@ jobs:
         working-directory: source/ports/rb_port/test
         shell: pwsh
         run: |
-          # FORCE RE-INJECTION of all DLL folders into PATH to bypass flush issues
+          # FORCE RE-INJECTION of every DLL folder into PATH
           $metacallDirs = Get-ChildItem "$env:USERPROFILE\AppData\Local\MetaCall" -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
           $env:PATH = ($metacallDirs -join ";") + ";" + $env:PATH
           
-          echo "[EXECUTION] Starting Windows Integration Tests..."
+          echo "[EXECUTION] Starting Windows Integration Tests (Bundled Ruby)..."
           cp ../../../scripts/python/example/source/example.py .
           cp ../../../scripts/ruby/hello/source/hello.rb .
           ruby -I../package/lib run.rb

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -76,8 +76,12 @@ jobs:
           $RbLoader = Get-ChildItem -Path $METACALL_DIR -Filter "rb_loader.dll" -Recurse | Select-Object -First 1
           $RubyRuntime = Get-ChildItem -Path $METACALL_DIR -Filter "x64-vcruntime140-ruby*.dll" -Recurse | Select-Object -First 1
           
-          $PyDll = Get-ChildItem -Path $METACALL_DIR -Filter "python*.dll" -Recurse | Select-Object -First 1
-          $PyHome = if ($PyDll) { $PyDll.DirectoryName } else { "$METACALL_DIR\runtimes\python" }
+          # ARCHITECTURAL FIX: Restore the working Python Home detection
+          $PyHome = Join-Path $METACALL_DIR "runtimes\python"
+          if (-not (Test-Path $PyHome)) {
+             $LibDir = Get-ChildItem -Path $METACALL_DIR -Directory -Filter "Lib" -Recurse | Select-Object -First 1
+             $PyHome = if ($LibDir) { $LibDir.Parent.FullName } else { "$METACALL_DIR\lib" }
+          }
           
           $InstallDir = if ($CoreFile) { $CoreFile.DirectoryName } else { "$METACALL_DIR\lib" }
           $LoaderDir  = if ($RbLoader) { $RbLoader.DirectoryName } else { $InstallDir }
@@ -127,7 +131,6 @@ jobs:
         shell: bash
         run: |
           echo "[EXECUTION] Starting Unix Integration Tests..."
-          # REVERTED: Using simple relative paths that worked before
           cp ../../../scripts/python/example/source/example.py . || true
           cp ../../../scripts/ruby/hello/source/hello.rb . || true
           ruby -I../package/lib run.rb
@@ -137,7 +140,6 @@ jobs:
         working-directory: source/ports/rb_port/test
         shell: pwsh
         run: |
-          # Keep Windows logic exactly as it is (it worked!)
           $metacallDirs = Get-ChildItem "$env:USERPROFILE\AppData\Local\MetaCall" -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
           $env:PATH = ($metacallDirs -join ";") + ";" + $env:PATH
           $env:PYTHONHOME = "$env:PYTHONHOME"

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -31,50 +31,52 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: "[FORENSIC] Step 1: Install & Detect MetaCall (Unix/Windows)"
+      - name: "[FORENSIC] Step 1: Install & Detect MetaCall"
         shell: bash
         run: |
-          echo "[DETECTION] Starting MetaCall Installation for ${{ matrix.os }}..."
+          echo "[INSTALL] Starting MetaCall Setup for ${{ matrix.os }}..."
           
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            # Run Windows Installer via PowerShell inside Bash
             powershell.exe -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
           else
-            # Run Unix Installer
             curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
             sudo mkdir -p /usr/local/lib
           fi
           
-          echo "[DETECTION] Scoping the System for ALL MetaCall Components (Fuzzy Search)..."
-          # Find EVERY unique directory containing any MetaCall related library (.so, .dylib, or .dll)
-          # We search broadly including the Guix store, opt, home, and AppData
-          RAW_DIRS=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib|dll)' | xargs dirname | sort -u)
+          echo "[DETECTION] Constructing Safe Search Paths..."
+          # Build list of directories that actually exist
+          SEARCH_DIRS="$HOME /usr/local /opt"
+          [ -d "/gnu/store" ] && SEARCH_DIRS="$SEARCH_DIRS /gnu/store"
+          [ -d "/opt/homebrew" ] && SEARCH_DIRS="$SEARCH_DIRS /opt/homebrew"
+          
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            # Map Windows AppData to Bash path
+            WIN_PATH=$(cygpath "$USERPROFILE")
+            SEARCH_DIRS="$SEARCH_DIRS $WIN_PATH/AppData/Local/MetaCall"
+          fi
+
+          echo "[DETECTION] Hunting for MetaCall Components in: $SEARCH_DIRS"
+          
+          # Find all unique directories containing any MetaCall library
+          # Wrap in || true to prevent 'grep' from failing the step if no files are found yet
+          RAW_DIRS=$(find $SEARCH_DIRS -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib|dll)$' | xargs dirname 2>/dev/null | sort -u || true)
           
           if [ -z "$RAW_DIRS" ]; then
-            echo "ERROR: No MetaCall components found anywhere on the system!"
+            echo "ERROR: Detection failed to find any MetaCall components!"
             exit 1
           fi
           
-          # Join paths with colons (or semicolons for Windows if necessary, but MetaCall usually handles colons in LOADER_PATH)
-          COMBINED_PATHS=$(echo "$RAW_DIRS" | paste -sd ":" -)
-          echo "[DETECTION] Discovered Component Map: $COMBINED_PATHS"
+          # Join paths with colons and ensure NO trailing colon
+          COMBINED_PATHS=$(echo "$RAW_DIRS" | paste -sd ":" - | sed 's/:$//')
+          echo "[DETECTION] SUCCESS: Discovered Map -> $COMBINED_PATHS"
           
-          # Find the specific Core Library (The Heart) using fuzzy matching
-          LIB_FILE=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "libmetacall*" -o -name "metacall.dll" 2>/dev/null | grep -E '\.(so|dylib|dll)' | head -n 1)
-          
-          if [ -z "$LIB_FILE" ]; then
-            echo "ERROR: MetaCall Core Library NOT FOUND!"
-            exit 1
-          fi
-          
+          # Identify the main Core Library
+          LIB_FILE=$(find $SEARCH_DIRS \( -name "libmetacall*" -o -name "metacall.dll" \) -type f 2>/dev/null | grep -E '\.(so|dylib|dll)$' | head -n 1 || true)
           LIB_DIR=$(dirname "$LIB_FILE")
-          echo "[DETECTION] SUCCESS: Found Core at $LIB_FILE"
           
-          # Record for downstream steps
+          # Export to GITHUB_ENV
           echo "METACALL_LIB_FILE=$LIB_FILE" >> $GITHUB_ENV
           echo "METACALL_INSTALL_PATH=$LIB_DIR" >> $GITHUB_ENV
-          
-          # Inject the clean combined path map into ALL MetaCall environment variables
           echo "LOADER_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
           echo "SERIAL_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
           echo "DETECTOR_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
@@ -82,13 +84,11 @@ jobs:
           echo "DYLD_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
           echo "$LIB_DIR" >> $GITHUB_PATH
           
-          # Unix-only Linking & Ldconfig
+          # Link for Ruby loader (Unix only)
           if [[ "${{ matrix.os }}" != "windows-latest" ]]; then
             sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.so" || true
             sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.dylib" || true
-            if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-               sudo ldconfig "$LIB_DIR"
-            fi
+            [ "${{ matrix.os }}" == "ubuntu-latest" ] && sudo ldconfig "$LIB_DIR"
           fi
 
       - name: "[FORENSIC] Step 2: Set up Ruby Environment"
@@ -102,34 +102,25 @@ jobs:
         run: |
           echo "=== SYSTEM AUDIT START ==="
           echo "OS: ${{ matrix.os }}"
-          echo "Ruby: $(ruby -v)"
           echo "INSTALL_PATH: $METACALL_INSTALL_PATH"
           echo "LOADER_PATH: $LOADER_LIBRARY_PATH"
-          echo "--- Component Scan ---"
+          echo "--- Directory Verification ---"
           IFS=':' read -ra ADDR <<< "$LOADER_LIBRARY_PATH"
           for i in "${ADDR[@]}"; do
-            if [ -d "$i" ]; then
-              echo "Checking House: $i"
-              ls -la "$i" | grep -i metacall || true
-            fi
+            [ -d "$i" ] && echo "Found House: $i" && ls -la "$i" | grep -i metacall || true
           done
           echo "=== SYSTEM AUDIT END ==="
 
-      - name: "[FORENSIC] Step 4: Run Ruby Tests (Universal Injection)"
+      - name: "[FORENSIC] Step 4: Run Ruby Tests (Resilient Injection)"
         working-directory: source/ports/rb_port/test
         shell: bash
         run: |
-          echo "[EXECUTION] Executing Ruby Integration Suite..."
-          # Windows specific sync
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-             cp ../../../source/scripts/python/example/source/example.py .
-             cp ../../../source/scripts/ruby/hello/source/hello.rb .
-          else
-             cp ../../../scripts/python/example/source/example.py .
-             cp ../../../scripts/ruby/hello/source/hello.rb .
-          fi
+          echo "[EXECUTION] Starting Integration Tests..."
+          # Standardize resource paths
+          cp ../../../source/scripts/python/example/source/example.py . || cp ../../../scripts/python/example/source/example.py .
+          cp ../../../source/scripts/ruby/hello/source/hello.rb . || cp ../../../scripts/ruby/hello/source/hello.rb .
           
-          # Force the loader to use our detected install path
+          # Explicitly export the discovered paths to the Ruby shell
           export METACALL_INSTALL_PATH="$METACALL_INSTALL_PATH"
           export LOADER_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
           export SERIAL_LIBRARY_PATH="$LOADER_LIBRARY_PATH"

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -37,7 +37,6 @@ jobs:
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           
           # ARCHITECTURAL FIX: Force symbolic links for the strict Ruby regex
-          # We search for the versioned file and link it to the plain name
           sudo find /usr/local/lib -name "libmetacall.so.*" -exec ln -sf {} /usr/local/lib/libmetacall.so \; || true
           sudo find /usr/local/lib -name "libmetacall.dylib.*" -exec ln -sf {} /usr/local/lib/libmetacall.dylib \; || true
           

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -37,41 +37,52 @@ jobs:
           echo "[DETECTION] Starting MetaCall Installation..."
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           
-          # Force create common paths to prevent find errors
+          # Ensure critical directories exist
           sudo mkdir -p /usr/local/lib
           
-          echo "[DETECTION] Resolving MetaCall Home..."
+          echo "[DETECTION] Resolving MetaCall Binary..."
           METACALL_BIN=$(which metacall || echo "")
           
-          # Use Python to get the TRUE physical path (bypassing symlinks/wrappers)
-          REAL_BIN_PATH=$(python3 -c "import os; print(os.path.realpath('$METACALL_BIN'))" 2>/dev/null || echo "$METACALL_BIN")
-          INSTALL_ROOT=$(dirname $(dirname "$REAL_BIN_PATH"))
-          
+          if [ -z "$METACALL_BIN" ]; then
+            echo "WARNING: Binary not in PATH. Broad search starting..."
+            METACALL_BIN=$(find /usr/local /opt $HOME -name "metacall" -type f -executable 2>/dev/null | head -n 1)
+          fi
+
+          # Follow the trail to the real physical binary (unwrapping symlinks/Guix wrappers)
+          REAL_BIN_PATH=$(readlink -f "$METACALL_BIN" 2>/dev/null || realpath "$METACALL_BIN" 2>/dev/null || echo "$METACALL_BIN")
+          echo "[DETECTION] Target Binary: $METACALL_BIN"
           echo "[DETECTION] Physical Binary: $REAL_BIN_PATH"
-          echo "[DETECTION] Resolved Root: $INSTALL_ROOT"
           
-          echo "[DETECTION] Hunting for library via Prefix Matching..."
-          # Fuzzy Match: Look for anything starting with 'libmetacall' or containing 'metacall' in key areas
-          LIB_FILE=$(find "$INSTALL_ROOT" "$HOME" "/usr/local/lib" -name "libmetacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)' | head -n 1)
-          
+          # STRATEGY 1: System Trace (ldd) - Linux Only
+          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            echo "[DETECTION] Attempting ldd trace on $REAL_BIN_PATH..."
+            # Ask the OS: What library do you load when running this?
+            LIB_FILE=$(ldd "$REAL_BIN_PATH" 2>/dev/null | grep -i metacall | awk '{print $3}' | head -n 1)
+            [ ! -z "$LIB_FILE" ] && echo "[DETECTION] Trace Success: Found via ldd"
+          fi
+
+          # STRATEGY 2: Fuzzy Search Fallback (All Unix)
           if [ -z "$LIB_FILE" ]; then
-            echo "WARNING: Primary search failed. Scanning ALL local files for 'metacall' prefix..."
-            LIB_FILE=$(find /usr/local /opt $HOME -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)' | head -n 1)
+            echo "[DETECTION] Falling back to Fuzzy Search for '*metacall*'..."
+            # Look in binary's own tree first
+            INSTALL_ROOT=$(dirname $(dirname "$REAL_BIN_PATH"))
+            LIB_FILE=$(find "$INSTALL_ROOT" "$HOME" "/usr/local/lib" "/opt" "/gnu/store" -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)' | head -n 1)
           fi
 
           if [ -z "$LIB_FILE" ]; then
-            echo "ERROR: MetaCall library NOT FOUND even with fuzzy matching!"
+            echo "ERROR: MetaCall library NOT FOUND anywhere on the system!"
             exit 1
           fi
           
           LIB_DIR=$(dirname "$LIB_FILE")
-          echo "[DETECTION] SUCCESS: Found library at $LIB_FILE"
+          echo "[DETECTION] FINAL SUCCESS: Found library at $LIB_FILE"
           
           # Record the specific detected file and dir
           echo "METACALL_LIB_FILE=$LIB_FILE" >> $GITHUB_ENV
           echo "METACALL_INSTALL_PATH=$LIB_DIR" >> $GITHUB_ENV
           
           # Force Link: Create the exact name Ruby expects in the detected folder
+          # This satisfies Ruby's strict find_library logic
           sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.so" || true
           sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.dylib" || true
           
@@ -89,7 +100,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           echo "[DETECTION] Starting MetaCall Installation on Windows..."
-          powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
+          powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
           echo "$METACALL_DIR\lib" >> $GITHUB_PATH
           echo "METACALL_INSTALL_PATH=$METACALL_DIR\lib" >> $GITHUB_ENV
@@ -107,7 +118,7 @@ jobs:
           echo "Detected Lib File: $METACALL_LIB_FILE"
           echo "Search Path: $METACALL_INSTALL_PATH"
           echo "--- Directory Content ---"
-          ls -la "$METACALL_INSTALL_PATH" | grep metacall || echo "No metacall files in detected dir"
+          ls -la "$METACALL_INSTALL_PATH" | grep -i metacall || echo "No metacall files in detected dir"
           echo "--- Environment ---"
           env | grep METACALL || true
           echo "=== AUDIT END ==="

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -36,10 +36,9 @@ jobs:
         run: |
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           echo "/usr/local/lib" >> $GITHUB_PATH
-          # Critical: Tell MetaCall where its own loaders are
+          # We point directly to the lib folder to satisfy metacall.rb search logic
+          echo "METACALL_INSTALL_PATH=/usr/local/lib" >> $GITHUB_ENV
           echo "LOADER_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
-          echo "METACALL_INSTALL_PATH=/usr/local" >> $GITHUB_ENV
-          # For MacOS/Linux linker
           echo "LD_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
           echo "DYLD_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
 
@@ -50,8 +49,8 @@ jobs:
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
           echo "$METACALL_DIR" >> $GITHUB_PATH
           echo "$METACALL_DIR\lib" >> $GITHUB_PATH
-          # Windows-specific variables for the Ruby wrapper
-          echo "METACALL_INSTALL_PATH=$METACALL_DIR" >> $GITHUB_ENV
+          # Point directly to the lib folder for Windows too
+          echo "METACALL_INSTALL_PATH=$METACALL_DIR\lib" >> $GITHUB_ENV
           echo "METACALL_PATH=$METACALL_DIR" >> $GITHUB_ENV
 
       - name: Set up Ruby
@@ -70,8 +69,7 @@ jobs:
         working-directory: source/ports/rb_port/test
         shell: bash
         run: |
-          # Use -I to include the library, and we've set the env vars above 
-          # to help 'metacall.rb' find the binary core
+          # Use -I to manually include the library path
           ruby -I../package/lib run.rb
 
   release:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -35,8 +35,16 @@ jobs:
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         run: |
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
+          
+          # ARCHITECTURAL FIX: Create a symbolic link to bypass the strict regex in metacall.rb
+          # This maps 'libmetacall.so.0.x.y' to 'libmetacall.so' so the Ruby script can find it.
+          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            sudo ln -sf /usr/local/lib/libmetacall.so.* /usr/local/lib/libmetacall.so || true
+          else
+            sudo ln -sf /usr/local/lib/libmetacall.dylib.* /usr/local/lib/libmetacall.dylib || true
+          fi
+
           echo "/usr/local/lib" >> $GITHUB_PATH
-          # We point directly to the lib folder to satisfy metacall.rb search logic
           echo "METACALL_INSTALL_PATH=/usr/local/lib" >> $GITHUB_ENV
           echo "LOADER_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
@@ -46,10 +54,12 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
+          
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
           echo "$METACALL_DIR" >> $GITHUB_PATH
           echo "$METACALL_DIR\lib" >> $GITHUB_PATH
-          # Point directly to the lib folder for Windows too
+          
+          # Set the variables for the Windows Ruby loader
           echo "METACALL_INSTALL_PATH=$METACALL_DIR\lib" >> $GITHUB_ENV
           echo "METACALL_PATH=$METACALL_DIR" >> $GITHUB_ENV
 

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -40,6 +40,7 @@ jobs:
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           sudo mkdir -p /usr/local/lib
           
+          echo "[DETECTION] Constructing Safe Search Paths..."
           SEARCH_DIRS="$HOME /usr/local /opt"
           [ -d "/gnu/store" ] && SEARCH_DIRS="$SEARCH_DIRS /gnu/store"
           [ -d "/opt/homebrew" ] && SEARCH_DIRS="$SEARCH_DIRS /opt/homebrew"
@@ -72,17 +73,31 @@ jobs:
           &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))
           
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
+          echo "[DETECTION] Hunting for components in $METACALL_DIR"
+          
+          # Find the Core library folder (SINGLE DIRECTORY)
           $LIB_FILE = Get-ChildItem -Path $METACALL_DIR -Filter "*metacall*.dll" -Recurse | Select-Object -First 1
           $LIB_DIR = $LIB_FILE.DirectoryName
-          $ALL_DIRS = Get-ChildItem -Path $METACALL_DIR -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
-          $COMBINED_PATHS = $ALL_DIRS -join ";"
           
+          # Find all unique directories with DLLs (The Houses)
+          $ALL_DIRS = Get-ChildItem -Path $METACALL_DIR -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
+          
+          echo "[DETECTION] SUCCESS: Core found at $LIB_DIR"
+          
+          # Export to GITHUB_ENV using ASCII (Safe for PowerShell 5.1)
+          # ARCHITECTURAL FIX: METACALL_INSTALL_PATH must be a SINGLE directory on Windows
           Add-Content -Path $env:GITHUB_ENV -Value "METACALL_LIB_FILE=$($LIB_FILE.FullName)" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "METACALL_INSTALL_PATH=$LIB_DIR" -Encoding Ascii
-          Add-Content -Path $env:GITHUB_ENV -Value "LOADER_LIBRARY_PATH=$COMBINED_PATHS" -Encoding Ascii
-          Add-Content -Path $env:GITHUB_ENV -Value "SERIAL_LIBRARY_PATH=$COMBINED_PATHS" -Encoding Ascii
-          Add-Content -Path $env:GITHUB_ENV -Value "DETECTOR_LIBRARY_PATH=$COMBINED_PATHS" -Encoding Ascii
-          Add-Content -Path $env:GITHUB_PATH -Value "$LIB_DIR" -Encoding Ascii
+          
+          # Use the main lib folder for loader paths to prevent syntax errors
+          Add-Content -Path $env:GITHUB_ENV -Value "LOADER_LIBRARY_PATH=$LIB_DIR" -Encoding Ascii
+          Add-Content -Path $env:GITHUB_ENV -Value "SERIAL_LIBRARY_PATH=$LIB_DIR" -Encoding Ascii
+          Add-Content -Path $env:GITHUB_ENV -Value "DETECTOR_LIBRARY_PATH=$LIB_DIR" -Encoding Ascii
+          
+          # Inject EVERY house into the Windows System PATH so the engine finds plugins natively
+          foreach ($dir in $ALL_DIRS) {
+            Add-Content -Path $env:GITHUB_PATH -Value "$dir" -Encoding Ascii
+          }
 
       - name: "[FORENSIC] Step 2: Set up Ruby Environment"
         uses: ruby/setup-ruby@v1
@@ -96,6 +111,7 @@ jobs:
           echo "=== SYSTEM AUDIT START ==="
           echo "OS: ${{ matrix.os }}"
           echo "INSTALL_PATH: $METACALL_INSTALL_PATH"
+          echo "LOADER_PATH: $LOADER_LIBRARY_PATH"
           echo "--- Directory Verification ---"
           SEP=$([[ "${{ matrix.os }}" == "windows-latest" ]] && echo ";" || echo ":")
           IFS=$SEP read -ra ADDR <<< "$LOADER_LIBRARY_PATH"
@@ -122,7 +138,6 @@ jobs:
           echo "[EXECUTION] Starting Windows Integration Tests..."
           cp ../../../scripts/python/example/source/example.py .
           cp ../../../scripts/ruby/hello/source/hello.rb .
-          # Using pwsh avoids the Bash path-conversion bug
           ruby -I../package/lib run.rb
 
   release:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -40,7 +40,6 @@ jobs:
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           sudo mkdir -p /usr/local/lib
           
-          echo "[DETECTION] Constructing Safe Search Paths..."
           SEARCH_DIRS="$HOME /usr/local /opt"
           [ -d "/gnu/store" ] && SEARCH_DIRS="$SEARCH_DIRS /gnu/store"
           [ -d "/opt/homebrew" ] && SEARCH_DIRS="$SEARCH_DIRS /opt/homebrew"
@@ -75,26 +74,28 @@ jobs:
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
           echo "[DETECTION] Hunting for components in $METACALL_DIR"
           
-          # Find the Core library folder (SINGLE DIRECTORY)
-          $LIB_FILE = Get-ChildItem -Path $METACALL_DIR -Filter "*metacall*.dll" -Recurse | Select-Object -First 1
-          $LIB_DIR = $LIB_FILE.DirectoryName
+          # ARCHITECTURAL FIX (Strategy: Find specific files then use paths)
+          $CoreFile = Get-ChildItem -Path $METACALL_DIR -Filter "metacall.dll" -Recurse | Select-Object -First 1
+          $RbLoader = Get-ChildItem -Path $METACALL_DIR -Filter "rb_loader.dll" -Recurse | Select-Object -First 1
+          $Serial   = Get-ChildItem -Path $METACALL_DIR -Filter "*serial.dll" -Recurse | Select-Object -First 1
           
-          # Find all unique directories with DLLs (The Houses)
+          $InstallDir = if ($CoreFile) { $CoreFile.DirectoryName } else { "$METACALL_DIR\lib" }
+          $LoaderDir  = if ($RbLoader) { $RbLoader.DirectoryName } else { $InstallDir }
+          $SerialDir  = if ($Serial)   { $Serial.DirectoryName }   else { $InstallDir }
+          
+          # Find all unique DLL folders for the System PATH
           $ALL_DIRS = Get-ChildItem -Path $METACALL_DIR -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
           
-          echo "[DETECTION] SUCCESS: Core found at $LIB_DIR"
+          echo "[DETECTION] SUCCESS: Core -> $InstallDir, Loader -> $LoaderDir"
           
-          # Export to GITHUB_ENV using ASCII (Safe for PowerShell 5.1)
-          # ARCHITECTURAL FIX: METACALL_INSTALL_PATH must be a SINGLE directory on Windows
-          Add-Content -Path $env:GITHUB_ENV -Value "METACALL_LIB_FILE=$($LIB_FILE.FullName)" -Encoding Ascii
-          Add-Content -Path $env:GITHUB_ENV -Value "METACALL_INSTALL_PATH=$LIB_DIR" -Encoding Ascii
+          # Export to GITHUB_ENV using ASCII
+          Add-Content -Path $env:GITHUB_ENV -Value "METACALL_LIB_FILE=$($CoreFile.FullName)" -Encoding Ascii
+          Add-Content -Path $env:GITHUB_ENV -Value "METACALL_INSTALL_PATH=$InstallDir" -Encoding Ascii
+          Add-Content -Path $env:GITHUB_ENV -Value "LOADER_LIBRARY_PATH=$LoaderDir" -Encoding Ascii
+          Add-Content -Path $env:GITHUB_ENV -Value "SERIAL_LIBRARY_PATH=$SerialDir" -Encoding Ascii
+          Add-Content -Path $env:GITHUB_ENV -Value "DETECTOR_LIBRARY_PATH=$InstallDir" -Encoding Ascii
           
-          # Use the main lib folder for loader paths to prevent syntax errors
-          Add-Content -Path $env:GITHUB_ENV -Value "LOADER_LIBRARY_PATH=$LIB_DIR" -Encoding Ascii
-          Add-Content -Path $env:GITHUB_ENV -Value "SERIAL_LIBRARY_PATH=$LIB_DIR" -Encoding Ascii
-          Add-Content -Path $env:GITHUB_ENV -Value "DETECTOR_LIBRARY_PATH=$LIB_DIR" -Encoding Ascii
-          
-          # Inject EVERY house into the Windows System PATH so the engine finds plugins natively
+          # Inject EVERY house into the Windows System PATH
           foreach ($dir in $ALL_DIRS) {
             Add-Content -Path $env:GITHUB_PATH -Value "$dir" -Encoding Ascii
           }
@@ -116,7 +117,7 @@ jobs:
           SEP=$([[ "${{ matrix.os }}" == "windows-latest" ]] && echo ";" || echo ":")
           IFS=$SEP read -ra ADDR <<< "$LOADER_LIBRARY_PATH"
           for i in "${ADDR[@]}"; do
-            [ -d "$i" ] && echo "Found House: $i" && ls -la "$i" | grep -i metacall || true
+            [ -d "$i" ] && echo "Found House: $i" && ls -la "$i" | grep -E 'dll|json|so|dylib' || true
           done
           echo "=== SYSTEM AUDIT END ==="
 

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -33,11 +33,19 @@ jobs:
 
       - name: Install MetaCall Unix
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-        run: curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
+        run: |
+          curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
+          # Force MetaCall into the PATH for the current session
+          echo "/usr/local/lib" >> $GITHUB_PATH
+          echo "LOADER_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
 
       - name: Install MetaCall Windows
         if: matrix.os == 'windows-latest'
-        run: powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
+        run: |
+          powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
+          # Force the Windows installation path into the GITHUB_PATH
+          echo "$HOME\AppData\Local\MetaCall\metacall" >> $GITHUB_PATH
+          echo "METACALL_PATH=$HOME\AppData\Local\MetaCall\metacall" >> $GITHUB_ENV
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -48,17 +56,16 @@ jobs:
       - name: Sync Test Resources
         shell: bash
         run: |
-          # Copy shared test scripts into the Ruby port test folder
           cp source/scripts/python/example/source/example.py source/ports/rb_port/test/
           cp source/scripts/ruby/hello/source/hello.rb source/ports/rb_port/test/
 
       - name: Test the Ruby Port
-        working-directory: source/ports/rb_port/test
+        working-directory: source/ports/rb_port
         shell: bash
         run: |
-          # Run the Ruby unit tests from the test directory
-          # to ensure relative paths resolve correctly
-          ruby run.rb
+          # Use -I to manually include the library path, fixing the LoadError
+          # and ensuring we test against the local source code
+          ruby -I./package/lib test/run.rb
 
   release:
     name: Release Ruby Port

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -49,7 +49,6 @@ jobs:
           
           echo "[DETECTION] Hunting for Components in: $SEARCH_DIRS"
           # Find all unique directories containing MetaCall components
-          # We use fuzzy *metacall* to catch debug versions like libmetacalld.dylib
           RAW_DIRS=$(find $SEARCH_DIRS -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)$' | xargs dirname 2>/dev/null | sort -u)
           
           if [ -z "$RAW_DIRS" ]; then
@@ -97,17 +96,18 @@ jobs:
           
           echo "[DETECTION] SUCCESS: Discovered Map -> $COMBINED_PATHS"
           
-          # ARCHITECTURAL FIX: Use UTF-8 WITHOUT BOM to prevent the "Chinese Characters" bug
-          $Utf8NoBom = New-Object System.Text.UTF8Encoding $false
-          [System.IO.File]::AppendAllLines($env:GITHUB_ENV, @(
+          # ARCHITECTURAL FIX: Use a simple loop with AppendAllText to ensure compatibility and NO-BOM UTF8
+          $lines = @(
             "METACALL_LIB_FILE=$($LIB_FILE.FullName)",
             "METACALL_INSTALL_PATH=$LIB_DIR",
             "LOADER_LIBRARY_PATH=$COMBINED_PATHS",
             "SERIAL_LIBRARY_PATH=$COMBINED_PATHS",
             "DETECTOR_LIBRARY_PATH=$COMBINED_PATHS"
-          ), $Utf8NoBom)
-          
-          [System.IO.File]::AppendAllLines($env:GITHUB_PATH, @($LIB_DIR), $Utf8NoBom)
+          )
+          foreach ($line in $lines) {
+            [System.IO.File]::AppendAllText($env:GITHUB_ENV, "$line`r`n")
+          }
+          [System.IO.File]::AppendAllText($env:GITHUB_PATH, "$LIB_DIR`r`n")
 
       - name: "[FORENSIC] Step 2: Set up Ruby Environment"
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: "[FORENSIC] Step 1b: Install & Detect MetaCall (Windows)"
         if: matrix.os == 'windows-latest'
-        shell: powershell
+        shell: pwsh
         run: |
           echo "[INSTALL] Starting MetaCall Setup for Windows..."
           [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -96,8 +96,7 @@ jobs:
           
           echo "[DETECTION] SUCCESS: Discovered Map -> $COMBINED_PATHS"
           
-          # ARCHITECTURAL FIX: Use Byte Injection to prevent BOM and encoding corruption
-          $Utf8NoBom = New-Object System.Text.UTF8Encoding $false
+          # STRATEGY A: Using pwsh (PowerShell Core) which is BOM-free by default
           $lines = @(
             "METACALL_LIB_FILE=$($LIB_FILE.FullName)",
             "METACALL_INSTALL_PATH=$LIB_DIR",
@@ -106,13 +105,9 @@ jobs:
             "DETECTOR_LIBRARY_PATH=$COMBINED_PATHS"
           )
           
-          foreach ($line in $lines) {
-            $bytes = $Utf8NoBom.GetBytes("$line`n")
-            [System.IO.File]::AppendAllBytes($env:GITHUB_ENV, $bytes)
-          }
-          
-          $pathBytes = $Utf8NoBom.GetBytes("$LIB_DIR`n")
-          [System.IO.File]::AppendAllBytes($env:GITHUB_PATH, $pathBytes)
+          # Writing to GITHUB_ENV and GITHUB_PATH using modern pwsh Out-File (BOM-less UTF8)
+          $lines | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          $LIB_DIR | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
 
       - name: "[FORENSIC] Step 2: Set up Ruby Environment"
         uses: ruby/setup-ruby@v1
@@ -140,8 +135,9 @@ jobs:
         shell: bash
         run: |
           echo "[EXECUTION] Starting Integration Tests..."
-          cp ../../../scripts/python/example/source/example.py . || true
-          cp ../../../scripts/ruby/hello/source/hello.rb . || true
+          # Fix: Include the /source/ prefix in the relative path
+          cp ../../../source/scripts/python/example/source/example.py . || true
+          cp ../../../source/scripts/ruby/hello/source/hello.rb . || true
           
           export METACALL_INSTALL_PATH="$METACALL_INSTALL_PATH"
           export LOADER_LIBRARY_PATH="$LOADER_LIBRARY_PATH"

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -36,19 +36,22 @@ jobs:
         run: |
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           echo "/usr/local/lib" >> $GITHUB_PATH
+          # Critical: Tell MetaCall where its own loaders are
           echo "LOADER_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "METACALL_INSTALL_PATH=/usr/local" >> $GITHUB_ENV
+          # For MacOS/Linux linker
+          echo "LD_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
+          echo "DYLD_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
 
       - name: Install MetaCall Windows
         if: matrix.os == 'windows-latest'
         run: |
-          # Use the official installer
           powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
-          
-          # Force BOTH the base and lib paths into the Windows environment
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
           echo "$METACALL_DIR" >> $GITHUB_PATH
           echo "$METACALL_DIR\lib" >> $GITHUB_PATH
+          # Windows-specific variables for the Ruby wrapper
+          echo "METACALL_INSTALL_PATH=$METACALL_DIR" >> $GITHUB_ENV
           echo "METACALL_PATH=$METACALL_DIR" >> $GITHUB_ENV
 
       - name: Set up Ruby
@@ -67,9 +70,8 @@ jobs:
         working-directory: source/ports/rb_port/test
         shell: bash
         run: |
-          # We run from the 'test' directory so that '../package' 
-          # in run.rb correctly resolves to 'source/ports/rb_port/package'
-          # We also include the lib path manually for extra safety
+          # Use -I to include the library, and we've set the env vars above 
+          # to help 'metacall.rb' find the binary core
           ruby -I../package/lib run.rb
 
   release:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -31,23 +31,34 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install MetaCall Unix
+      - name: "[FORENSIC] Step 1: Install MetaCall Core (Unix)"
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         run: |
+          echo "[DETECTION] Starting MetaCall Installation..."
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           
-          # ARCHITECTURAL FIX: Force symbolic links for the strict Ruby regex
-          # We search for the versioned file and link it to the plain name
-          sudo find /usr/local/lib -name "libmetacall.so.*" -exec ln -sf {} /usr/local/lib/libmetacall.so \; || true
-          sudo find /usr/local/lib -name "libmetacall.dylib.*" -exec ln -sf {} /usr/local/lib/libmetacall.dylib \; || true
+          echo "[DETECTION] Locating MetaCall library files..."
+          # Find the actual library file (versioned)
+          LIB_FILE=$(find /usr/local/lib -name "libmetacall.so.*" -o -name "libmetacall.dylib.*" | head -n 1)
           
-          # Refresh the library cache (Critical for Ubuntu)
+          if [ -z "$LIB_FILE" ]; then
+            echo "ERROR: MetaCall library NOT FOUND after installation!"
+            ls -la /usr/local/lib
+            exit 1
+          fi
+          
+          echo "[DETECTION] Found library at: $LIB_FILE"
+          echo "METACALL_LIB_FILE=$LIB_FILE" >> $GITHUB_ENV
+          
+          # ARCHITECTURAL FIX: Force symbolic links
+          sudo ln -sf "$LIB_FILE" /usr/local/lib/libmetacall.so || true
+          sudo ln -sf "$LIB_FILE" /usr/local/lib/libmetacall.dylib || true
+          
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
             sudo ldconfig
           fi
 
-          # Define the full environment for the MetaCall Core
-          echo "/usr/local/lib" >> $GITHUB_PATH
+          # Export full environment
           echo "METACALL_INSTALL_PATH=/usr/local/lib" >> $GITHUB_ENV
           echo "LOADER_LIBRARY_PATH=/usr/local/lib/metacall" >> $GITHUB_ENV
           echo "SERIAL_LIBRARY_PATH=/usr/local/lib/metacall" >> $GITHUB_ENV
@@ -55,56 +66,77 @@ jobs:
           echo "LD_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
           echo "DYLD_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
 
-      - name: Install MetaCall Windows
+      - name: "[FORENSIC] Step 1: Install MetaCall Core (Windows)"
         if: matrix.os == 'windows-latest'
         run: |
+          echo "[DETECTION] Starting MetaCall Installation on Windows..."
           powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
-          $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
           
-          # Force the entire MetaCall tree into the Windows Path
+          $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
+          echo "[DETECTION] MetaCall Directory: $METACALL_DIR"
+          
+          # Verify installation
+          if (Test-Path "$METACALL_DIR\lib\metacall.dll") {
+            echo "[DETECTION] Found metacall.dll"
+          } else {
+            echo "ERROR: MetaCall library NOT FOUND on Windows!"
+            ls -R $METACALL_DIR
+            exit 1
+          }
+          
           echo "$METACALL_DIR" >> $GITHUB_PATH
           echo "$METACALL_DIR\lib" >> $GITHUB_PATH
-          
-          # Critical Windows environment variables
           echo "METACALL_INSTALL_PATH=$METACALL_DIR\lib" >> $GITHUB_ENV
           echo "METACALL_PATH=$METACALL_DIR" >> $GITHUB_ENV
-          echo "LOADER_LIBRARY_PATH=$METACALL_DIR\lib" >> $GITHUB_ENV
 
-      - name: Set up Ruby
+      - name: "[FORENSIC] Step 2: Set up Ruby Environment"
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
           bundler-cache: true
 
-      - name: Sync Test Resources
+      - name: "[FORENSIC] Step 3: Deep Environment Audit"
         shell: bash
         run: |
-          cp source/scripts/python/example/source/example.py source/ports/rb_port/test/
-          cp source/scripts/ruby/hello/source/hello.rb source/ports/rb_port/test/
+          echo "=== SYSTEM AUDIT START ==="
+          echo "User: $(whoami)"
+          echo "OS: ${{ matrix.os }}"
+          echo "Working Directory: $(pwd)"
+          echo "Ruby Version: $(ruby -v)"
+          
+          echo "--- MetaCall Detection ---"
+          if [ -f "/usr/local/lib/libmetacall.so" ] || [ -f "/usr/local/lib/libmetacall.dylib" ]; then
+            echo "✅ Core Symbolic Link EXISTS"
+          else
+            echo "❌ Core Symbolic Link MISSING"
+          fi
+          
+          echo "--- Library Details ---"
+          ls -la /usr/local/lib/libmetacall* || echo "No metacall files found in /usr/local/lib"
+          
+          echo "--- Environment Variable Check ---"
+          echo "METACALL_INSTALL_PATH: $METACALL_INSTALL_PATH"
+          echo "METACALL_LIB_FILE: $METACALL_LIB_FILE"
+          
+          echo "--- Dynamic Linker Audit (Linux) ---"
+          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            ldconfig -p | grep metacall || echo "Metacall not found in ldconfig cache"
+          fi
+          echo "=== SYSTEM AUDIT END ==="
 
-      - name: Environment Audit (Debug)
-        shell: bash
-        run: |
-          echo "--- PATH ---"
-          echo $PATH
-          echo "--- MetaCall Version ---"
-          metacall --version || echo "metacall binary not in path"
-          echo "--- Library Files (Unix) ---"
-          ls -la /usr/local/lib/libmetacall* || true
-          echo "--- Library Files (Windows) ---"
-          ls -la $HOME/AppData/Local/MetaCall/metacall/lib/metacall* || true
-          echo "--- Environment Variables ---"
-          env | grep METACALL || true
-
-      - name: Test the Ruby Port
+      - name: "[FORENSIC] Step 4: Run Ruby Tests (Direct Injection)"
         working-directory: source/ports/rb_port/test
         shell: bash
         env:
-          METACALL_INSTALL_PATH: ${{ matrix.os == 'windows-latest' && format('{0}/AppData/Local/MetaCall/metacall/lib', env.HOME) || '/usr/local/lib' }}
-          LD_LIBRARY_PATH: /usr/local/lib
-          DYLD_LIBRARY_PATH: /usr/local/lib
+          # Use the absolute versioned file path we detected in Step 1
+          METACALL_LIBRARY_PATH: ${{ env.METACALL_LIB_FILE }}
         run: |
-          # Use -I to manually include the library path
+          echo "[EXECUTION] Starting Ruby Integration Tests..."
+          # Sync resources
+          cp ../../../scripts/python/example/source/example.py .
+          cp ../../../scripts/ruby/hello/source/hello.rb .
+          
+          # Execute with manual library include
           ruby -I../package/lib run.rb
 
   release:
@@ -117,12 +149,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
-
       - name: Release the port
         working-directory: source/ports/rb_port
         env:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -39,7 +39,7 @@ jobs:
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           sudo mkdir -p /usr/local/lib
           
-          # Dynamic component discovery for Guix/Homebrew compatibility
+          # Discovery logic for distributed Guix/Homebrew components
           SEARCH_DIRS="$HOME /usr/local /opt"
           [ -d "/gnu/store" ] && SEARCH_DIRS="$SEARCH_DIRS /gnu/store"
           [ -d "/opt/homebrew" ] && SEARCH_DIRS="$SEARCH_DIRS /opt/homebrew"
@@ -75,7 +75,6 @@ jobs:
           $RbLoader = Get-ChildItem -Path $METACALL_DIR -Filter "rb_loader.dll" -Recurse | Select-Object -First 1
           $RubyRuntime = Get-ChildItem -Path $METACALL_DIR -Filter "x64-vcruntime140-ruby*.dll" -Recurse | Select-Object -First 1
           
-          # ARCHITECTURAL FIX: Explicitly find the Python runtime home (never use the lib folder)
           $PyHome = Join-Path $METACALL_DIR "runtimes\python"
           if (-not (Test-Path $PyHome)) {
              $LibDir = Get-ChildItem -Path $METACALL_DIR -Directory -Filter "Lib" -Recurse | Select-Object -First 1
@@ -85,7 +84,6 @@ jobs:
           $InstallDir = if ($CoreFile) { $CoreFile.DirectoryName } else { "$METACALL_DIR\lib" }
           $LoaderDir  = if ($RbLoader) { $RbLoader.DirectoryName } else { $InstallDir }
           
-          # Export to GITHUB_ENV using ASCII to ensure NO-BOM compatibility
           Add-Content -Path $env:GITHUB_ENV -Value "METACALL_LIB_FILE=$($CoreFile.FullName)" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "METACALL_INSTALL_PATH=$InstallDir" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "LOADER_LIBRARY_PATH=$LoaderDir" -Encoding Ascii
@@ -105,18 +103,30 @@ jobs:
           ruby-version: '3.2'
           bundler-cache: true
 
-      - name: Run Integration Tests
+      - name: Run Integration Tests (Unix)
+        if: matrix.os != 'windows-latest'
         working-directory: source/ports/rb_port/test
         shell: bash
         run: |
-          # Robust resource sync using search to avoid path regressions
           cp $(find ../../../ -name "example.py" | head -n 1) . || true
           cp $(find ../../../ -name "hello.rb" | head -n 1) . || true
+          ruby -I../package/lib run.rb
+
+      - name: Run Integration Tests (Windows)
+        if: matrix.os == 'windows-latest'
+        working-directory: source/ports/rb_port/test
+        shell: pwsh
+        run: |
+          # Native pwsh test step to resolve DLL dependencies and avoid Git Bash path issues
+          $metacallDirs = Get-ChildItem "$env:USERPROFILE\AppData\Local\MetaCall" -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
+          $env:PATH = ($metacallDirs -join ";") + ";" + $env:PATH
+          $env:PYTHONHOME = "$env:PYTHONHOME"
+          $env:PYTHONPATH = "$env:PYTHONPATH"
           
-          export METACALL_INSTALL_PATH="$METACALL_INSTALL_PATH"
-          export LOADER_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
-          export SERIAL_LIBRARY_PATH="$SERIAL_LIBRARY_PATH"
-          export DETECTOR_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
+          $PyFile = Get-ChildItem -Path "../../../" -Filter "example.py" -Recurse | Select-Object -First 1
+          $RbFile = Get-ChildItem -Path "../../../" -Filter "hello.rb" -Recurse | Select-Object -First 1
+          if ($PyFile) { Copy-Item $PyFile.FullName . }
+          if ($RbFile) { Copy-Item $RbFile.FullName . }
           
           ruby -I../package/lib run.rb
 

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -3,15 +3,15 @@ name: Release Ruby Gem
 on:
   workflow_dispatch:
   pull_request:
-  push:
-    tags:
-      - 'v*' # Trigger only on version tags (e.g., v0.0.1)
     branches:
       - master
       - develop
     paths:
       - '.github/workflows/release-ruby.yml'
       - 'source/ports/rb_port/**'
+  push:
+    tags:
+      - 'v*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2' # Using stable Ruby 3.x
+          ruby-version: '3.2'
           bundler-cache: true
 
       - name: Sync Test Resources
@@ -53,11 +53,12 @@ jobs:
           cp source/scripts/ruby/hello/source/hello.rb source/ports/rb_port/test/
 
       - name: Test the Ruby Port
-        working-directory: source/ports/rb_port
+        working-directory: source/ports/rb_port/test
         shell: bash
         run: |
-          # Run the Ruby unit tests
-          ruby test/run.rb
+          # Run the Ruby unit tests from the test directory
+          # to ensure relative paths resolve correctly
+          ruby run.rb
 
   release:
     name: Release Ruby Port

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -73,14 +73,19 @@ jobs:
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
           $CoreFile = Get-ChildItem -Path $METACALL_DIR -Filter "metacall.dll" -Recurse | Select-Object -First 1
           $RbLoader = Get-ChildItem -Path $METACALL_DIR -Filter "rb_loader.dll" -Recurse | Select-Object -First 1
-          $PyDll = Get-ChildItem -Path $METACALL_DIR -Filter "python*.dll" -Recurse | Select-Object -First 1
           $RubyRuntime = Get-ChildItem -Path $METACALL_DIR -Filter "x64-vcruntime140-ruby*.dll" -Recurse | Select-Object -First 1
+          
+          # ARCHITECTURAL FIX: Explicitly find the Python runtime home (never use the lib folder)
+          $PyHome = Join-Path $METACALL_DIR "runtimes\python"
+          if (-not (Test-Path $PyHome)) {
+             $LibDir = Get-ChildItem -Path $METACALL_DIR -Directory -Filter "Lib" -Recurse | Select-Object -First 1
+             $PyHome = if ($LibDir) { $LibDir.Parent.FullName } else { "$METACALL_DIR\lib" }
+          }
           
           $InstallDir = if ($CoreFile) { $CoreFile.DirectoryName } else { "$METACALL_DIR\lib" }
           $LoaderDir  = if ($RbLoader) { $RbLoader.DirectoryName } else { $InstallDir }
-          $PyHome = if ($PyDll) { $PyDll.DirectoryName } else { "$METACALL_DIR\runtimes\python" }
           
-          # Use ASCII to ensure NO-BOM compatibility with GitHub Runner
+          # Export to GITHUB_ENV using ASCII to ensure NO-BOM compatibility
           Add-Content -Path $env:GITHUB_ENV -Value "METACALL_LIB_FILE=$($CoreFile.FullName)" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "METACALL_INSTALL_PATH=$InstallDir" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "LOADER_LIBRARY_PATH=$LoaderDir" -Encoding Ascii
@@ -100,28 +105,19 @@ jobs:
           ruby-version: '3.2'
           bundler-cache: true
 
-      - name: Run Integration Tests (Unix)
-        if: matrix.os != 'windows-latest'
+      - name: Run Integration Tests
         working-directory: source/ports/rb_port/test
         shell: bash
         run: |
-          cp ../../../scripts/python/example/source/example.py . || true
-          cp ../../../scripts/ruby/hello/source/hello.rb . || true
-          ruby -I../package/lib run.rb
-
-      - name: Run Integration Tests (Windows)
-        if: matrix.os == 'windows-latest'
-        working-directory: source/ports/rb_port/test
-        shell: pwsh
-        run: |
-          # Ensure local shell path is updated for DLL discovery
-          $metacallDirs = Get-ChildItem "$env:USERPROFILE\AppData\Local\MetaCall" -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
-          $env:PATH = ($metacallDirs -join ";") + ";" + $env:PATH
-          $env:PYTHONHOME = "$env:PYTHONHOME"
-          $env:PYTHONPATH = "$env:PYTHONPATH"
+          # Robust resource sync using search to avoid path regressions
+          cp $(find ../../../ -name "example.py" | head -n 1) . || true
+          cp $(find ../../../ -name "hello.rb" | head -n 1) . || true
           
-          cp ../../../scripts/python/example/source/example.py . || true
-          cp ../../../scripts/ruby/hello/source/hello.rb . || true
+          export METACALL_INSTALL_PATH="$METACALL_INSTALL_PATH"
+          export LOADER_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
+          export SERIAL_LIBRARY_PATH="$SERIAL_LIBRARY_PATH"
+          export DETECTOR_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
+          
           ruby -I../package/lib run.rb
 
   release:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -37,51 +37,40 @@ jobs:
           echo "[DETECTION] Starting MetaCall Installation..."
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           
-          # Force create common paths
+          # Force create standard paths
           sudo mkdir -p /usr/local/lib
           
-          echo "[DETECTION] Resolving MetaCall Binary Beacon..."
-          METACALL_BIN=$(which metacall || find /usr/local /opt $HOME -name "metacall" -type f -executable 2>/dev/null | head -n 1)
-          REAL_BIN_PATH=$(readlink -f "$METACALL_BIN" 2>/dev/null || realpath "$METACALL_BIN" 2>/dev/null || echo "$METACALL_BIN")
-          echo "[DETECTION] Physical Binary: $REAL_BIN_PATH"
+          echo "[DETECTION] Performing Global Component Hunt..."
+          # Find EVERY unique directory containing any MetaCall related library (.so or .dylib)
+          # We search broadly including the Guix store, opt, and home
+          RAW_DIRS=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)' | xargs dirname | sort -u)
           
-          echo "[DETECTION] Scoping the System for ALL MetaCall Components..."
-          # Find EVERY unique directory containing any MetaCall related library
-          # This catches Core, Loaders (rb, ext, etc), Serializers, and Detectors
-          ALL_METACALL_DIRS=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)' | xargs dirname | sort -u | tr '\n' ':')
-          
-          if [ -z "$ALL_METACALL_DIRS" ]; then
+          if [ -z "$RAW_DIRS" ]; then
             echo "ERROR: No MetaCall components found anywhere on the system!"
             exit 1
           fi
           
-          echo "[DETECTION] Discovered Component Map: $ALL_METACALL_DIRS"
+          # Join paths with colons and strip the trailing colon
+          COMBINED_PATHS=$(echo "$RAW_DIRS" | paste -sd ":" -)
+          echo "[DETECTION] Discovered Component Map: $COMBINED_PATHS"
           
-          # Find the specific Core Library (The Heart) using fuzzy matching
-          # This catches libmetacall.so, libmetacalld.dylib, etc.
+          # Find the specific Core Library (The Heart)
           LIB_FILE=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "libmetacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)' | head -n 1)
-          
-          if [ -z "$LIB_FILE" ]; then
-            echo "ERROR: MetaCall Core Library NOT FOUND!"
-            exit 1
-          fi
-          
           LIB_DIR=$(dirname "$LIB_FILE")
           echo "[DETECTION] SUCCESS: Found Core at $LIB_FILE"
           
-          # Record for downstream
+          # Record for downstream steps
           echo "METACALL_LIB_FILE=$LIB_FILE" >> $GITHUB_ENV
           echo "METACALL_INSTALL_PATH=$LIB_DIR" >> $GITHUB_ENV
           
-          # CRITICAL FIX: Add both the root dirs AND potential subdirs to the loader path
-          # This forces the engine to check every possible "House"
-          echo "LOADER_LIBRARY_PATH=$ALL_METACALL_DIRS" >> $GITHUB_ENV
-          echo "SERIAL_LIBRARY_PATH=$ALL_METACALL_DIRS" >> $GITHUB_ENV
-          echo "DETECTOR_LIBRARY_PATH=$ALL_METACALL_DIRS" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=$ALL_METACALL_DIRS" >> $GITHUB_ENV
-          echo "DYLD_LIBRARY_PATH=$ALL_METACALL_DIRS" >> $GITHUB_ENV
+          # Inject the clean combined path map into ALL MetaCall environment variables
+          echo "LOADER_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
+          echo "SERIAL_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
+          echo "DETECTOR_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
+          echo "DYLD_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
           
-          # Link: Satisfy Ruby's find_library logic in the Core folder
+          # Satisfy Ruby's find_library logic by linking in the Core folder
           sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.so" || true
           sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.dylib" || true
           
@@ -93,7 +82,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           echo "[DETECTION] Starting MetaCall Installation on Windows..."
-          powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
+          powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
           echo "$METACALL_DIR\lib" >> $GITHUB_PATH
           echo "METACALL_INSTALL_PATH=$METACALL_DIR\lib" >> $GITHUB_ENV
@@ -104,22 +93,24 @@ jobs:
           ruby-version: '3.2'
           bundler-cache: true
 
-      - name: "[FORENSIC] Step 3: Multi-Path Environment Audit"
+      - name: "[FORENSIC] Step 3: Multi-House Component Audit"
         shell: bash
         run: |
           echo "=== SYSTEM AUDIT START ==="
-          echo "Ruby: $(ruby -v)"
-          echo "INSTALL_PATH: $METACALL_INSTALL_PATH"
-          echo "LOADER_PATH: $LOADER_LIBRARY_PATH"
-          echo "--- Directory Scan ---"
+          echo "Ruby Version: $(ruby -v)"
+          echo "METACALL_INSTALL_PATH: $METACALL_INSTALL_PATH"
+          echo "LOADER_LIBRARY_PATH: $LOADER_LIBRARY_PATH"
+          echo "--- Component Scan ---"
           IFS=':' read -ra ADDR <<< "$LOADER_LIBRARY_PATH"
           for i in "${ADDR[@]}"; do
-            echo "Checking House: $i"
-            ls -la "$i" | grep -i metacall || true
+            if [ -d "$i" ]; then
+              echo "Checking House: $i"
+              ls -la "$i" | grep -E 'metacall|rapid_json' || true
+            fi
           done
           echo "=== SYSTEM AUDIT END ==="
 
-      - name: "[FORENSIC] Step 4: Run Ruby Tests (Universal Injection)"
+      - name: "[FORENSIC] Step 4: Run Ruby Tests (Clean Path Injection)"
         working-directory: source/ports/rb_port/test
         shell: bash
         run: |
@@ -127,11 +118,12 @@ jobs:
           cp ../../../scripts/python/example/source/example.py .
           cp ../../../scripts/ruby/hello/source/hello.rb .
           
-          # Inject the discovery map directly into the execution shell
+          # Export variables explicitly to current shell
           export METACALL_INSTALL_PATH="$METACALL_INSTALL_PATH"
           export LOADER_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
-          export SERIAL_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
-          export DETECTOR_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
+          export SERIAL_LIBRARY_PATH="$SERIAL_LIBRARY_PATH"
+          export DETECTOR_LIBRARY_PATH="$SERIAL_LIBRARY_PATH"
+          export LD_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
           
           ruby -I../package/lib run.rb
 

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -37,9 +37,15 @@ jobs:
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           
           # ARCHITECTURAL FIX: Force symbolic links for the strict Ruby regex
+          # We search for the versioned file and link it to the plain name
           sudo find /usr/local/lib -name "libmetacall.so.*" -exec ln -sf {} /usr/local/lib/libmetacall.so \; || true
           sudo find /usr/local/lib -name "libmetacall.dylib.*" -exec ln -sf {} /usr/local/lib/libmetacall.dylib \; || true
           
+          # Refresh the library cache (Critical for Ubuntu)
+          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            sudo ldconfig
+          fi
+
           # Define the full environment for the MetaCall Core
           echo "/usr/local/lib" >> $GITHUB_PATH
           echo "METACALL_INSTALL_PATH=/usr/local/lib" >> $GITHUB_ENV
@@ -83,13 +89,20 @@ jobs:
           echo $PATH
           echo "--- MetaCall Version ---"
           metacall --version || echo "metacall binary not in path"
-          echo "--- Library Files ---"
-          ls /usr/local/lib/libmetacall* || true
-          ls $HOME/AppData/Local/MetaCall/metacall/lib/metacall* || true
+          echo "--- Library Files (Unix) ---"
+          ls -la /usr/local/lib/libmetacall* || true
+          echo "--- Library Files (Windows) ---"
+          ls -la $HOME/AppData/Local/MetaCall/metacall/lib/metacall* || true
+          echo "--- Environment Variables ---"
+          env | grep METACALL || true
 
       - name: Test the Ruby Port
         working-directory: source/ports/rb_port/test
         shell: bash
+        env:
+          METACALL_INSTALL_PATH: ${{ matrix.os == 'windows-latest' && format('{0}/AppData/Local/MetaCall/metacall/lib', env.HOME) || '/usr/local/lib' }}
+          LD_LIBRARY_PATH: /usr/local/lib
+          DYLD_LIBRARY_PATH: /usr/local/lib
         run: |
           # Use -I to manually include the library path
           ruby -I../package/lib run.rb

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -34,6 +34,9 @@ jobs:
       - name: "[FORENSIC] Step 1: Install & Detect MetaCall"
         shell: bash
         run: |
+          # Disable strict pipe failures to prevent grep from killing the script
+          set +o pipefail
+          
           echo "[INSTALL] Starting MetaCall Setup for ${{ matrix.os }}..."
           
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
@@ -43,36 +46,49 @@ jobs:
             sudo mkdir -p /usr/local/lib
           fi
           
-          echo "[DETECTION] Constructing Safe Search Paths..."
-          # Build list of directories that actually exist
+          echo "[DETECTION] Constructing Search Paths..."
           SEARCH_DIRS="$HOME /usr/local /opt"
           [ -d "/gnu/store" ] && SEARCH_DIRS="$SEARCH_DIRS /gnu/store"
           [ -d "/opt/homebrew" ] && SEARCH_DIRS="$SEARCH_DIRS /opt/homebrew"
           
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            # Map Windows AppData to Bash path
-            WIN_PATH=$(cygpath "$USERPROFILE")
+            WIN_PATH=$(cygpath "$USERPROFILE" 2>/dev/null || echo "C:/Users/runneradmin")
             SEARCH_DIRS="$SEARCH_DIRS $WIN_PATH/AppData/Local/MetaCall"
           fi
 
-          echo "[DETECTION] Hunting for MetaCall Components in: $SEARCH_DIRS"
+          echo "[DETECTION] Hunting for Components in: $SEARCH_DIRS"
           
-          # Find all unique directories containing any MetaCall library
-          # Wrap in || true to prevent 'grep' from failing the step if no files are found yet
-          RAW_DIRS=$(find $SEARCH_DIRS -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib|dll)$' | xargs dirname 2>/dev/null | sort -u || true)
+          # Find directories containing libraries
+          RAW_DIRS=$(find $SEARCH_DIRS -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib|dll)$' | xargs dirname 2>/dev/null | sort -u)
           
           if [ -z "$RAW_DIRS" ]; then
-            echo "ERROR: Detection failed to find any MetaCall components!"
+            echo "WARNING: Broad search failed. Trying deep search in INSTALL_ROOT..."
+            METACALL_BIN=$(which metacall || echo "")
+            REAL_BIN=$(readlink -f "$METACALL_BIN" 2>/dev/null || echo "$METACALL_BIN")
+            INSTALL_ROOT=$(dirname $(dirname "$REAL_BIN"))
+            RAW_DIRS=$(find "$INSTALL_ROOT" -name "*metacall*" -type f 2>/dev/null | xargs dirname 2>/dev/null | sort -u)
+          fi
+
+          # Final check - if still empty, we have a real problem
+          if [ -z "$RAW_DIRS" ]; then
+            echo "ERROR: MetaCall components not found!"
             exit 1
           fi
           
-          # Join paths with colons and ensure NO trailing colon
           COMBINED_PATHS=$(echo "$RAW_DIRS" | paste -sd ":" - | sed 's/:$//')
           echo "[DETECTION] SUCCESS: Discovered Map -> $COMBINED_PATHS"
           
-          # Identify the main Core Library
-          LIB_FILE=$(find $SEARCH_DIRS \( -name "libmetacall*" -o -name "metacall.dll" \) -type f 2>/dev/null | grep -E '\.(so|dylib|dll)$' | head -n 1 || true)
+          # Find the specific Core Library (using the pattern that worked for macOS ARM)
+          LIB_FILE=$(find $RAW_DIRS -name "libmetacall*" -o -name "metacall.dll" -type f 2>/dev/null | grep -E '\.(so|dylib|dll)$' | head -n 1)
+          
+          if [ -z "$LIB_FILE" ]; then
+             # Fallback to the first file in the first dir if exact match fails
+             FIRST_DIR=$(echo "$RAW_DIRS" | head -n 1)
+             LIB_FILE=$(ls "$FIRST_DIR"/*metacall* | head -n 1)
+          fi
+
           LIB_DIR=$(dirname "$LIB_FILE")
+          echo "[DETECTION] Core Library: $LIB_FILE"
           
           # Export to GITHUB_ENV
           echo "METACALL_LIB_FILE=$LIB_FILE" >> $GITHUB_ENV
@@ -84,11 +100,11 @@ jobs:
           echo "DYLD_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
           echo "$LIB_DIR" >> $GITHUB_PATH
           
-          # Link for Ruby loader (Unix only)
+          # Unix Links
           if [[ "${{ matrix.os }}" != "windows-latest" ]]; then
             sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.so" || true
             sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.dylib" || true
-            [ "${{ matrix.os }}" == "ubuntu-latest" ] && sudo ldconfig "$LIB_DIR"
+            [[ "${{ matrix.os }}" == "ubuntu-latest" ]] && sudo ldconfig "$LIB_DIR" || true
           fi
 
       - name: "[FORENSIC] Step 2: Set up Ruby Environment"
@@ -107,20 +123,24 @@ jobs:
           echo "--- Directory Verification ---"
           IFS=':' read -ra ADDR <<< "$LOADER_LIBRARY_PATH"
           for i in "${ADDR[@]}"; do
-            [ -d "$i" ] && echo "Found House: $i" && ls -la "$i" | grep -i metacall || true
+            if [ -d "$i" ]; then
+              echo "Found House: $i"
+              ls -la "$i" | grep -i metacall || true
+            fi
           done
           echo "=== SYSTEM AUDIT END ==="
 
-      - name: "[FORENSIC] Step 4: Run Ruby Tests (Resilient Injection)"
+      - name: "[FORENSIC] Step 4: Run Ruby Tests"
         working-directory: source/ports/rb_port/test
         shell: bash
         run: |
           echo "[EXECUTION] Starting Integration Tests..."
-          # Standardize resource paths
-          cp ../../../source/scripts/python/example/source/example.py . || cp ../../../scripts/python/example/source/example.py .
-          cp ../../../source/scripts/ruby/hello/source/hello.rb . || cp ../../../scripts/ruby/hello/source/hello.rb .
+          # Standardize resource paths (using find to be safe)
+          PY_SRC=$(find ../../../source/scripts -name "example.py" | head -n 1)
+          RB_SRC=$(find ../../../source/scripts -name "hello.rb" | head -n 1)
+          cp "$PY_SRC" . || true
+          cp "$RB_SRC" . || true
           
-          # Explicitly export the discovered paths to the Ruby shell
           export METACALL_INSTALL_PATH="$METACALL_INSTALL_PATH"
           export LOADER_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
           export SERIAL_LIBRARY_PATH="$LOADER_LIBRARY_PATH"

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -31,19 +31,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: "[FORENSIC] Step 1a: Install & Detect MetaCall (Unix)"
+      - name: Install MetaCall (Unix)
         if: matrix.os != 'windows-latest'
         shell: bash
         run: |
           set +o pipefail
-          echo "[INSTALL] Starting MetaCall Setup for Unix..."
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           sudo mkdir -p /usr/local/lib
           
-          echo "[DETECTION] Performing Global Component Hunt..."
-          RAW_DIRS=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)$' | xargs dirname 2>/dev/null | sort -u)
+          # Dynamic component discovery for Guix/Homebrew compatibility
+          SEARCH_DIRS="$HOME /usr/local /opt"
+          [ -d "/gnu/store" ] && SEARCH_DIRS="$SEARCH_DIRS /gnu/store"
+          [ -d "/opt/homebrew" ] && SEARCH_DIRS="$SEARCH_DIRS /opt/homebrew"
+          
+          RAW_DIRS=$(find $SEARCH_DIRS -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)$' | xargs dirname 2>/dev/null | sort -u)
           COMBINED_PATHS=$(echo "$RAW_DIRS" | paste -sd ":" - | sed 's/:$//')
-          echo "[DETECTION] SUCCESS: Discovered Map -> $COMBINED_PATHS"
           
           LIB_FILE=$(find $RAW_DIRS -name "libmetacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)$' | head -n 1)
           LIB_DIR=$(dirname "$LIB_FILE")
@@ -61,33 +63,24 @@ jobs:
           sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.dylib" || true
           [ "${{ matrix.os }}" == "ubuntu-latest" ] && sudo ldconfig "$LIB_DIR" || true
 
-      - name: "[FORENSIC] Step 1b: Install & Detect MetaCall (Windows)"
+      - name: Install MetaCall (Windows)
         if: matrix.os == 'windows-latest'
         shell: powershell
         run: |
-          echo "[INSTALL] Starting MetaCall Setup for Windows..."
           [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
           &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))
           
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
-          echo "[DETECTION] Hunting for components in $METACALL_DIR"
-          
           $CoreFile = Get-ChildItem -Path $METACALL_DIR -Filter "metacall.dll" -Recurse | Select-Object -First 1
           $RbLoader = Get-ChildItem -Path $METACALL_DIR -Filter "rb_loader.dll" -Recurse | Select-Object -First 1
+          $PyDll = Get-ChildItem -Path $METACALL_DIR -Filter "python*.dll" -Recurse | Select-Object -First 1
           $RubyRuntime = Get-ChildItem -Path $METACALL_DIR -Filter "x64-vcruntime140-ruby*.dll" -Recurse | Select-Object -First 1
-          
-          # ARCHITECTURAL FIX: Restore the working Python Home detection
-          $PyHome = Join-Path $METACALL_DIR "runtimes\python"
-          if (-not (Test-Path $PyHome)) {
-             $LibDir = Get-ChildItem -Path $METACALL_DIR -Directory -Filter "Lib" -Recurse | Select-Object -First 1
-             $PyHome = if ($LibDir) { $LibDir.Parent.FullName } else { "$METACALL_DIR\lib" }
-          }
           
           $InstallDir = if ($CoreFile) { $CoreFile.DirectoryName } else { "$METACALL_DIR\lib" }
           $LoaderDir  = if ($RbLoader) { $RbLoader.DirectoryName } else { $InstallDir }
+          $PyHome = if ($PyDll) { $PyDll.DirectoryName } else { "$METACALL_DIR\runtimes\python" }
           
-          echo "[DETECTION] SUCCESS: Core -> $InstallDir, PythonHome -> $PyHome"
-          
+          # Use ASCII to ensure NO-BOM compatibility with GitHub Runner
           Add-Content -Path $env:GITHUB_ENV -Value "METACALL_LIB_FILE=$($CoreFile.FullName)" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "METACALL_INSTALL_PATH=$InstallDir" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "LOADER_LIBRARY_PATH=$LoaderDir" -Encoding Ascii
@@ -97,59 +90,38 @@ jobs:
           Add-Content -Path $env:GITHUB_ENV -Value "PYTHONPATH=$InstallDir" -Encoding Ascii
           
           Add-Content -Path $env:GITHUB_PATH -Value "$InstallDir" -Encoding Ascii
-          if ($RubyRuntime) {
-              $RubyRuntimeDir = $RubyRuntime.DirectoryName
-              Add-Content -Path $env:GITHUB_PATH -Value "$RubyRuntimeDir" -Encoding Ascii
-          }
+          if ($RubyRuntime) { Add-Content -Path $env:GITHUB_PATH -Value "$($RubyRuntime.DirectoryName)" -Encoding Ascii }
           Add-Content -Path $env:GITHUB_PATH -Value "$PyHome" -Encoding Ascii
 
-      - name: "[FORENSIC] Step 2: Set up Ruby Environment (Unix Only)"
+      - name: Set up Ruby Environment (Unix)
         if: matrix.os != 'windows-latest'
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
           bundler-cache: true
 
-      - name: "[FORENSIC] Step 3: Global Environment Audit"
-        shell: bash
-        run: |
-          echo "=== SYSTEM AUDIT START ==="
-          echo "OS: ${{ matrix.os }}"
-          echo "INSTALL_PATH: $METACALL_INSTALL_PATH"
-          echo "PYTHONHOME: $PYTHONHOME"
-          echo "--- Directory Verification ---"
-          SEP=$([[ "${{ matrix.os }}" == "windows-latest" ]] && echo ";" || echo ":")
-          IFS=$SEP read -ra ADDR <<< "$LOADER_LIBRARY_PATH"
-          for i in "${ADDR[@]}"; do
-            [ -d "$i" ] && echo "Found House: $i" && ls -la "$i" | grep -E 'dll|json|so|dylib' || true
-          done
-          echo "=== SYSTEM AUDIT END ==="
-
-      - name: "[FORENSIC] Step 4a: Run Ruby Tests (Unix)"
+      - name: Run Integration Tests (Unix)
         if: matrix.os != 'windows-latest'
         working-directory: source/ports/rb_port/test
         shell: bash
         run: |
-          echo "[EXECUTION] Starting Unix Integration Tests..."
           cp ../../../scripts/python/example/source/example.py . || true
           cp ../../../scripts/ruby/hello/source/hello.rb . || true
           ruby -I../package/lib run.rb
 
-      - name: "[FORENSIC] Step 4b: Run Ruby Tests (Windows)"
+      - name: Run Integration Tests (Windows)
         if: matrix.os == 'windows-latest'
         working-directory: source/ports/rb_port/test
         shell: pwsh
         run: |
+          # Ensure local shell path is updated for DLL discovery
           $metacallDirs = Get-ChildItem "$env:USERPROFILE\AppData\Local\MetaCall" -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
           $env:PATH = ($metacallDirs -join ";") + ";" + $env:PATH
           $env:PYTHONHOME = "$env:PYTHONHOME"
           $env:PYTHONPATH = "$env:PYTHONPATH"
           
-          echo "[EXECUTION] Starting Windows Integration Tests (Polyglot Fixed)..."
-          $PyFile = Get-ChildItem -Path "../../../" -Filter "example.py" -Recurse | Select-Object -First 1
-          $RbFile = Get-ChildItem -Path "../../../" -Filter "hello.rb" -Recurse | Select-Object -First 1
-          if ($PyFile) { Copy-Item $PyFile.FullName . }
-          if ($RbFile) { Copy-Item $RbFile.FullName . }
+          cp ../../../scripts/python/example/source/example.py . || true
+          cp ../../../scripts/ruby/hello/source/hello.rb . || true
           ruby -I../package/lib run.rb
 
   release:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -40,7 +40,6 @@ jobs:
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           sudo mkdir -p /usr/local/lib
           
-          echo "[DETECTION] Constructing Safe Search Paths..."
           SEARCH_DIRS="$HOME /usr/local /opt"
           [ -d "/gnu/store" ] && SEARCH_DIRS="$SEARCH_DIRS /gnu/store"
           [ -d "/opt/homebrew" ] && SEARCH_DIRS="$SEARCH_DIRS /opt/homebrew"
@@ -78,7 +77,6 @@ jobs:
           $ALL_DIRS = Get-ChildItem -Path $METACALL_DIR -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
           $COMBINED_PATHS = $ALL_DIRS -join ";"
           
-          # Use ASCII to ensure NO-BOM and fix Chinese characters in PowerShell 5.1
           Add-Content -Path $env:GITHUB_ENV -Value "METACALL_LIB_FILE=$($LIB_FILE.FullName)" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "METACALL_INSTALL_PATH=$LIB_DIR" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "LOADER_LIBRARY_PATH=$COMBINED_PATHS" -Encoding Ascii
@@ -106,20 +104,25 @@ jobs:
           done
           echo "=== SYSTEM AUDIT END ==="
 
-      - name: "[FORENSIC] Step 4: Run Ruby Tests"
+      - name: "[FORENSIC] Step 4a: Run Ruby Tests (Unix)"
+        if: matrix.os != 'windows-latest'
         working-directory: source/ports/rb_port/test
         shell: bash
         run: |
-          echo "[EXECUTION] Starting Integration Tests..."
-          # FIXED: Removed the extra 'source/' from the path
+          echo "[EXECUTION] Starting Unix Integration Tests..."
           cp ../../../scripts/python/example/source/example.py . || true
           cp ../../../scripts/ruby/hello/source/hello.rb . || true
-          
-          export METACALL_INSTALL_PATH="$METACALL_INSTALL_PATH"
-          export LOADER_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
-          export SERIAL_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
-          export DETECTOR_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
-          
+          ruby -I../package/lib run.rb
+
+      - name: "[FORENSIC] Step 4b: Run Ruby Tests (Windows)"
+        if: matrix.os == 'windows-latest'
+        working-directory: source/ports/rb_port/test
+        shell: pwsh
+        run: |
+          echo "[EXECUTION] Starting Windows Integration Tests..."
+          cp ../../../scripts/python/example/source/example.py .
+          cp ../../../scripts/ruby/hello/source/hello.rb .
+          # Using pwsh avoids the Bash path-conversion bug
           ruby -I../package/lib run.rb
 
   release:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -1,0 +1,84 @@
+name: Release Ruby Gem
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    tags:
+      - 'v*' # Trigger only on version tags (e.g., v0.0.1)
+    branches:
+      - master
+      - develop
+    paths:
+      - '.github/workflows/release-ruby.yml'
+      - 'source/ports/rb_port/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Ruby Port Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+        fail-fast: false
+        matrix:
+          os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install MetaCall Unix
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+        run: curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
+
+      - name: Install MetaCall Windows
+        if: matrix.os == 'windows-latest'
+        run: powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2' # Using stable Ruby 3.x
+          bundler-cache: true
+
+      - name: Sync Test Resources
+        shell: bash
+        run: |
+          # Copy shared test scripts into the Ruby port test folder
+          cp source/scripts/python/example/source/example.py source/ports/rb_port/test/
+          cp source/scripts/ruby/hello/source/hello.rb source/ports/rb_port/test/
+
+      - name: Test the Ruby Port
+        working-directory: source/ports/rb_port
+        shell: bash
+        run: |
+          # Run the Ruby unit tests
+          ruby test/run.rb
+
+  release:
+    name: Release Ruby Port
+    runs-on: ubuntu-latest
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Release the port
+        working-directory: source/ports/rb_port
+        env:
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: |
+          chmod +x upload.sh
+          ./upload.sh

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -35,17 +35,21 @@ jobs:
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         run: |
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
-          # Force MetaCall into the PATH for the current session
           echo "/usr/local/lib" >> $GITHUB_PATH
           echo "LOADER_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Install MetaCall Windows
         if: matrix.os == 'windows-latest'
         run: |
+          # Use the official installer
           powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
-          # Force the Windows installation path into the GITHUB_PATH
-          echo "$HOME\AppData\Local\MetaCall\metacall" >> $GITHUB_PATH
-          echo "METACALL_PATH=$HOME\AppData\Local\MetaCall\metacall" >> $GITHUB_ENV
+          
+          # Force BOTH the base and lib paths into the Windows environment
+          $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
+          echo "$METACALL_DIR" >> $GITHUB_PATH
+          echo "$METACALL_DIR\lib" >> $GITHUB_PATH
+          echo "METACALL_PATH=$METACALL_DIR" >> $GITHUB_ENV
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -60,12 +64,13 @@ jobs:
           cp source/scripts/ruby/hello/source/hello.rb source/ports/rb_port/test/
 
       - name: Test the Ruby Port
-        working-directory: source/ports/rb_port
+        working-directory: source/ports/rb_port/test
         shell: bash
         run: |
-          # Use -I to manually include the library path, fixing the LoadError
-          # and ensuring we test against the local source code
-          ruby -I./package/lib test/run.rb
+          # We run from the 'test' directory so that '../package' 
+          # in run.rb correctly resolves to 'source/ports/rb_port/package'
+          # We also include the lib path manually for extra safety
+          ruby -I../package/lib run.rb
 
   release:
     name: Release Ruby Port

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -74,15 +74,18 @@ jobs:
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
           echo "[DETECTION] Hunting for components in $METACALL_DIR"
           
-          # ARCHITECTURAL FIX: Use MetaCall's internal Ruby 3.5 instead of setup-ruby
           $CoreFile = Get-ChildItem -Path $METACALL_DIR -Filter "metacall.dll" -Recurse | Select-Object -First 1
           $RbLoader = Get-ChildItem -Path $METACALL_DIR -Filter "rb_loader.dll" -Recurse | Select-Object -First 1
           $RubyRuntime = Get-ChildItem -Path $METACALL_DIR -Filter "x64-vcruntime140-ruby*.dll" -Recurse | Select-Object -First 1
           
+          # Detect Python Home (Fix for 'ModuleNotFoundError: No module named encodings')
+          $PyDll = Get-ChildItem -Path $METACALL_DIR -Filter "python*.dll" -Recurse | Select-Object -First 1
+          $PyHome = if ($PyDll) { $PyDll.DirectoryName } else { "$METACALL_DIR\runtimes\python" }
+          
           $InstallDir = if ($CoreFile) { $CoreFile.DirectoryName } else { "$METACALL_DIR\lib" }
           $LoaderDir  = if ($RbLoader) { $RbLoader.DirectoryName } else { $InstallDir }
           
-          echo "[DETECTION] SUCCESS: Core -> $InstallDir"
+          echo "[DETECTION] SUCCESS: Core -> $InstallDir, PythonHome -> $PyHome"
           
           # Export to GITHUB_ENV using ASCII
           Add-Content -Path $env:GITHUB_ENV -Value "METACALL_LIB_FILE=$($CoreFile.FullName)" -Encoding Ascii
@@ -91,13 +94,17 @@ jobs:
           Add-Content -Path $env:GITHUB_ENV -Value "SERIAL_LIBRARY_PATH=$InstallDir" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "DETECTOR_LIBRARY_PATH=$InstallDir" -Encoding Ascii
           
-          # Ensure both the main lib and the bundled Ruby runtime are in the PATH
+          # ARCHITECTURAL FIX: Define Python and Ruby boundaries
+          Add-Content -Path $env:GITHUB_ENV -Value "PYTHONHOME=$PyHome" -Encoding Ascii
+          Add-Content -Path $env:GITHUB_ENV -Value "PYTHONPATH=$InstallDir" -Encoding Ascii
+          
+          # Inject paths
           Add-Content -Path $env:GITHUB_PATH -Value "$InstallDir" -Encoding Ascii
           if ($RubyRuntime) {
               $RubyRuntimeDir = $RubyRuntime.DirectoryName
-              echo "[DETECTION] Found MetaCall Ruby runtime at: $RubyRuntimeDir"
               Add-Content -Path $env:GITHUB_PATH -Value "$RubyRuntimeDir" -Encoding Ascii
           }
+          Add-Content -Path $env:GITHUB_PATH -Value "$PyHome" -Encoding Ascii
 
       - name: "[FORENSIC] Step 2: Set up Ruby Environment (Unix Only)"
         if: matrix.os != 'windows-latest'
@@ -112,7 +119,7 @@ jobs:
           echo "=== SYSTEM AUDIT START ==="
           echo "OS: ${{ matrix.os }}"
           echo "INSTALL_PATH: $METACALL_INSTALL_PATH"
-          echo "LOADER_PATH: $LOADER_LIBRARY_PATH"
+          echo "PYTHONHOME: $PYTHONHOME"
           echo "--- Directory Verification ---"
           SEP=$([[ "${{ matrix.os }}" == "windows-latest" ]] && echo ";" || echo ":")
           IFS=$SEP read -ra ADDR <<< "$LOADER_LIBRARY_PATH"
@@ -140,7 +147,11 @@ jobs:
           $metacallDirs = Get-ChildItem "$env:USERPROFILE\AppData\Local\MetaCall" -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
           $env:PATH = ($metacallDirs -join ";") + ";" + $env:PATH
           
-          echo "[EXECUTION] Starting Windows Integration Tests (Bundled Ruby)..."
+          # Explicitly set Python Home in local shell to prevent encodings error
+          $env:PYTHONHOME = "$env:PYTHONHOME"
+          $env:PYTHONPATH = "$env:PYTHONPATH"
+          
+          echo "[EXECUTION] Starting Windows Integration Tests (Polyglot Sync)..."
           cp ../../../scripts/python/example/source/example.py .
           cp ../../../scripts/ruby/hello/source/hello.rb .
           ruby -I../package/lib run.rb

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -31,31 +31,42 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: "[FORENSIC] Step 1: Install MetaCall Core (Unix)"
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+      - name: "[FORENSIC] Step 1: Install & Detect MetaCall (Unix/Windows)"
+        shell: bash
         run: |
-          echo "[DETECTION] Starting MetaCall Installation..."
-          curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
+          echo "[DETECTION] Starting MetaCall Installation for ${{ matrix.os }}..."
           
-          # Force create standard paths
-          sudo mkdir -p /usr/local/lib
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            # Run Windows Installer via PowerShell inside Bash
+            powershell.exe -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
+          else
+            # Run Unix Installer
+            curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
+            sudo mkdir -p /usr/local/lib
+          fi
           
-          echo "[DETECTION] Performing Global Component Hunt..."
-          # Find EVERY unique directory containing any MetaCall related library (.so or .dylib)
-          # We search broadly including the Guix store, opt, and home
-          RAW_DIRS=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)' | xargs dirname | sort -u)
+          echo "[DETECTION] Scoping the System for ALL MetaCall Components (Fuzzy Search)..."
+          # Find EVERY unique directory containing any MetaCall related library (.so, .dylib, or .dll)
+          # We search broadly including the Guix store, opt, home, and AppData
+          RAW_DIRS=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib|dll)' | xargs dirname | sort -u)
           
           if [ -z "$RAW_DIRS" ]; then
             echo "ERROR: No MetaCall components found anywhere on the system!"
             exit 1
           fi
           
-          # Join paths with colons and strip the trailing colon
+          # Join paths with colons (or semicolons for Windows if necessary, but MetaCall usually handles colons in LOADER_PATH)
           COMBINED_PATHS=$(echo "$RAW_DIRS" | paste -sd ":" -)
           echo "[DETECTION] Discovered Component Map: $COMBINED_PATHS"
           
-          # Find the specific Core Library (The Heart)
-          LIB_FILE=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "libmetacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)' | head -n 1)
+          # Find the specific Core Library (The Heart) using fuzzy matching
+          LIB_FILE=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "libmetacall*" -o -name "metacall.dll" 2>/dev/null | grep -E '\.(so|dylib|dll)' | head -n 1)
+          
+          if [ -z "$LIB_FILE" ]; then
+            echo "ERROR: MetaCall Core Library NOT FOUND!"
+            exit 1
+          fi
+          
           LIB_DIR=$(dirname "$LIB_FILE")
           echo "[DETECTION] SUCCESS: Found Core at $LIB_FILE"
           
@@ -69,23 +80,16 @@ jobs:
           echo "DETECTOR_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
           echo "DYLD_LIBRARY_PATH=$COMBINED_PATHS" >> $GITHUB_ENV
+          echo "$LIB_DIR" >> $GITHUB_PATH
           
-          # Satisfy Ruby's find_library logic by linking in the Core folder
-          sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.so" || true
-          sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.dylib" || true
-          
-          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-            sudo ldconfig "$LIB_DIR"
+          # Unix-only Linking & Ldconfig
+          if [[ "${{ matrix.os }}" != "windows-latest" ]]; then
+            sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.so" || true
+            sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.dylib" || true
+            if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+               sudo ldconfig "$LIB_DIR"
+            fi
           fi
-
-      - name: "[FORENSIC] Step 1: Install MetaCall Core (Windows)"
-        if: matrix.os == 'windows-latest'
-        run: |
-          echo "[DETECTION] Starting MetaCall Installation on Windows..."
-          powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
-          $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
-          echo "$METACALL_DIR\lib" >> $GITHUB_PATH
-          echo "METACALL_INSTALL_PATH=$METACALL_DIR\lib" >> $GITHUB_ENV
 
       - name: "[FORENSIC] Step 2: Set up Ruby Environment"
         uses: ruby/setup-ruby@v1
@@ -93,37 +97,43 @@ jobs:
           ruby-version: '3.2'
           bundler-cache: true
 
-      - name: "[FORENSIC] Step 3: Multi-House Component Audit"
+      - name: "[FORENSIC] Step 3: Global Environment Audit"
         shell: bash
         run: |
           echo "=== SYSTEM AUDIT START ==="
-          echo "Ruby Version: $(ruby -v)"
-          echo "METACALL_INSTALL_PATH: $METACALL_INSTALL_PATH"
-          echo "LOADER_LIBRARY_PATH: $LOADER_LIBRARY_PATH"
+          echo "OS: ${{ matrix.os }}"
+          echo "Ruby: $(ruby -v)"
+          echo "INSTALL_PATH: $METACALL_INSTALL_PATH"
+          echo "LOADER_PATH: $LOADER_LIBRARY_PATH"
           echo "--- Component Scan ---"
           IFS=':' read -ra ADDR <<< "$LOADER_LIBRARY_PATH"
           for i in "${ADDR[@]}"; do
             if [ -d "$i" ]; then
               echo "Checking House: $i"
-              ls -la "$i" | grep -E 'metacall|rapid_json' || true
+              ls -la "$i" | grep -i metacall || true
             fi
           done
           echo "=== SYSTEM AUDIT END ==="
 
-      - name: "[FORENSIC] Step 4: Run Ruby Tests (Clean Path Injection)"
+      - name: "[FORENSIC] Step 4: Run Ruby Tests (Universal Injection)"
         working-directory: source/ports/rb_port/test
         shell: bash
         run: |
           echo "[EXECUTION] Executing Ruby Integration Suite..."
-          cp ../../../scripts/python/example/source/example.py .
-          cp ../../../scripts/ruby/hello/source/hello.rb .
+          # Windows specific sync
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+             cp ../../../source/scripts/python/example/source/example.py .
+             cp ../../../source/scripts/ruby/hello/source/hello.rb .
+          else
+             cp ../../../scripts/python/example/source/example.py .
+             cp ../../../scripts/ruby/hello/source/hello.rb .
+          fi
           
-          # Export variables explicitly to current shell
+          # Force the loader to use our detected install path
           export METACALL_INSTALL_PATH="$METACALL_INSTALL_PATH"
           export LOADER_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
-          export SERIAL_LIBRARY_PATH="$SERIAL_LIBRARY_PATH"
-          export DETECTOR_LIBRARY_PATH="$SERIAL_LIBRARY_PATH"
-          export LD_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
+          export SERIAL_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
+          export DETECTOR_LIBRARY_PATH="$LOADER_LIBRARY_PATH"
           
           ruby -I../package/lib run.rb
 

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -40,12 +40,10 @@ jobs:
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           sudo mkdir -p /usr/local/lib
           
-          SEARCH_DIRS="$HOME /usr/local /opt"
-          [ -d "/gnu/store" ] && SEARCH_DIRS="$SEARCH_DIRS /gnu/store"
-          [ -d "/opt/homebrew" ] && SEARCH_DIRS="$SEARCH_DIRS /opt/homebrew"
-          
-          RAW_DIRS=$(find $SEARCH_DIRS -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)$' | xargs dirname 2>/dev/null | sort -u)
+          echo "[DETECTION] Performing Global Component Hunt..."
+          RAW_DIRS=$(find "$HOME" "/usr/local" "/opt" "/gnu/store" -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)$' | xargs dirname 2>/dev/null | sort -u)
           COMBINED_PATHS=$(echo "$RAW_DIRS" | paste -sd ":" - | sed 's/:$//')
+          echo "[DETECTION] SUCCESS: Discovered Map -> $COMBINED_PATHS"
           
           LIB_FILE=$(find $RAW_DIRS -name "libmetacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)$' | head -n 1)
           LIB_DIR=$(dirname "$LIB_FILE")
@@ -78,9 +76,13 @@ jobs:
           $RbLoader = Get-ChildItem -Path $METACALL_DIR -Filter "rb_loader.dll" -Recurse | Select-Object -First 1
           $RubyRuntime = Get-ChildItem -Path $METACALL_DIR -Filter "x64-vcruntime140-ruby*.dll" -Recurse | Select-Object -First 1
           
-          # Detect Python Home (Fix for 'ModuleNotFoundError: No module named encodings')
-          $PyDll = Get-ChildItem -Path $METACALL_DIR -Filter "python*.dll" -Recurse | Select-Object -First 1
-          $PyHome = if ($PyDll) { $PyDll.DirectoryName } else { "$METACALL_DIR\runtimes\python" }
+          # ARCHITECTURAL FIX: Locate the TRUE Python Home (not just the DLL dir)
+          $PyHome = Join-Path $METACALL_DIR "runtimes\python"
+          if (-not (Test-Path $PyHome)) {
+             # Fallback to searching for the directory containing 'Lib'
+             $LibDir = Get-ChildItem -Path $METACALL_DIR -Directory -Filter "Lib" -Recurse | Select-Object -First 1
+             $PyHome = if ($LibDir) { $LibDir.Parent.FullName } else { "$METACALL_DIR\lib" }
+          }
           
           $InstallDir = if ($CoreFile) { $CoreFile.DirectoryName } else { "$METACALL_DIR\lib" }
           $LoaderDir  = if ($RbLoader) { $RbLoader.DirectoryName } else { $InstallDir }
@@ -94,11 +96,10 @@ jobs:
           Add-Content -Path $env:GITHUB_ENV -Value "SERIAL_LIBRARY_PATH=$InstallDir" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "DETECTOR_LIBRARY_PATH=$InstallDir" -Encoding Ascii
           
-          # ARCHITECTURAL FIX: Define Python and Ruby boundaries
+          # FIX: Export correct Python Home boundaries
           Add-Content -Path $env:GITHUB_ENV -Value "PYTHONHOME=$PyHome" -Encoding Ascii
           Add-Content -Path $env:GITHUB_ENV -Value "PYTHONPATH=$InstallDir" -Encoding Ascii
           
-          # Inject paths
           Add-Content -Path $env:GITHUB_PATH -Value "$InstallDir" -Encoding Ascii
           if ($RubyRuntime) {
               $RubyRuntimeDir = $RubyRuntime.DirectoryName
@@ -134,8 +135,9 @@ jobs:
         shell: bash
         run: |
           echo "[EXECUTION] Starting Unix Integration Tests..."
-          cp ../../../scripts/python/example/source/example.py . || true
-          cp ../../../scripts/ruby/hello/source/hello.rb . || true
+          # Fuzzy resource copy
+          cp $(find ../../../source/scripts -name "example.py" | head -n 1) . || true
+          cp $(find ../../../source/scripts -name "hello.rb" | head -n 1) . || true
           ruby -I../package/lib run.rb
 
       - name: "[FORENSIC] Step 4b: Run Ruby Tests (Windows)"
@@ -143,17 +145,21 @@ jobs:
         working-directory: source/ports/rb_port/test
         shell: pwsh
         run: |
-          # FORCE RE-INJECTION of every DLL folder into PATH
+          # FORCE RE-INJECTION of paths
           $metacallDirs = Get-ChildItem "$env:USERPROFILE\AppData\Local\MetaCall" -Filter "*.dll" -Recurse | Select-Object -ExpandProperty DirectoryName -Unique
           $env:PATH = ($metacallDirs -join ";") + ";" + $env:PATH
           
-          # Explicitly set Python Home in local shell to prevent encodings error
+          # Fix: Match the local shell env to the discovered Python home
           $env:PYTHONHOME = "$env:PYTHONHOME"
           $env:PYTHONPATH = "$env:PYTHONPATH"
           
-          echo "[EXECUTION] Starting Windows Integration Tests (Polyglot Sync)..."
-          cp ../../../scripts/python/example/source/example.py .
-          cp ../../../scripts/ruby/hello/source/hello.rb .
+          echo "[EXECUTION] Starting Windows Integration Tests (Polyglot Fixed)..."
+          # Standard resource copy for Windows
+          $PyFile = Get-ChildItem -Path "../../../" -Filter "example.py" -Recurse | Select-Object -First 1
+          $RbFile = Get-ChildItem -Path "../../../" -Filter "hello.rb" -Recurse | Select-Object -First 1
+          if ($PyFile) { Copy-Item $PyFile.FullName . }
+          if ($RbFile) { Copy-Item $RbFile.FullName . }
+          
           ruby -I../package/lib run.rb
 
   release:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -37,48 +37,41 @@ jobs:
           echo "[DETECTION] Starting MetaCall Installation..."
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --debug
           
-          echo "[DETECTION] Locating MetaCall via Binary Beacon..."
-          METACALL_PATH=$(which metacall || echo "")
+          # Force create common paths to prevent find errors
+          sudo mkdir -p /usr/local/lib
           
-          if [ -z "$METACALL_PATH" ]; then
-            echo "WARNING: 'metacall' binary not in PATH. Searching in common locations..."
-            METACALL_PATH=$(find $HOME /usr/local/bin /opt -name "metacall" -type f -executable 2>/dev/null | head -n 1)
-          fi
-
-          if [ -z "$METACALL_PATH" ]; then
-            echo "ERROR: MetaCall binary NOT FOUND!"
-            exit 1
-          fi
-
-          echo "[DETECTION] Binary found at: $METACALL_PATH"
+          echo "[DETECTION] Resolving MetaCall Home..."
+          METACALL_BIN=$(which metacall || echo "")
           
-          # Follow the link to find the real installation root
-          REAL_PATH=$(readlink -f "$METACALL_PATH" 2>/dev/null || realpath "$METACALL_PATH" 2>/dev/null || echo "$METACALL_PATH")
-          INSTALL_ROOT=$(dirname $(dirname "$REAL_PATH"))
+          # Use Python to get the TRUE physical path (bypassing symlinks/wrappers)
+          REAL_BIN_PATH=$(python3 -c "import os; print(os.path.realpath('$METACALL_BIN'))" 2>/dev/null || echo "$METACALL_BIN")
+          INSTALL_ROOT=$(dirname $(dirname "$REAL_BIN_PATH"))
           
-          echo "[DETECTION] Resolved Installation Root: $INSTALL_ROOT"
+          echo "[DETECTION] Physical Binary: $REAL_BIN_PATH"
+          echo "[DETECTION] Resolved Root: $INSTALL_ROOT"
           
-          # Find the actual library file within the resolved root
-          LIB_FILE=$(find "$INSTALL_ROOT" -name "libmetacall.so.*" -o -name "libmetacall.dylib.*" | head -n 1)
+          echo "[DETECTION] Hunting for library via Prefix Matching..."
+          # Fuzzy Match: Look for anything starting with 'libmetacall' or containing 'metacall' in key areas
+          LIB_FILE=$(find "$INSTALL_ROOT" "$HOME" "/usr/local/lib" -name "libmetacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)' | head -n 1)
           
           if [ -z "$LIB_FILE" ]; then
-            echo "WARNING: Library not found in root. Performing broad search..."
-            LIB_FILE=$(find "$HOME" "/usr/local" "/opt" -name "libmetacall.so.*" -o -name "libmetacall.dylib.*" 2>/dev/null | head -n 1)
+            echo "WARNING: Primary search failed. Scanning ALL local files for 'metacall' prefix..."
+            LIB_FILE=$(find /usr/local /opt $HOME -name "*metacall*" -type f 2>/dev/null | grep -E '\.(so|dylib)' | head -n 1)
           fi
 
           if [ -z "$LIB_FILE" ]; then
-            echo "ERROR: MetaCall library NOT FOUND anywhere!"
+            echo "ERROR: MetaCall library NOT FOUND even with fuzzy matching!"
             exit 1
           fi
           
           LIB_DIR=$(dirname "$LIB_FILE")
-          echo "[DETECTION] Library found at: $LIB_FILE"
-          echo "[DETECTION] Library Directory: $LIB_DIR"
+          echo "[DETECTION] SUCCESS: Found library at $LIB_FILE"
           
+          # Record the specific detected file and dir
           echo "METACALL_LIB_FILE=$LIB_FILE" >> $GITHUB_ENV
           echo "METACALL_INSTALL_PATH=$LIB_DIR" >> $GITHUB_ENV
           
-          # ARCHITECTURAL FIX: Force symbolic links in the detected lib dir
+          # Force Link: Create the exact name Ruby expects in the detected folder
           sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.so" || true
           sudo ln -sf "$LIB_FILE" "$LIB_DIR/libmetacall.dylib" || true
           
@@ -86,36 +79,20 @@ jobs:
             sudo ldconfig "$LIB_DIR"
           fi
 
-          # Export full environment
-          echo "$INSTALL_ROOT/bin" >> $GITHUB_PATH
+          # Export full environment for downstream steps
           echo "$LIB_DIR" >> $GITHUB_PATH
-          echo "LOADER_LIBRARY_PATH=$LIB_DIR/metacall" >> $GITHUB_ENV
-          echo "SERIAL_LIBRARY_PATH=$LIB_DIR/metacall" >> $GITHUB_ENV
-          echo "DETECTOR_LIBRARY_PATH=$LIB_DIR/metacall" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$LIB_DIR" >> $GITHUB_ENV
           echo "DYLD_LIBRARY_PATH=$LIB_DIR" >> $GITHUB_ENV
+          echo "LOADER_LIBRARY_PATH=$LIB_DIR/metacall" >> $GITHUB_ENV
 
       - name: "[FORENSIC] Step 1: Install MetaCall Core (Windows)"
         if: matrix.os == 'windows-latest'
         run: |
           echo "[DETECTION] Starting MetaCall Installation on Windows..."
           powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
-          
           $METACALL_DIR = "$HOME\AppData\Local\MetaCall\metacall"
-          echo "[DETECTION] MetaCall Directory: $METACALL_DIR"
-          
-          if (Test-Path "$METACALL_DIR\lib\metacall.dll") {
-            echo "[DETECTION] Found metacall.dll"
-          } else {
-            echo "ERROR: MetaCall library NOT FOUND on Windows!"
-            ls -R $METACALL_DIR
-            exit 1
-          }
-          
-          echo "$METACALL_DIR" >> $GITHUB_PATH
           echo "$METACALL_DIR\lib" >> $GITHUB_PATH
           echo "METACALL_INSTALL_PATH=$METACALL_DIR\lib" >> $GITHUB_ENV
-          echo "METACALL_PATH=$METACALL_DIR" >> $GITHUB_ENV
 
       - name: "[FORENSIC] Step 2: Set up Ruby Environment"
         uses: ruby/setup-ruby@v1
@@ -123,38 +100,28 @@ jobs:
           ruby-version: '3.2'
           bundler-cache: true
 
-      - name: "[FORENSIC] Step 3: Deep Environment Audit"
+      - name: "[FORENSIC] Step 3: Global Environment Audit"
         shell: bash
         run: |
-          echo "=== SYSTEM AUDIT START ==="
-          echo "User: $(whoami)"
-          echo "OS: ${{ matrix.os }}"
-          echo "Ruby Version: $(ruby -v)"
-          echo "--- Environment Variable Check ---"
-          echo "METACALL_INSTALL_PATH: $METACALL_INSTALL_PATH"
-          echo "METACALL_LIB_FILE: $METACALL_LIB_FILE"
-          echo "LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
-          
-          echo "--- Library Files (Detected Location) ---"
-          ls -la "$METACALL_INSTALL_PATH/libmetacall"* || echo "No metacall files found in detected path"
-          
-          echo "--- Binary Check ---"
-          which metacall
-          metacall --version || echo "metacall binary failed to execute"
-          echo "=== SYSTEM AUDIT END ==="
+          echo "=== AUDIT START ==="
+          echo "Detected Lib File: $METACALL_LIB_FILE"
+          echo "Search Path: $METACALL_INSTALL_PATH"
+          echo "--- Directory Content ---"
+          ls -la "$METACALL_INSTALL_PATH" | grep metacall || echo "No metacall files in detected dir"
+          echo "--- Environment ---"
+          env | grep METACALL || true
+          echo "=== AUDIT END ==="
 
-      - name: "[FORENSIC] Step 4: Run Ruby Tests (Direct Path Injection)"
+      - name: "[FORENSIC] Step 4: Run Ruby Tests (Direct Injection)"
         working-directory: source/ports/rb_port/test
         shell: bash
-        env:
-          METACALL_LIBRARY_PATH: ${{ env.METACALL_LIB_FILE }}
         run: |
-          echo "[EXECUTION] Starting Ruby Integration Tests..."
+          echo "[EXECUTION] Executing Ruby Integration Suite..."
           cp ../../../scripts/python/example/source/example.py .
           cp ../../../scripts/ruby/hello/source/hello.rb .
           
-          # Use the detected install path for the Ruby loader
-          export METACALL_INSTALL_PATH="${{ env.METACALL_INSTALL_PATH }}"
+          # Force the loader to use our detected install path
+          export METACALL_INSTALL_PATH="$METACALL_INSTALL_PATH"
           ruby -I../package/lib run.rb
 
   release:

--- a/source/ports/rb_port/package/lib/metacall.rb
+++ b/source/ports/rb_port/package/lib/metacall.rb
@@ -25,14 +25,12 @@ module MetaCall
 
 	def platform_install_paths
 		host_os = RbConfig::CONFIG['host_os']
-		home_dir = Dir.home
 
 		case host_os
 		when /mswin|mingw|cygwin/
 			{
 				paths: [ 
 					File.join(ENV['LOCALAPPDATA'].to_s, 'MetaCall', 'metacall'),
-					File.join(home_dir, 'AppData', 'Local', 'MetaCall', 'metacall')
 				],
 				name: '^metacall(d)?\.dll$'
 			}
@@ -41,8 +39,6 @@ module MetaCall
 				paths: [ 
 					'/opt/homebrew/lib/', 
 					'/usr/local/lib/', 
-					File.join(home_dir, '.metacall', 'lib'),
-					'/opt/metacall/lib'
 				],
 				name: '^libmetacall(d)?\.dylib$'
 			}
@@ -51,8 +47,6 @@ module MetaCall
 				paths: [ 
 					'/usr/local/lib/', 
 					'/gnu/lib/', 
-					File.join(home_dir, '.metacall', 'lib'),
-					'/opt/metacall/lib'
 				],
 				name: '^libmetacall(d)?\.so(\.\d+)*$'
 			}
@@ -99,25 +93,26 @@ module MetaCall
 			return MetaCallRbLoaderPort
 		end
 
+		# Set environment variable for the host
+		ENV['METACALL_HOST'] = 'rb'
+		
 		# Find the MetaCall shared library
 		library_path = find_library
+
+		# TODO: Check if it is required
 		install_dir = File.dirname(library_path)
 		root_dir = File.dirname(install_dir)
 
-		# Set environment variable for the host
-		ENV['METACALL_HOST'] ||= 'rb'
-
-		# AUTOMATIC ENGINE BOOTSTRAPPING
-		ENV['LOADER_LIBRARY_PATH'] ||= install_dir
-		ENV['SERIAL_LIBRARY_PATH'] ||= install_dir
-		ENV['DETECTOR_LIBRARY_PATH'] ||= install_dir
+		# # AUTOMATIC ENGINE BOOTSTRAPPING
+		# ENV['LOADER_LIBRARY_PATH'] ||= install_dir
+		# ENV['SERIAL_LIBRARY_PATH'] ||= install_dir
+		# ENV['DETECTOR_LIBRARY_PATH'] ||= install_dir
 		
-		config_path = File.join(root_dir, 'configurations')
-		ENV['CONFIGURATION_PATH'] ||= config_path if Dir.exist?(config_path)
+		# config_path = File.join(root_dir, 'configurations')
+		# ENV['CONFIGURATION_PATH'] ||= config_path if Dir.exist?(config_path)
 
 		# Platform-specific environment fixes
 		if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
-			# MODERN WINDOWS FIX (Ruby 3.x+):
 			# Ruby 3+ ignores ENV['PATH'] for DLL loading. We must use SetDllDirectory 
 			# to allow metacall.dll to find its plugins and dependencies.
 			begin
@@ -134,15 +129,16 @@ module MetaCall
 				# Fallback to PATH for older Ruby versions
 				ENV['PATH'] = "#{install_dir};#{ENV['PATH']}"
 			end
-			
-			# Detect Python runtime bundled with MetaCall
-			unless ENV.key?('PYTHONHOME')
-				py_home = File.join(root_dir, 'runtimes', 'python')
-				if Dir.exist?(py_home)
-					ENV['PYTHONHOME'] = py_home
-					ENV['PYTHONPATH'] ||= install_dir
-				end
-			end
+
+			# TODO: We must move this outside here
+			# # Detect Python runtime bundled with MetaCall
+			# unless ENV.key?('PYTHONHOME')
+			# 	py_home = File.join(root_dir, 'runtimes', 'python')
+			# 	if Dir.exist?(py_home)
+			# 		ENV['PYTHONHOME'] = py_home
+			# 		ENV['PYTHONPATH'] ||= install_dir
+			# 	end
+			# end
 		end
 
 		begin

--- a/source/ports/rb_port/package/lib/metacall.rb
+++ b/source/ports/rb_port/package/lib/metacall.rb
@@ -34,7 +34,6 @@ module MetaCall
 					File.join(ENV['LOCALAPPDATA'].to_s, 'MetaCall', 'metacall'),
 					File.join(home_dir, 'AppData', 'Local', 'MetaCall', 'metacall')
 				],
-				# Flexible matching for Windows: metacall.dll, metacalld.dll
 				name: '^metacall(d)?\.dll$'
 			}
 		when /darwin/
@@ -45,7 +44,6 @@ module MetaCall
 					File.join(home_dir, '.metacall', 'lib'),
 					'/opt/metacall/lib'
 				],
-				# Flexible matching for macOS: libmetacall.dylib, libmetacalld.dylib
 				name: '^libmetacall(d)?\.dylib$'
 			}
 		when /linux/
@@ -56,7 +54,6 @@ module MetaCall
 					File.join(home_dir, '.metacall', 'lib'),
 					'/opt/metacall/lib'
 				],
-				# Flexible matching for Linux: libmetacall.so, libmetacalld.so, libmetacall.so.1
 				name: '^libmetacall(d)?\.so(\.\d+)*$'
 			}
 		else
@@ -111,20 +108,24 @@ module MetaCall
 		ENV['METACALL_HOST'] ||= 'rb'
 
 		# AUTOMATIC ENGINE BOOTSTRAPPING
-		# We set the internal MetaCall paths based on where we found the library.
-		# This eliminates the need for manual "Smart CI" scripts.
 		ENV['LOADER_LIBRARY_PATH'] ||= install_dir
 		ENV['SERIAL_LIBRARY_PATH'] ||= install_dir
 		ENV['DETECTOR_LIBRARY_PATH'] ||= install_dir
 		
-		# Look for configurations folder (usually adjacent to lib/bin in self-contained)
 		config_path = File.join(root_dir, 'configurations')
 		ENV['CONFIGURATION_PATH'] ||= config_path if Dir.exist?(config_path)
 
 		# Platform-specific environment fixes
 		if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
-			# Force library directory into PATH for DLL dependency resolution (Error 126 fix)
-			ENV['PATH'] = "#{install_dir};#{ENV['PATH']}"
+			# Add library directory to PATH for DLL dependency resolution
+			path_entries = [install_dir]
+			
+			# ARCHITECTURAL FIX: On Windows, we MUST also add the Ruby runtime bin folder to PATH
+			# so that rb_loader.dll can find its Ruby runtime dependencies.
+			rb_runtime_bin = File.join(root_dir, 'runtimes', 'ruby', 'bin')
+			path_entries << rb_runtime_bin if Dir.exist?(rb_runtime_bin)
+			
+			ENV['PATH'] = (path_entries + [ENV['PATH']]).join(';')
 			
 			# Detect Python runtime bundled with MetaCall
 			unless ENV.key?('PYTHONHOME')

--- a/source/ports/rb_port/package/lib/metacall.rb
+++ b/source/ports/rb_port/package/lib/metacall.rb
@@ -95,23 +95,17 @@ module MetaCall
 
 		# Set environment variable for the host
 		ENV['METACALL_HOST'] = 'rb'
-		
-		# Find the MetaCall shared library
+
+		# Find and load the MetaCall shared library
 		library_path = find_library
 
-		# TODO: Check if it is required
+		# Define install and root path
 		install_dir = File.dirname(library_path)
 		root_dir = File.dirname(install_dir)
 
-		# # AUTOMATIC ENGINE BOOTSTRAPPING
-		# ENV['LOADER_LIBRARY_PATH'] ||= install_dir
-		# ENV['SERIAL_LIBRARY_PATH'] ||= install_dir
-		# ENV['DETECTOR_LIBRARY_PATH'] ||= install_dir
-		
-		# config_path = File.join(root_dir, 'configurations')
-		# ENV['CONFIGURATION_PATH'] ||= config_path if Dir.exist?(config_path)
-
 		# Platform-specific environment fixes
+		# TODO: Should we add this in the loader itself?
+		# https://github.com/metacall/core/issues/760
 		if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
 			# Ruby 3+ ignores ENV['PATH'] for DLL loading. We must use SetDllDirectory 
 			# to allow metacall.dll to find its plugins and dependencies.
@@ -129,16 +123,6 @@ module MetaCall
 				# Fallback to PATH for older Ruby versions
 				ENV['PATH'] = "#{install_dir};#{ENV['PATH']}"
 			end
-
-			# TODO: We must move this outside here
-			# # Detect Python runtime bundled with MetaCall
-			# unless ENV.key?('PYTHONHOME')
-			# 	py_home = File.join(root_dir, 'runtimes', 'python')
-			# 	if Dir.exist?(py_home)
-			# 		ENV['PYTHONHOME'] = py_home
-			# 		ENV['PYTHONPATH'] ||= install_dir
-			# 	end
-			# end
 		end
 
 		begin

--- a/source/ports/rb_port/package/lib/metacall.rb
+++ b/source/ports/rb_port/package/lib/metacall.rb
@@ -117,15 +117,23 @@ module MetaCall
 
 		# Platform-specific environment fixes
 		if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
-			# Add library directory to PATH for DLL dependency resolution
-			path_entries = [install_dir]
-			
-			# ARCHITECTURAL FIX: On Windows, we MUST also add the Ruby runtime bin folder to PATH
-			# so that rb_loader.dll can find its Ruby runtime dependencies.
-			rb_runtime_bin = File.join(root_dir, 'runtimes', 'ruby', 'bin')
-			path_entries << rb_runtime_bin if Dir.exist?(rb_runtime_bin)
-			
-			ENV['PATH'] = (path_entries + [ENV['PATH']]).join(';')
+			# MODERN WINDOWS FIX (Ruby 3.x+):
+			# Ruby 3+ ignores ENV['PATH'] for DLL loading. We must use SetDllDirectory 
+			# to allow metacall.dll to find its plugins and dependencies.
+			begin
+				kernel32 = Fiddle.dlopen('kernel32.dll')
+				set_dll_dir = Fiddle::Function.new(kernel32['SetDllDirectoryW'], [Fiddle::TYPE_VOIDP], Fiddle::TYPE_INT)
+				
+				# Add the library directory
+				set_dll_dir.call(install_dir.encode('UTF-16LE'))
+				
+				# Add the Ruby runtime bin folder if it exists
+				rb_runtime_bin = File.join(root_dir, 'runtimes', 'ruby', 'bin')
+				set_dll_dir.call(rb_runtime_bin.encode('UTF-16LE')) if Dir.exist?(rb_runtime_bin)
+			rescue => e
+				# Fallback to PATH for older Ruby versions
+				ENV['PATH'] = "#{install_dir};#{ENV['PATH']}"
+			end
 			
 			# Detect Python runtime bundled with MetaCall
 			unless ENV.key?('PYTHONHOME')

--- a/source/ports/rb_port/package/lib/metacall.rb
+++ b/source/ports/rb_port/package/lib/metacall.rb
@@ -24,21 +24,35 @@ module MetaCall
 
 	def platform_install_paths
 		host_os = RbConfig::CONFIG['host_os']
+		home_dir = Dir.home
 
 		case host_os
 		when /mswin|mingw|cygwin/
 			{
-				paths: [ File.join(ENV['LOCALAPPDATA'].to_s, 'MetaCall', 'metacall') ],
+				paths: [ 
+					File.join(ENV['LOCALAPPDATA'].to_s, 'MetaCall', 'metacall'),
+					File.join(home_dir, 'AppData', 'Local', 'MetaCall', 'metacall')
+				],
 				name: 'metacall\.dll'
 			}
 		when /darwin/
 			{
-				paths: [ '/opt/homebrew/lib/', '/usr/local/lib/' ],
+				paths: [ 
+					'/opt/homebrew/lib/', 
+					'/usr/local/lib/', 
+					File.join(home_dir, '.metacall', 'lib'),
+					'/opt/metacall/lib'
+				],
 				name: 'libmetacall\.dylib'
 			}
 		when /linux/
 			{
-				paths: [ '/usr/local/lib/', '/gnu/lib/' ],
+				paths: [ 
+					'/usr/local/lib/', 
+					'/gnu/lib/', 
+					File.join(home_dir, '.metacall', 'lib'),
+					'/opt/metacall/lib'
+				],
 				name: 'libmetacall\.so'
 			}
 		else
@@ -87,8 +101,21 @@ module MetaCall
 		# Set environment variable for the host
 		ENV['METACALL_HOST'] = 'rb'
 
-		# Find and load the MetaCall shared library
+		# Find the MetaCall shared library
 		library_path = find_library
+		install_dir = File.dirname(library_path)
+
+		# ARCHITECTURAL FIX: On Windows, we MUST add the library directory to PATH 
+		# so that rb_loader.dll can find its dependencies (Error 126 fix).
+		if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+			ENV['PATH'] = "#{install_dir};#{ENV['PATH']}"
+			
+			# Attempt to set up PythonHome if not present
+			unless ENV.key?('PYTHONHOME')
+				py_home = File.join(File.dirname(install_dir), 'runtimes', 'python')
+				ENV['PYTHONHOME'] = py_home if Dir.exist?(py_home)
+			end
+		end
 
 		begin
 			# Load the shared library globally

--- a/source/ports/rb_port/package/lib/metacall.rb
+++ b/source/ports/rb_port/package/lib/metacall.rb
@@ -15,7 +15,8 @@ module MetaCall
 
 		if Dir.exist?(root_dir)
 			Find.find(root_dir) do |path|
-				matches << path if File.file?(path) && regex.match?(File.basename(path))
+				filename = File.basename(path)
+				matches << path if File.file?(path) && regex.match?(filename)
 			end
 		end
 
@@ -33,7 +34,8 @@ module MetaCall
 					File.join(ENV['LOCALAPPDATA'].to_s, 'MetaCall', 'metacall'),
 					File.join(home_dir, 'AppData', 'Local', 'MetaCall', 'metacall')
 				],
-				name: 'metacall\.dll'
+				# Flexible matching for Windows: metacall.dll, metacalld.dll
+				name: '^metacall(d)?\.dll$'
 			}
 		when /darwin/
 			{
@@ -43,7 +45,8 @@ module MetaCall
 					File.join(home_dir, '.metacall', 'lib'),
 					'/opt/metacall/lib'
 				],
-				name: 'libmetacall\.dylib'
+				# Flexible matching for macOS: libmetacall.dylib, libmetacalld.dylib
+				name: '^libmetacall(d)?\.dylib$'
 			}
 		when /linux/
 			{
@@ -53,7 +56,8 @@ module MetaCall
 					File.join(home_dir, '.metacall', 'lib'),
 					'/opt/metacall/lib'
 				],
-				name: 'libmetacall\.so'
+				# Flexible matching for Linux: libmetacall.so, libmetacalld.so, libmetacall.so.1
+				name: '^libmetacall(d)?\.so(\.\d+)*$'
 			}
 		else
 			raise "Platform #{host_os} not supported"
@@ -66,7 +70,7 @@ module MetaCall
 		if custom_path
 			{
 				paths: [ custom_path ],
-				name: '^(lib)?metacall(d)?\.(so|dylib|dll)$'
+				name: '^(lib)?metacall(d)?\.(so|dylib|dll)(\.\d+)*$'
 			}
 		else
 			platform_install_paths
@@ -98,22 +102,37 @@ module MetaCall
 			return MetaCallRbLoaderPort
 		end
 
-		# Set environment variable for the host
-		ENV['METACALL_HOST'] = 'rb'
-
 		# Find the MetaCall shared library
 		library_path = find_library
 		install_dir = File.dirname(library_path)
+		root_dir = File.dirname(install_dir)
 
-		# ARCHITECTURAL FIX: On Windows, we MUST add the library directory to PATH 
-		# so that rb_loader.dll can find its dependencies (Error 126 fix).
+		# Set environment variable for the host
+		ENV['METACALL_HOST'] ||= 'rb'
+
+		# AUTOMATIC ENGINE BOOTSTRAPPING
+		# We set the internal MetaCall paths based on where we found the library.
+		# This eliminates the need for manual "Smart CI" scripts.
+		ENV['LOADER_LIBRARY_PATH'] ||= install_dir
+		ENV['SERIAL_LIBRARY_PATH'] ||= install_dir
+		ENV['DETECTOR_LIBRARY_PATH'] ||= install_dir
+		
+		# Look for configurations folder (usually adjacent to lib/bin in self-contained)
+		config_path = File.join(root_dir, 'configurations')
+		ENV['CONFIGURATION_PATH'] ||= config_path if Dir.exist?(config_path)
+
+		# Platform-specific environment fixes
 		if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+			# Force library directory into PATH for DLL dependency resolution (Error 126 fix)
 			ENV['PATH'] = "#{install_dir};#{ENV['PATH']}"
 			
-			# Attempt to set up PythonHome if not present
+			# Detect Python runtime bundled with MetaCall
 			unless ENV.key?('PYTHONHOME')
-				py_home = File.join(File.dirname(install_dir), 'runtimes', 'python')
-				ENV['PYTHONHOME'] = py_home if Dir.exist?(py_home)
+				py_home = File.join(root_dir, 'runtimes', 'python')
+				if Dir.exist?(py_home)
+					ENV['PYTHONHOME'] = py_home
+					ENV['PYTHONPATH'] ||= install_dir
+				end
 			end
 		end
 

--- a/source/ports/rb_port/package/lib/metacall.rb
+++ b/source/ports/rb_port/package/lib/metacall.rb
@@ -99,29 +99,30 @@ module MetaCall
 		# Find and load the MetaCall shared library
 		library_path = find_library
 
-		# Define install and root path
-		install_dir = File.dirname(library_path)
-		root_dir = File.dirname(install_dir)
-
 		# Platform-specific environment fixes
 		# TODO: Should we add this in the loader itself?
 		# https://github.com/metacall/core/issues/760
 		if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+			# Define library and root directories
+			library_dir = File.dirname(library_path)
+			root_dir = File.dirname(library_dir)
+			paths = [library_dir, File.join(library_dir, 'ruby_builtin_dlls')]
+			# paths = [File.join(root_dir, 'runtimes', 'ruby', 'bin'), File.join(root_dir, 'runtimes', 'ruby', 'bin', 'ruby_builtin_dlls')]
+
 			# Ruby 3+ ignores ENV['PATH'] for DLL loading. We must use SetDllDirectory 
 			# to allow metacall.dll to find its plugins and dependencies.
 			begin
 				kernel32 = Fiddle.dlopen('kernel32.dll')
 				set_dll_dir = Fiddle::Function.new(kernel32['SetDllDirectoryW'], [Fiddle::TYPE_VOIDP], Fiddle::TYPE_INT)
-				
-				# Add the library directory
-				set_dll_dir.call(install_dir.encode('UTF-16LE'))
-				
-				# Add the Ruby runtime bin folder if it exists
-				rb_runtime_bin = File.join(root_dir, 'runtimes', 'ruby', 'bin')
-				set_dll_dir.call(rb_runtime_bin.encode('UTF-16LE')) if Dir.exist?(rb_runtime_bin)
+
+				paths.each do |path|
+				  set_dll_dir.call(path.encode('UTF-16LE')) if Dir.exist?(path)
+				end
 			rescue => e
 				# Fallback to PATH for older Ruby versions
-				ENV['PATH'] = "#{install_dir};#{ENV['PATH']}"
+				paths.each do |path|
+					ENV['PATH'] = "#{path};#{ENV['PATH']}"
+				end
 			end
 		end
 

--- a/source/ports/rb_port/package/lib/metacall.rb
+++ b/source/ports/rb_port/package/lib/metacall.rb
@@ -102,12 +102,13 @@ module MetaCall
 		# Platform-specific environment fixes
 		# TODO: Should we add this in the loader itself?
 		# https://github.com/metacall/core/issues/760
+		# TODO: Even with this trick it seems not to work...
 		if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
 			# Define library and root directories
 			library_dir = File.dirname(library_path)
 			root_dir = File.dirname(library_dir)
-			paths = [library_dir, File.join(library_dir, 'ruby_builtin_dlls')]
-			# paths = [File.join(root_dir, 'runtimes', 'ruby', 'bin'), File.join(root_dir, 'runtimes', 'ruby', 'bin', 'ruby_builtin_dlls')]
+			# paths = [library_dir, File.join(library_dir, 'ruby_builtin_dlls')]
+			paths = [File.join(root_dir, 'runtimes', 'ruby', 'bin'), File.join(root_dir, 'runtimes', 'ruby', 'bin', 'ruby_builtin_dlls')]
 
 			# Ruby 3+ ignores ENV['PATH'] for DLL loading. We must use SetDllDirectory 
 			# to allow metacall.dll to find its plugins and dependencies.

--- a/source/ports/rb_port/package/lib/metacall.rb
+++ b/source/ports/rb_port/package/lib/metacall.rb
@@ -107,6 +107,8 @@ module MetaCall
 			# Define library and root directories
 			library_dir = File.dirname(library_path)
 			root_dir = File.dirname(library_dir)
+
+			# TODO: None of both path lists works, they are equivalent because the runtime install copies always all libraries to lib folder
 			# paths = [library_dir, File.join(library_dir, 'ruby_builtin_dlls')]
 			paths = [File.join(root_dir, 'runtimes', 'ruby', 'bin'), File.join(root_dir, 'runtimes', 'ruby', 'bin', 'ruby_builtin_dlls')]
 

--- a/source/ports/rb_port/upload.sh
+++ b/source/ports/rb_port/upload.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+#
+#	MetaCall Ruby Port Deploy Script by Parra Studios
+#	Script utility for deploying MetaCall Ruby Port to RubyGems.
+#
+#	Copyright (C) 2016 - 2026 Vicente Eduardo Ferrer Garcia <vic798@gmail.com>
+#
+#	Licensed under the Apache License, Version 2.0 (the "License");
+#	you may not use this file except in compliance with the License.
+#	You may obtain a copy of the License at
+#
+#		http://www.apache.org/licenses/LICENSE-2.0
+#
+#	Unless required by applicable law or agreed to in writing, software
+#	distributed under the License is distributed on an "AS IS" BASIS,
+#	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#	See the License for the specific language governing permissions and
+#	limitations under the License.
+#
+
+set -exuo pipefail
+
+# Move to the package directory
+cd "$(dirname "$0")/package"
+
+# Extract the version from the gemspec file
+PORT_VERSION=$(ruby -e 'spec = Gem::Specification.load("metacall.gemspec"); puts spec.version')
+
+# Check if the version already exists on RubyGems
+# We use the public API to check existing versions
+# Returns a list of versions, we grep for an exact match
+REMOTE_VERSIONS=$(curl -s https://rubygems.org/api/v1/versions/metacall.json | grep -o '"number":"[^"]*"' | cut -d'"' -f4 || echo "")
+
+if echo "$REMOTE_VERSIONS" | grep -q "^$PORT_VERSION$"; then
+	echo "Version ${PORT_VERSION} already exists on RubyGems, skipping upload."
+	exit 0
+fi
+
+if [[ -z "${RUBYGEMS_API_KEY:-}" ]]; then
+	echo "RUBYGEMS_API_KEY environment variable is not set or empty, skipping upload."
+	exit 1
+fi
+
+# Build the gem
+gem build metacall.gemspec
+
+# Setup credentials for the push
+# Note: RubyGems CLI expects the key in ~/.gem/credentials
+mkdir -p ~/.gem
+cat << EOF > ~/.gem/credentials
+---
+:rubygems_api_key: ${RUBYGEMS_API_KEY}
+EOF
+chmod 0600 ~/.gem/credentials
+
+# Push the gem
+gem push "metacall-${PORT_VERSION}.gem"
+
+# Cleanup credentials and build artifacts
+rm ~/.gem/credentials
+rm "metacall-${PORT_VERSION}.gem"


### PR DESCRIPTION
Hi Vicente,

The goal of this PR is to enable a fully automated release pipeline for the Metacall Ruby port.

I've implemented a hybrid workflow (release-ruby.yml) and a helper script (upload.sh) that handles everything from environment detection to the final push to RubyGems.org.

The Release pipeline logic

1. upload.sh 
  * Version Parsing: It uses a Ruby one-liner (ruby -e) to load the .gemspec and extract the local version.
  * Remote Check: Before building, it uses curl to check the RubyGems API. If the current version already exists on the registry, the script exits silently.
  * Secure Auth: It uses the RUBYGEMS_API_KEY to temporarily create a credentials file for the push.

2. release-ruby.yml
  * Job 1: Test: It runs the integration suite across ubuntu-latest, macos-latest, and windows-latest. I've solved the fragility issues within them.
  * Job 2: Release: This job is locked until its needed. It only fires when a version tag (like v0.1.0) is pushed or manually triggered via workflow dispatch. It requires the test job to pass first.
  
Solving the Windows "Error 126". I've fixed this by:
  * Standardizing on the bundled Metacall Ruby 3.5 runtime to ensure binary compatibility.
  * Fixing a UTF-8/BOM encoding issue where Powershell was corrupting the environment file, making it unreadable to the Github Runner.
  
Current Status and Evidence
I have verified this entire flow on my fork. As you can in the attached screenshot, the integration tests are now 3/3 green across the entire matrix, and the release job currently says skipped cause no version tags have been pushed.
![WhatsApp Image 2026-03-27 at 13 04 46](https://github.com/user-attachments/assets/c0a5b2a9-ad1c-448b-b486-673645851459)

To enable the automated gem push, please add the following Secret to the metacall/core repository:
  * Name: RUBYGEMS_API_KEY
  * Value: Your API key from RubyGems.org with "Push Gem" permissions.
