### PR TITLE
Feature/unified rpath darwin

### DIFF
--- a/cmake/PatchRPath.cmake
+++ b/cmake/PatchRPath.cmake
@@ -1,0 +1,66 @@
+#
+#	CMake PatchRPath by Parra Studios
+#	Unified RPath patching for ELF (patchelf) and Mach-O (install_name_tool).
+#
+#	Copyright (C) 2016 - 2026 Vicente Eduardo Ferrer Garcia <vic798@gmail.com>
+#
+#	Licensed under the Apache License, Version 2.0 (the "License");
+#	you may not use this file except in compliance with the License.
+#	You may obtain a copy of the License at
+#
+#		http://www.apache.org/licenses/LICENSE-2.0
+#
+#	Unless required by applicable law or agreed to in writing, software
+#	distributed under the License is distributed on an "AS IS" BASIS,
+#	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#	See the License for the specific language governing permissions and
+#	limitations under the License.
+#
+
+include_guard(GLOBAL)
+
+# metacall_patch_rpath(TARGET_NAME LIBRARIES OUTPUT_DIR)
+#
+# Attach POST_BUILD commands to TARGET_NAME that fix the rpath of each library
+# in LIBRARIES so sibling libraries resolve relative to the binary's location.
+#
+# On macOS:  install_name_tool -id @rpath/<basename> && -add_rpath @loader_path
+# On Linux:  patchelf --set-rpath $ORIGIN
+
+function(metacall_patch_rpath TARGET_NAME LIBRARIES OUTPUT_DIR)
+	if(APPLE)
+		find_program(INSTALL_NAME_TOOL_EXECUTABLE NAMES install_name_tool)
+
+		if(NOT INSTALL_NAME_TOOL_EXECUTABLE)
+			message(WARNING "install_name_tool not found, skipping Mach-O rpath patching for ${TARGET_NAME}")
+			return()
+		endif()
+
+		foreach(lib_path ${LIBRARIES})
+			get_filename_component(lib_basename "${lib_path}" NAME)
+
+			add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+				COMMAND "${INSTALL_NAME_TOOL_EXECUTABLE}" -id "@rpath/${lib_basename}" "${lib_path}"
+				COMMAND "${INSTALL_NAME_TOOL_EXECUTABLE}" -add_rpath @loader_path "${lib_path}"
+				COMMENT "Applying Mach-O rpath fixes for ${lib_basename}"
+			)
+		endforeach()
+
+	elseif(PROJECT_OS_FAMILY MATCHES "unix")
+		find_package(Patchelf)
+
+		if(NOT Patchelf_FOUND)
+			message(WARNING "patchelf not found, skipping ELF rpath patching for ${TARGET_NAME}")
+			return()
+		endif()
+
+		foreach(lib_path ${LIBRARIES})
+			get_filename_component(lib_basename "${lib_path}" NAME)
+
+			add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+				COMMAND "${Patchelf_EXECUTABLE}" --set-rpath "$ORIGIN" "${lib_path}"
+				COMMENT "Applying ELF rpath fixes for ${lib_basename}"
+			)
+		endforeach()
+	endif()
+endfunction()

--- a/source/loaders/rs_loader/rust/.cargo/config
+++ b/source/loaders/rs_loader/rust/.cargo/config
@@ -1,3 +1,3 @@
 parallel-compiler = true
 [build]
-rustflags = ["-C", "link-args=-Wl,-rpath=$ORIGIN"]
+rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]

--- a/source/loaders/rs_loader/rust/.cargo/config.in
+++ b/source/loaders/rs_loader/rust/.cargo/config.in
@@ -1,0 +1,3 @@
+parallel-compiler = true
+[build]
+rustflags = [@CARGO_RUSTFLAGS@]

