### PR TITLE
Release job fails due to missing MetaCall installation during cargo publish verification

### DIFF
--- a/source/ports/rs_port/upload.sh
+++ b/source/ports/rs_port/upload.sh
@@ -28,7 +28,7 @@ function publish() {
     # Check if versions do not match, and if so, publish them
     if [ ! "${crate_version}" = "${project_version}" ]; then
         echo "Publishing $1: ${crate_version} -> ${project_version}"
-        cargo publish --verbose --locked --token ${CARGO_REGISTRY_TOKEN}
+        cargo publish --verbose --locked --no-verify --token ${CARGO_REGISTRY_TOKEN}
     fi
 }
 


### PR DESCRIPTION
Description:

The Release Rust Port job ([run example](https://github.com/metacall/core/actions/runs/24053297933/job/70154032518)) fails with:


MetaCall library not found. Searched in: `/usr/local/lib/`, `/gnu/lib/`.
error: failed to verify package tarball
Error: Process completed with exit code 101.
Root Cause:

The release job starts on a fresh runner and never installs MetaCall. When cargo publish runs, it verifies the package tarball by executing build.rs, which requires MetaCall to be present on the system — and fails when it isn't found.

Why this is safe to fix with `--no-verify`:

The release job already depends on needs: test, which runs a full build and test suite with MetaCall installed. By the time release runs, correctness is already verified. The verification step in cargo publish is therefore redundant.

Fix:

In `source/ports/rs_port/upload.sh`, change:

`cargo publish --verbose --locked --token ${CARGO_REGISTRY_TOKEN}`
to:
`cargo publish --verbose --locked --no-verify --token ${CARGO_REGISTRY_TOKEN}`

Alternative: Install MetaCall in the release job before running upload.sh, but this is unnecessary overhead given the test job already covers it.