### PR TITLE
fix(ext_loader): add default constructors to prevent uninitialized memory

### DIFF
--- a/source/loaders/ext_loader/source/ext_loader_impl.cpp
+++ b/source/loaders/ext_loader/source/ext_loader_impl.cpp
@@ -66,11 +66,15 @@ typedef struct loader_impl_ext_type
 	std::set<fs::path> paths;
 	std::map<std::string, loader_impl_ext_handle_lib_type> destroy_list;
 
+	loader_impl_ext_type() : paths(), destroy_list() {}
+
 } * loader_impl_ext;
 
 typedef struct loader_impl_ext_handle_type
 {
 	std::vector<loader_impl_ext_handle_lib_type> extensions;
+
+	loader_impl_ext_handle_type() : extensions() {}
 
 } * loader_impl_ext_handle;
 


### PR DESCRIPTION
## Summary

Fix uninitialized memory detected by MemorySanitizer in ext_loader_impl_execution_path.

## Changes

Added default constructors to `loader_impl_ext_type` and `loader_impl_ext_handle_type` structs to explicitly initialize their members (`paths`, `destroy_list`, `extensions`).

## Context

This bug was found while implementing the Memory Sanitizer CI job. MSan reported use-of-uninitialized-value repeatedly at ext_loader_impl.cpp:136.