### PR TITLE
fix(msan): harden loader path handling to avoid uninitialized reads

### DIFF
--- a/source/configuration/source/configuration_object.c
+++ b/source/configuration/source/configuration_object.c
@@ -221,11 +221,13 @@ int configuration_object_childs_valid(set_key key, set_value val)
 size_t configuration_object_child_path(configuration config, value v, char *path)
 {
 	const char *value_path = value_to_string(v);
-	size_t size = value_type_size(v);
+	size_t value_path_size = strnlen(value_path, PORTABILITY_PATH_SIZE);
+	size_t size = value_path_size + 1;
 
 	if (portability_path_is_absolute(value_path, size) == 0)
 	{
-		memcpy(path, value_path, size);
+		memcpy(path, value_path, value_path_size);
+		path[value_path_size] = '\0';
 	}
 	else
 	{

--- a/source/loader/source/loader_impl.c
+++ b/source/loader/source/loader_impl.c
@@ -291,7 +291,7 @@ void loader_impl_configuration_execution_paths(loader_impl_interface iface, load
 		{
 			if (value_type_id(execution_paths_array[iterator]) == TYPE_STRING)
 			{
-				loader_path execution_path;
+				loader_path execution_path = { 0 };
 
 				configuration_object_child_path(impl->config, execution_paths_array[iterator], execution_path);
 
@@ -1006,7 +1006,20 @@ int loader_impl_execution_path(plugin p, loader_impl impl, const loader_path pat
 				}
 			}
 
-			vector_push_back(paths, (void *)path);
+			if (path != NULL)
+			{
+				loader_path normalized_path = { 0 };
+
+				strncpy(normalized_path, path, LOADER_PATH_SIZE - 1);
+
+				vector_push_back(paths, normalized_path);
+			}
+			else
+			{
+				loader_path empty_path = { 0 };
+
+				vector_push_back(paths, empty_path);
+			}
 
 			return 0;
 		}

--- a/source/loaders/ext_loader/source/ext_loader_impl.cpp
+++ b/source/loaders/ext_loader/source/ext_loader_impl.cpp
@@ -66,11 +66,15 @@ typedef struct loader_impl_ext_type
 	std::set<fs::path> paths;
 	std::map<std::string, loader_impl_ext_handle_lib_type> destroy_list;
 
+	loader_impl_ext_type() : paths(), destroy_list() {}
+
 } * loader_impl_ext;
 
 typedef struct loader_impl_ext_handle_type
 {
 	std::vector<loader_impl_ext_handle_lib_type> extensions;
+
+	loader_impl_ext_handle_type() : extensions() {}
 
 } * loader_impl_ext_handle;
 

--- a/source/loaders/ext_loader/source/ext_loader_impl.cpp
+++ b/source/loaders/ext_loader/source/ext_loader_impl.cpp
@@ -135,7 +135,7 @@ int ext_loader_impl_execution_path(loader_impl impl, const loader_path path)
 {
 	loader_impl_ext ext_impl = static_cast<loader_impl_ext>(loader_impl_get(impl));
 
-	ext_impl->paths.insert(fs::path(std::string(path, strnlen(path, 1000))));
+	ext_impl->paths.insert(fs::path(std::string(path, strnlen(path, LOADER_PATH_SIZE))));
 
 	return 0;
 }

--- a/source/loaders/ext_loader/source/ext_loader_impl.cpp
+++ b/source/loaders/ext_loader/source/ext_loader_impl.cpp
@@ -66,15 +66,11 @@ typedef struct loader_impl_ext_type
 	std::set<fs::path> paths;
 	std::map<std::string, loader_impl_ext_handle_lib_type> destroy_list;
 
-	loader_impl_ext_type() : paths(), destroy_list() {}
-
 } * loader_impl_ext;
 
 typedef struct loader_impl_ext_handle_type
 {
 	std::vector<loader_impl_ext_handle_lib_type> extensions;
-
-	loader_impl_ext_handle_type() : extensions() {}
 
 } * loader_impl_ext_handle;
 
@@ -137,7 +133,7 @@ int ext_loader_impl_execution_path(loader_impl impl, const loader_path path)
 {
 	loader_impl_ext ext_impl = static_cast<loader_impl_ext>(loader_impl_get(impl));
 
-	ext_impl->paths.insert(fs::path(path));
+	ext_impl->paths.insert(fs::path(std::string(path, strnlen(path, 1000))));
 
 	return 0;
 }

--- a/source/loaders/ext_loader/source/ext_loader_impl.cpp
+++ b/source/loaders/ext_loader/source/ext_loader_impl.cpp
@@ -34,6 +34,8 @@
 
 #include <log/log.h>
 
+#include <cstring>
+
 #if defined __has_include
 	#if __has_include(<filesystem>)
 		#include <filesystem>


### PR DESCRIPTION

This PR fixes repeated MemorySanitizer uninitialized-read reports in the loader execution-path flow by hardening path construction and storage across configuration, loader core, and ext loader.

**What changed**

1.ext_loader: bounded path conversion using LOADER_PATH_SIZE

- Replaced direct path conversion with bounded string construction before filesystem path conversion.
- Added cstring include required for strnlen.

2.loader core: normalize deferred execution paths before storage

- Zero-initialize temporary loader_path buffers.
- Avoid raw push of external path pointers into fixed-size vector slots.
- Copy paths into normalized, null-terminated loader_path buffers before vector insertion.

3.configuration: bound and terminate child path copy

- Use bounded length for copied path data.
- Explicitly write null terminator after memcpy.

**Why**
MSan showed repeated use-of-uninitialized-value in ext_loader execution path handling. Root cause is partially initialized path-buffer propagation through loader path flow. This PR prevents reading beyond initialized bytes and aligns bounds with loader path size contracts.