### PR TITLE
chore: resolve clippy warning on Windows

### DIFF
--- a/source/loaders/rs_loader/rust/compiler/src/wrapper/class.rs
+++ b/source/loaders/rs_loader/rust/compiler/src/wrapper/class.rs
@@ -544,11 +544,12 @@ impl ToMetaResult for i64 {
         // and not regenerated for each target platform so they will break ABI when using this.
         #[cfg(any(target_pointer_width = "32", windows))]
         {
-            if self < c_long::MIN as i64 || self > c_long::MAX as i64{
-                panic!("i64 does not fit into c_long on this platform");
-            }
+            Ok(unsafe { metacall_value_create_long(self.try_into().unwrap()) })
         }
-        Ok(unsafe { metacall_value_create_long(self) })
+        #[cfg(not(any(target_pointer_width = "32", windows)))]
+        {
+            Ok(unsafe { metacall_value_create_long(self) })
+        }
     }
 }
 

--- a/source/ports/rs_port/src/types/metacall_value.rs
+++ b/source/ports/rs_port/src/types/metacall_value.rs
@@ -171,13 +171,8 @@ impl MetaCallValue for i64 {
         // Meanwhile as a workaround, we just panic if it does not fit.        
         #[cfg(any(target_pointer_width = "32", windows))]
         {
-            if self < std::os::raw::c_long::MIN as i64 || self > std::os::raw::c_long::MAX as i64 {
-                panic!("i64 does not fit into c_long on this platform");
-            }
-
-            return unsafe { metacall_value_create_long(self as std::os::raw::c_long) };
+            unsafe { metacall_value_create_long(self.try_into().unwrap()) }
         }
-
         #[cfg(not(any(target_pointer_width = "32", windows)))]
         {
             unsafe { metacall_value_create_long(self) }


### PR DESCRIPTION
## Description

Adjust the `i64` to `c_long` conversion path for Windows so Clippy passes cleanly.

This change is limited to lint-related code adjustments and does not introduce functional changes.

### before:
#### rs_loader:

<img width="644" height="290" alt="Screenshot from 2026-03-29 09-17-51" src="https://github.com/user-attachments/assets/1dc2de79-f113-442e-803f-16627c87ee04" />

#### rs_port:
<img width="861" height="424" alt="Screenshot from 2026-03-29 09-14-49" src="https://github.com/user-attachments/assets/1dfcf41f-aead-4f10-97f2-6cc7d3c9f63e" />


### after:

#### rs_loader:
<img width="657" height="112" alt="Screenshot from 2026-03-29 09-18-18" src="https://github.com/user-attachments/assets/70c20176-4a27-4aa0-8686-2798a9c5e7c1" />

#### rs_port:
<img width="557" height="62" alt="image" src="https://github.com/user-attachments/assets/dac50a41-0f6d-4b39-b07a-787b9eaea08f" />


# Checklist:

- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.