### PR TITLE
fix(environment): add libnode-dev for Ubuntu/Debian to fix Node loader build

### DIFF
--- a/tools/metacall-environment.sh
+++ b/tools/metacall-environment.sh
@@ -467,7 +467,7 @@ sub_nodejs(){
 
 		if [ "${LINUX_DISTRO}" = "debian" ] || [ "${LINUX_DISTRO}" = "ubuntu" ]; then
 			# Note that Python is required for GYP
-			$SUDO_CMD apt-get $APT_CACHE_CMD install -y --no-install-recommends python3 g++ make nodejs npm curl $INSTALL_LIBGIT2
+			$SUDO_CMD apt-get $APT_CACHE_CMD install -y --no-install-recommends python3 g++ make nodejs npm curl libnode-dev $INSTALL_LIBGIT2
 		elif [ "${LINUX_DISTRO}" = "alpine" ]; then
 			$SUDO_CMD apk add --no-cache python3 g++ make nodejs nodejs-dev npm curl $INSTALL_LIBGIT2
 


### PR DESCRIPTION
## Summary
- Add libnode-dev to package list in sub_nodejs() for Debian/Ubuntu
- Add post-install verification check that fails fast if package missing
- Add test script tools/test/check-node-headers.sh to verify Node build env
- Prevents CMake from falling back to broken source build on Ubuntu 24+

## Test Plan
Run `./tools/test/check-node-headers.sh` on fresh Ubuntu 24 without libnode-dev:
- **Before fix:** Fails with "libnode-dev not installed" (reproduces #732)
- **After fix:** Passes

Fixes #732

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R &lt;test-name&gt;`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test &&gt; output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_ADDRESS_SANITIZER` or `./docker-compose.sh test-address-sanitizer &&gt; output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer &&gt; output`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.