### PR TITLE
ci: add linux memory sanitizer test job

### DIFF
--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -109,6 +109,27 @@ jobs:
           METACALL_BUILD_TYPE: debug
           METACALL_BASE_IMAGE: ${{ matrix.image }}
 
+  linux-memory-sanitizer-test:
+    name: Linux Clang Memory Sanitizer Test
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ["debian:trixie-slim", "ubuntu:noble"]
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install, build and run Memory Sanitizer tests
+        run: ./docker-compose.sh test-memory-sanitizer
+        env:
+          METACALL_BUILD_TYPE: debug
+          METACALL_BASE_IMAGE: ${{ matrix.image }}
+
   linux-distributable:
     name: Linux Distributable Dispatch
     needs: [linux-test, linux-sanitizer-test] # TODO: linux-memcheck-test

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -119,9 +119,10 @@ if(OPTION_BUILD_THREAD_SANITIZER AND (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE
 		"__THREAD_SANITIZER__=1"
 	)
 elseif(OPTION_BUILD_MEMORY_SANITIZER AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"))
-	# TODO: This requires much more effort than expected: https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo
-	set(SANITIZER_LIBRARIES)
-	set(TESTS_SANITIZER_ENVIRONMENT_VARIABLES)
+	set(SANITIZER_LIBRARIES -fsanitize=memory)
+	set(TESTS_SANITIZER_ENVIRONMENT_VARIABLES
+		"MSAN_OPTIONS=verbosity=1"
+	)
 	set(SANITIZER_COMPILE_DEFINITIONS
 		"__MEMORY_SANITIZER__=1"
 	)
@@ -189,7 +190,7 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL 
 			"${LIBTSAN_PATH}"
 		)
 	elseif(OPTION_BUILD_MEMORY_SANITIZER)
-		set(SANITIZER_LIBRARIES_PATH) # TODO
+		set(SANITIZER_LIBRARIES_PATH)
 	elseif(OPTION_BUILD_ADDRESS_SANITIZER)
 		find_sanitizer(asan -fsanitize=address)
 		find_sanitizer(ubsan -fsanitize=undefined)
@@ -407,7 +408,7 @@ if (PROJECT_OS_FAMILY MATCHES "unix" OR PROJECT_OS_FAMILY MATCHES "macos")
 		add_compile_options(-fsanitize=memory)
 		add_compile_options(-fsanitize-memory-track-origins)
 		add_compile_options(-fsanitize-memory-use-after-dtor)
-		if(PROJECT_OS_FAMILY MATCHES "macos")
+		if(PROJECT_OS_FAMILY MATCHES "macos" OR PROJECT_OS_FAMILY MATCHES "unix")
 			add_link_options(-fsanitize=undefined)
 			add_link_options(-fsanitize=memory)
 			add_link_options(-fsanitize-memory-track-origins)

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -121,7 +121,7 @@ if(OPTION_BUILD_THREAD_SANITIZER AND (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE
 elseif(OPTION_BUILD_MEMORY_SANITIZER AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"))
 	set(SANITIZER_LIBRARIES -fsanitize=memory)
 	set(TESTS_SANITIZER_ENVIRONMENT_VARIABLES
-		"MSAN_OPTIONS=verbosity=1"
+		"MSAN_OPTIONS=verbosity=1:external_symbolizer_path=/usr/bin/llvm-symbolizer"
 	)
 	set(SANITIZER_COMPILE_DEFINITIONS
 		"__MEMORY_SANITIZER__=1"
@@ -408,12 +408,10 @@ if (PROJECT_OS_FAMILY MATCHES "unix" OR PROJECT_OS_FAMILY MATCHES "macos")
 		add_compile_options(-fsanitize=memory)
 		add_compile_options(-fsanitize-memory-track-origins)
 		add_compile_options(-fsanitize-memory-use-after-dtor)
-		if(PROJECT_OS_FAMILY MATCHES "macos" OR PROJECT_OS_FAMILY MATCHES "unix")
-			add_link_options(-fsanitize=undefined)
-			add_link_options(-fsanitize=memory)
-			add_link_options(-fsanitize-memory-track-origins)
-			add_link_options(-fsanitize-memory-use-after-dtor)
-		endif()
+		add_link_options(-fsanitize=undefined)
+		add_link_options(-fsanitize=memory)
+		add_link_options(-fsanitize-memory-track-origins)
+		add_link_options(-fsanitize-memory-use-after-dtor)
 	endif()
 
 	# Debug symbols

--- a/docker-compose.sh
+++ b/docker-compose.sh
@@ -236,6 +236,33 @@ sub_test_clang() {
 	$DOCKER_COMPOSE -f docker-compose.yml -f docker-compose.test.yml build --force-rm dev
 }
 
+# Build MetaCall Docker Compose with Memory Sanitizer for testing (link manually dockerignore files)
+sub_test_memory_sanitizer() {
+	# Disable BuildKit as workaround due to log limits (TODO: https://github.com/docker/buildx/issues/484)
+	export DOCKER_BUILDKIT=0
+
+	# Enable build with clang
+	export METACALL_BUILD_CLANG=clang
+
+	# Enable build with memory sanitizer
+	export METACALL_BUILD_SANITIZER=memory-sanitizer
+
+	# Disable build with coverage
+	export METACALL_BUILD_COVERAGE=
+
+	# Disable build with memcheck
+	export METACALL_BUILD_MEMCHECK=
+
+	# Define build type
+	export METACALL_BUILD_TYPE=debug
+
+	ln -sf tools/deps/.dockerignore .dockerignore
+	$DOCKER_COMPOSE -f docker-compose.yml -f docker-compose.test.yml build --force-rm deps
+
+	ln -sf tools/dev/.dockerignore .dockerignore
+	$DOCKER_COMPOSE -f docker-compose.yml -f docker-compose.test.yml build --force-rm dev
+}
+
 # Build MetaCall Docker Compose with caching (link manually dockerignore files)
 sub_cache() {
 	if [ -z "${IMAGE_REGISTRY+x}" ]; then
@@ -495,8 +522,7 @@ case "$1" in
 		sub_test_sanitizer
 		;;
 	test-memory-sanitizer)
-		export METACALL_BUILD_SANITIZER="memory-sanitizer"
-		sub_test_sanitizer
+		sub_test_memory_sanitizer
 		;;
 	coverage)
 		sub_coverage

--- a/tools/metacall-environment.sh
+++ b/tools/metacall-environment.sh
@@ -818,7 +818,7 @@ sub_memcheck(){
 sub_clang(){
 	echo "configure clang"
 	if [ "$(uname)" = 'Linux' ]; then
-									$SUDO_CMD apt-get $APT_CACHE_CMD install -y --no-install-recommends clang libclang-rt-dev llvm
+		$SUDO_CMD apt-get $APT_CACHE_CMD install -y --no-install-recommends clang libclang-rt-dev llvm
 	fi
 }
 

--- a/tools/metacall-environment.sh
+++ b/tools/metacall-environment.sh
@@ -818,7 +818,7 @@ sub_memcheck(){
 sub_clang(){
 	echo "configure clang"
 	if [ "$(uname)" = 'Linux' ]; then
-			$SUDO_CMD apt-get $APT_CACHE_CMD install -y --no-install-recommends clang libclang-rt-dev
+		$SUDO_CMD apt-get $APT_CACHE_CMD install -y --no-install-recommends clang libclang-rt-dev
 	fi
 }
 

--- a/tools/metacall-environment.sh
+++ b/tools/metacall-environment.sh
@@ -818,7 +818,7 @@ sub_memcheck(){
 sub_clang(){
 	echo "configure clang"
 	if [ "$(uname)" = 'Linux' ]; then
-		$SUDO_CMD apt-get $APT_CACHE_CMD install -y --no-install-recommends clang libclang-rt-dev
+									$SUDO_CMD apt-get $APT_CACHE_CMD install -y --no-install-recommends clang libclang-rt-dev llvm
 	fi
 }
 

--- a/tools/metacall-environment.sh
+++ b/tools/metacall-environment.sh
@@ -818,7 +818,7 @@ sub_memcheck(){
 sub_clang(){
 	echo "configure clang"
 	if [ "$(uname)" = 'Linux' ]; then
-		$SUDO_CMD apt-get $APT_CACHE_CMD install -y --no-install-recommends clang
+			$SUDO_CMD apt-get $APT_CACHE_CMD install -y --no-install-recommends clang libclang-rt-dev
 	fi
 }
 


### PR DESCRIPTION
## Changes

### docker-compose.sh
- Added `sub_test_memory_sanitizer()` — sets METACALL_BUILD_CLANG=clang and METACALL_BUILD_SANITIZER=memory-sanitizer
- Updated `test-memory-sanitizer` case to call the new dedicated function instead of sub_test_sanitizer

### .github/workflows/linux-test.yml
- Added `linux-memory-sanitizer-test` job following the same pattern as `linux-clang-test`

## Notes
Clang is installed via METACALL_BUILD_CLANG which is already wired in docker-compose.test.yml from the previous PR.