--- a/source/loaders/rs_loader/rust/CMakeLists.txt
+++ b/source/loaders/rs_loader/rust/CMakeLists.txt
@@ -55,6 +55,20 @@ add_custom_target(${target}_runtime
 	COMMAND ${CMAKE_COMMAND} -E copy_if_different ${Rust_RUSTC_LIBRARIES} ${PROJECT_OUTPUT_DIR}
 )
 
+# Darwin: allow undefined metacall symbols (resolved at runtime via dynamic_lookup)
+# Linux: embed $ORIGIN rpath so sibling libraries resolve at load time
+if(APPLE)
+	set(CARGO_RUSTFLAGS "\"-C\", \"link-args=-Wl,-undefined,dynamic_lookup\"")
+else()
+	set(CARGO_RUSTFLAGS "\"-C\", \"link-args=-Wl,-rpath,$ORIGIN\"")
+endif()
+
+configure_file(
+	"${CMAKE_CURRENT_SOURCE_DIR}/.cargo/config.in"
+	"${CMAKE_CURRENT_SOURCE_DIR}/.cargo/config"
+	@ONLY
+)
+
 include(PatchRPath)
 
 set(RUSTC_LIBS)
@@ -63,9 +77,10 @@ foreach(rustc_lib ${Rust_RUSTC_LIBRARIES})
 	list(APPEND RUSTC_LIBS "${PROJECT_OUTPUT_DIR}/${rustc_lib_name}")
 endforeach()
 
-add_custom_target(${target}_rpath DEPENDS ${target}_runtime)
-metacall_patch_rpath(${target}_rpath "${RUSTC_LIBS}" "${PROJECT_OUTPUT_DIR}")
-set(TARGET_DEPENDENCY ${target}_rpath)
+# Patching runs after cargo build, not before
+set(PATCH_LIBS "${TARGET_OUTPUT}" ${RUSTC_LIBS})
+add_custom_target(${target}_rpath ALL DEPENDS ${target})
+metacall_patch_rpath(${target}_rpath "${PATCH_LIBS}" "${PROJECT_OUTPUT_DIR}")
 
 if(OPTION_BUILD_MUSL)
 	set(RUST_CTR_STATIC "-Ctarget-feature=-crt-static -Clink-self-contained=off -L/usr/lib/x86_64-linux-musl") #-Clink-args=--dynamic-linker /lib/ld-musl-x86_64.so.1
@@ -78,7 +93,7 @@ add_custom_target(${target} ALL
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	COMMAND ${RUSTFLAGS} ${Rust_CARGO_EXECUTABLE} build ${TARGET_BUILD_TYPE}
 	COMMAND ${CMAKE_COMMAND} -E copy_if_different ${TARGET_BUILD_PATH} ${TARGET_OUTPUT}
-	DEPENDS ${target}_runtime ${TARGET_DEPENDENCY}
+	DEPENDS ${target}_runtime
 )
 
 set_property(TARGET ${target}

--- a/source/loaders/rs_loader/rust/CMakeLists.txt
+++ b/source/loaders/rs_loader/rust/CMakeLists.txt
@@ -55,37 +55,17 @@ add_custom_target(${target}_runtime
 	COMMAND ${CMAKE_COMMAND} -E copy_if_different ${Rust_RUSTC_LIBRARIES} ${PROJECT_OUTPUT_DIR}
 )
 
-# On Linux, execute patchelf in order to patch rpath in the dependencies
-if(PROJECT_OS_FAMILY MATCHES "unix" OR PROJECT_OS_FAMILY MATCHES "macos")
-	# Find Patchelf
-	find_package(Patchelf)
+include(PatchRPath)
 
-	if(NOT Patchelf_FOUND)
-		include(InstallPatchelf)
+set(RUSTC_LIBS)
+foreach(rustc_lib ${Rust_RUSTC_LIBRARIES})
+	get_filename_component(rustc_lib_name "${rustc_lib}" NAME)
+	list(APPEND RUSTC_LIBS "${PROJECT_OUTPUT_DIR}/${rustc_lib_name}")
+endforeach()
 
-		if(NOT Patchelf_FOUND)
-			message(SEND_ERROR "Patchelf not found")
-			return()
-		endif()
-
-		set(TARGET_INSTALL_DEPENDENCY Patchelf)
-	endif()
-
-	set(RUSTC_LIBS)
-	add_custom_target(${target}_patchelf DEPENDS ${target}_runtime ${TARGET_INSTALL_DEPENDENCY})
-	foreach(rustc_lib ${Rust_RUSTC_LIBRARIES})
-		get_filename_component(rustc_lib_name ${rustc_lib} NAME)
-		list(APPEND RUSTC_LIBS ${PROJECT_OUTPUT_DIR}/${rustc_lib_name})
-		add_custom_command(TARGET ${target}_patchelf POST_BUILD
-			COMMAND ${Patchelf_EXECUTABLE} --set-rpath [=["\$$ORIGIN"]=] ${PROJECT_OUTPUT_DIR}/${rustc_lib_name}
-		)
-	endforeach()
-
-	set(TARGET_DEPENDENCY ${target}_patchelf)
-else()
-	# TODO: Implement patchelf equivalent (if needed) for other platforms
-	set(RUSTC_LIBS ${Rust_RUSTC_LIBRARIES})
-endif()
+add_custom_target(${target}_rpath DEPENDS ${target}_runtime)
+metacall_patch_rpath(${target}_rpath "${RUSTC_LIBS}" "${PROJECT_OUTPUT_DIR}")
+set(TARGET_DEPENDENCY ${target}_rpath)
 
 if(OPTION_BUILD_MUSL)
 	set(RUST_CTR_STATIC "-Ctarget-feature=-crt-static -Clink-self-contained=off -L/usr/lib/x86_64-linux-musl") #-Clink-args=--dynamic-linker /lib/ld-musl-x86_64.so.1


### PR DESCRIPTION
I’ve implemented a unified RPath patching module (PatchRPath.cmake) to handle binary portability across both Darwin and Linux. This replaces the legacy, platform-specific hacks and the hard dependency on patchelf for macOS builds.

Key Changes:

Unified API: Created a metacall_patch_rpath function that automatically switches between install_name_tool (Darwin) and patchelf (Linux).

Darwin Linker Fixes: Updated the Rust loader build to use -Wl,-undefined,dynamic_lookup on macOS. This allows the compiler to ignore undefined MetaCall core symbols at build time, which are resolved at runtime when the plugin is loaded.

Dynamic Cargo Configuration: Introduced a .cargo/config.in template. CMake now generates the correct .cargo/config based on the host OS, ensuring Linux-specific flags like $ORIGIN don't break the Mac linker.

Build Order & Dependency Logic: Fixed a race condition where patching was attempted before the library was finished. The patching target now correctly waits for the Cargo build to complete and specifically includes the loader's own .dylib in the patch list.

How I tested it
I’ve verified this on Apple Silicon (M-series) with the following results:

Compilation: The Rust loader and MetaCall CLI now build to 100% success without manual environment tweaks.

<img width="824" height="228" alt="Screenshot 2026-03-28 at 2 40 53 AM" src="https://github.com/user-attachments/assets/4a06e6ef-4c2c-4cf5-ba25-4c15e814462c" />


Header Verification: Used otool -l to confirm that @loader_path is correctly embedded in the Mach-O load commands.

<img width="815" height="145" alt="Screenshot 2026-03-28 at 2 42 04 AM" src="https://github.com/user-attachments/assets/c472b083-df08-4dde-a9d3-1c291d5d51b3" />


Runtime Check: The metacallcli initializes successfully. While it currently shows missing plugin errors (due to .so vs .dylib mapping), the core linking issues are fully resolved.

<img width="816" height="244" alt="Screenshot 2026-03-28 at 2 51 38 AM" src="https://github.com/user-attachments/assets/2dc8e80e-512a-42f8-b935-5a64fa2aa0ad" />

