### PR TITLE
Add freebsd ci

### DIFF
--- a/.github/workflows/freebsd-test.yml
+++ b/.github/workflows/freebsd-test.yml
@@ -1,0 +1,42 @@
+name: FreeBSD Test
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+      - develop
+    tags:
+      - v*.*.*
+
+concurrency:
+  group: freebsd-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        build: [debug, release]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run FreeBSD VM
+        uses: cross-platform-actions/action@v0.32.0
+        with:
+          operating_system: freebsd
+          version: 14.2
+          architecture: x86-64
+          shell: sh
+          run: |
+            sh ./tools/metacall-environment.sh base
+            mkdir build && cd build
+            sh ../tools/metacall-configure.sh ${{ matrix.build }}
+            sh ../tools/metacall-build.sh ${{ matrix.build }}

--- a/.github/workflows/freebsd-test.yml
+++ b/.github/workflows/freebsd-test.yml
@@ -38,5 +38,5 @@ jobs:
           run: |
             sh ./tools/metacall-environment.sh base python
             mkdir build && cd build
-            sh ../tools/metacall-configure.sh ${{ matrix.build }} scripts python tests address-sanitizer
+            sh ../tools/metacall-configure.sh ${{ matrix.build }} scripts python tests 
             sh ../tools/metacall-build.sh ${{ matrix.build }} tests

--- a/.github/workflows/freebsd-test.yml
+++ b/.github/workflows/freebsd-test.yml
@@ -38,5 +38,5 @@ jobs:
           run: |
             sh ./tools/metacall-environment.sh base python
             mkdir build && cd build
-            sh ../tools/metacall-configure.sh ${{ matrix.build }} scripts python tests
+            sh ../tools/metacall-configure.sh ${{ matrix.build }} scripts python tests address-sanitizer
             sh ../tools/metacall-build.sh ${{ matrix.build }} tests

--- a/.github/workflows/freebsd-test.yml
+++ b/.github/workflows/freebsd-test.yml
@@ -36,7 +36,7 @@ jobs:
           architecture: x86-64
           shell: sh
           run: |
-            sh ./tools/metacall-environment.sh base python
+            sh ./tools/metacall-environment.sh base python c
             mkdir build && cd build
             sh ../tools/metacall-configure.sh ${{ matrix.build }} scripts python c tests 
             sh ../tools/metacall-build.sh ${{ matrix.build }} c tests

--- a/.github/workflows/freebsd-test.yml
+++ b/.github/workflows/freebsd-test.yml
@@ -36,7 +36,7 @@ jobs:
           architecture: x86-64
           shell: sh
           run: |
-            sh ./tools/metacall-environment.sh base python c
+            sh ./tools/metacall-environment.sh base python c nodejs
             mkdir -p build && cd build
-            sh ../tools/metacall-configure.sh ${{ matrix.build }} scripts python c tests 
-            sh ../tools/metacall-build.sh ${{ matrix.build }} c tests
+            sh ../tools/metacall-configure.sh ${{ matrix.build }} scripts python c nodejs tests 
+            sh ../tools/metacall-build.sh ${{ matrix.build }} c nodejs tests

--- a/.github/workflows/freebsd-test.yml
+++ b/.github/workflows/freebsd-test.yml
@@ -11,18 +11,20 @@ on:
       - v*.*.*
 
 concurrency:
-  group: freebsd-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
+    name: FreeBSD Test
     runs-on: ubuntu-latest
-
     strategy:
+      fail-fast: false
       matrix:
         # TODO: Implement more architectures and versions matrix
-        # TODO: Implement OpenBSD and Haiku 
+        # TODO: Implement OpenBSD, Haiku, OmniOS
         build: [debug, release]
+        arch: [x86-64, arm64]
 
     steps:
       - name: Checkout
@@ -35,7 +37,7 @@ jobs:
         with:
           operating_system: freebsd
           version: 14.2
-          architecture: x86-64
+          architecture: ${{ matrix.arch }}
           shell: sh
           run: |
             sh ./tools/metacall-environment.sh base python c nodejs

--- a/.github/workflows/freebsd-test.yml
+++ b/.github/workflows/freebsd-test.yml
@@ -37,6 +37,6 @@ jobs:
           shell: sh
           run: |
             sh ./tools/metacall-environment.sh base python c
-            mkdir build && cd build
+            mkdir -p build && cd build
             sh ../tools/metacall-configure.sh ${{ matrix.build }} scripts python c tests 
             sh ../tools/metacall-build.sh ${{ matrix.build }} c tests

--- a/.github/workflows/freebsd-test.yml
+++ b/.github/workflows/freebsd-test.yml
@@ -38,5 +38,5 @@ jobs:
           run: |
             sh ./tools/metacall-environment.sh base python
             mkdir build && cd build
-            sh ../tools/metacall-configure.sh ${{ matrix.build }} scripts python tests 
-            sh ../tools/metacall-build.sh ${{ matrix.build }} tests
+            sh ../tools/metacall-configure.sh ${{ matrix.build }} scripts python c tests 
+            sh ../tools/metacall-build.sh ${{ matrix.build }} c tests

--- a/.github/workflows/freebsd-test.yml
+++ b/.github/workflows/freebsd-test.yml
@@ -20,6 +20,8 @@ jobs:
 
     strategy:
       matrix:
+        # TODO: Implement more architectures and versions matrix
+        # TODO: Implement OpenBSD and Haiku 
         build: [debug, release]
 
     steps:

--- a/.github/workflows/freebsd-test.yml
+++ b/.github/workflows/freebsd-test.yml
@@ -36,7 +36,7 @@ jobs:
           architecture: x86-64
           shell: sh
           run: |
-            sh ./tools/metacall-environment.sh base
+            sh ./tools/metacall-environment.sh base python
             mkdir build && cd build
-            sh ../tools/metacall-configure.sh ${{ matrix.build }}
-            sh ../tools/metacall-build.sh ${{ matrix.build }}
+            sh ../tools/metacall-configure.sh ${{ matrix.build }} python tests
+            sh ../tools/metacall-build.sh ${{ matrix.build }} tests

--- a/.github/workflows/freebsd-test.yml
+++ b/.github/workflows/freebsd-test.yml
@@ -38,5 +38,5 @@ jobs:
           run: |
             sh ./tools/metacall-environment.sh base python
             mkdir build && cd build
-            sh ../tools/metacall-configure.sh ${{ matrix.build }} python tests
+            sh ../tools/metacall-configure.sh ${{ matrix.build }} scripts python tests
             sh ../tools/metacall-build.sh ${{ matrix.build }} tests

--- a/cmake/FindNodeJS.cmake
+++ b/cmake/FindNodeJS.cmake
@@ -39,12 +39,6 @@ if(NodeJS_EXECUTABLE)
 	set(NodeJS_FIND_QUIETLY TRUE)
 endif()
 
-if(PROJECT_OS_BSD)
-    set(MAKE_COMMAND gmake)
-else()
-    set(MAKE_COMMAND make)
-endif()
-
 option(NodeJS_CMAKE_DEBUG "Print paths for debugging NodeJS dependencies." OFF)
 option(NodeJS_SHARED_UV "If it is enabled, libuv won't be required by this script." OFF)
 option(NodeJS_BUILD_FROM_SOURCE "If it is enabled, NodeJS runtime library will be built from source." OFF)
@@ -600,6 +594,12 @@ if(NOT NodeJS_LIBRARY)
 			include(ProcessorCount)
 
 			ProcessorCount(N)
+
+			if(PROJECT_OS_BSD)
+				set(MAKE_COMMAND gmake)
+			else()
+				set(MAKE_COMMAND make)
+			endif()
 
 			if(N GREATER 1)
 				execute_process(

--- a/cmake/FindNodeJS.cmake
+++ b/cmake/FindNodeJS.cmake
@@ -425,13 +425,7 @@ if(NOT NodeJS_LIBRARY)
 		message(STATUS "Extract NodeJS distribution")
 		execute_process(COMMAND ${CMAKE_COMMAND} -E tar "xvf" "${NodeJS_DOWNLOAD_FILE}" WORKING_DIRECTORY "${NodeJS_BASE_PATH}" OUTPUT_QUIET)
 	endif()
-	if(PROJECT_OS_BSD)
-		execute_process(
-			COMMAND sed -i '' "/ASSERT_TRIVIALLY_COPYABLE(T);/d" "${NodeJS_OUTPUT_PATH}/deps/v8/src/base/small-vector.h"
-			WORKING_DIRECTORY "${NodeJS_OUTPUT_PATH}"
-		)
-	endif()
-	
+
 	if(WIN32)
 		if(NodeJS_VERSION_MAJOR LESS 14)
 			set(NodeJS_COMPILE_PATH "${NodeJS_OUTPUT_PATH}/${CMAKE_BUILD_TYPE}")

--- a/cmake/FindNodeJS.cmake
+++ b/cmake/FindNodeJS.cmake
@@ -39,6 +39,12 @@ if(NodeJS_EXECUTABLE)
 	set(NodeJS_FIND_QUIETLY TRUE)
 endif()
 
+if(PROJECT_OS_BSD)
+    set(MAKE_COMMAND gmake)
+else()
+    set(MAKE_COMMAND make)
+endif()
+
 option(NodeJS_CMAKE_DEBUG "Print paths for debugging NodeJS dependencies." OFF)
 option(NodeJS_SHARED_UV "If it is enabled, libuv won't be required by this script." OFF)
 option(NodeJS_BUILD_FROM_SOURCE "If it is enabled, NodeJS runtime library will be built from source." OFF)
@@ -592,12 +598,12 @@ if(NOT NodeJS_LIBRARY)
 			if(N GREATER 1)
 				execute_process(
 					WORKING_DIRECTORY "${NodeJS_OUTPUT_PATH}"
-					COMMAND ${BUILD_DEBUG_ASAN_OPTIONS} make -j${N} -C ${NodeJS_OUTPUT_PATH}/out BUILDTYPE=${CMAKE_BUILD_TYPE} V=1
+					COMMAND ${BUILD_DEBUG_ASAN_OPTIONS} ${MAKE_COMMAND} -j${N} -C ${NodeJS_OUTPUT_PATH}/out BUILDTYPE=${CMAKE_BUILD_TYPE} V=1
 				)
 			else()
 				execute_process(
 					WORKING_DIRECTORY "${NodeJS_OUTPUT_PATH}"
-					COMMAND ${BUILD_DEBUG_ASAN_OPTIONS} make -C ${NodeJS_OUTPUT_PATH}/out BUILDTYPE=${CMAKE_BUILD_TYPE} V=1
+					COMMAND ${BUILD_DEBUG_ASAN_OPTIONS} ${MAKE_COMMAND} -C ${NodeJS_OUTPUT_PATH}/out BUILDTYPE=${CMAKE_BUILD_TYPE} V=1
 				)
 			endif()
 		endif()

--- a/cmake/FindNodeJS.cmake
+++ b/cmake/FindNodeJS.cmake
@@ -431,7 +431,13 @@ if(NOT NodeJS_LIBRARY)
 		message(STATUS "Extract NodeJS distribution")
 		execute_process(COMMAND ${CMAKE_COMMAND} -E tar "xvf" "${NodeJS_DOWNLOAD_FILE}" WORKING_DIRECTORY "${NodeJS_BASE_PATH}" OUTPUT_QUIET)
 	endif()
-
+	if(PROJECT_OS_BSD)
+		execute_process(
+			COMMAND sed -i '' "/ASSERT_TRIVIALLY_COPYABLE(T);/d" "${NodeJS_OUTPUT_PATH}/deps/v8/src/base/small-vector.h"
+			WORKING_DIRECTORY "${NodeJS_OUTPUT_PATH}"
+		)
+	endif()
+	
 	if(WIN32)
 		if(NodeJS_VERSION_MAJOR LESS 14)
 			set(NodeJS_COMPILE_PATH "${NodeJS_OUTPUT_PATH}/${CMAKE_BUILD_TYPE}")

--- a/cmake/FindNodeJS.cmake
+++ b/cmake/FindNodeJS.cmake
@@ -591,27 +591,22 @@ if(NOT NodeJS_LIBRARY)
 			# Create build output directory
 			execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${NodeJS_OUTPUT_PATH}/out)
 
-			include(ProcessorCount)
-
-			ProcessorCount(N)
-
 			if(PROJECT_OS_BSD)
 				set(MAKE_COMMAND gmake)
 			else()
 				set(MAKE_COMMAND make)
 			endif()
 
+			include(ProcessorCount)
+			ProcessorCount(N)
 			if(N GREATER 1)
-				execute_process(
-					WORKING_DIRECTORY "${NodeJS_OUTPUT_PATH}"
-					COMMAND ${BUILD_DEBUG_ASAN_OPTIONS} ${MAKE_COMMAND} -j${N} -C ${NodeJS_OUTPUT_PATH}/out BUILDTYPE=${CMAKE_BUILD_TYPE} V=1
-				)
-			else()
-				execute_process(
-					WORKING_DIRECTORY "${NodeJS_OUTPUT_PATH}"
-					COMMAND ${BUILD_DEBUG_ASAN_OPTIONS} ${MAKE_COMMAND} -C ${NodeJS_OUTPUT_PATH}/out BUILDTYPE=${CMAKE_BUILD_TYPE} V=1
-				)
+				set(MAKE_PARALLEL "-j${N}")
 			endif()
+
+			execute_process(
+				WORKING_DIRECTORY "${NodeJS_OUTPUT_PATH}"
+				COMMAND ${BUILD_DEBUG_ASAN_OPTIONS} ${MAKE_COMMAND} ${MAKE_PARALLEL} -C ${NodeJS_OUTPUT_PATH}/out BUILDTYPE=${CMAKE_BUILD_TYPE} V=1
+			)
 		endif()
 	endif()
 

--- a/source/detours/plthook_detour/CMakeLists.txt
+++ b/source/detours/plthook_detour/CMakeLists.txt
@@ -148,6 +148,7 @@ target_link_libraries(${target}
 	PRIVATE
 	# On macOS, we use dynamic lookup to avoid loading libmetacall twice
 	$<$<NOT:$<PLATFORM_ID:Darwin>>:${META_PROJECT_NAME}::metacall>
+	# FreeBSD and OpenBSD required libraries for PLTHook
 	$<$<PLATFORM_ID:FreeBSD,NetBSD>:util>
 
 	PUBLIC

--- a/source/detours/plthook_detour/CMakeLists.txt
+++ b/source/detours/plthook_detour/CMakeLists.txt
@@ -148,6 +148,7 @@ target_link_libraries(${target}
 	PRIVATE
 	# On macOS, we use dynamic lookup to avoid loading libmetacall twice
 	$<$<NOT:$<PLATFORM_ID:Darwin>>:${META_PROJECT_NAME}::metacall>
+	$<$<PLATFORM_ID:FreeBSD,NetBSD>:util>
 
 	PUBLIC
 	${DEFAULT_LIBRARIES}

--- a/source/portability/include/portability/portability_executable_path.h
+++ b/source/portability/include/portability/portability_executable_path.h
@@ -35,6 +35,10 @@ typedef char portability_executable_path_str[PORTABILITY_PATH_SIZE];
 	defined(__CYGWIN__) || defined(__CYGWIN32__) || \
 	defined(__MINGW32__) || defined(__MINGW64__)
 typedef DWORD portability_executable_path_length;
+
+#elif defined(__FreeBSD__)
+typedef size_t portability_executable_path_length;
+
 #elif defined(unix) || defined(__unix__) || defined(__unix) || \
 	defined(linux) || defined(__linux__) || defined(__linux) || defined(__gnu_linux) || \
 	defined(__NetBSD__) || defined(__DragonFly__)
@@ -42,8 +46,7 @@ typedef DWORD portability_executable_path_length;
 typedef ssize_t portability_executable_path_length;
 #elif (defined(__APPLE__) && defined(__MACH__)) || defined(__MACOSX__)
 typedef uint32_t portability_executable_path_length;
-#elif defined(__FreeBSD__)
-typedef size_t portability_executable_path_length;
+
 #elif defined(sun) || defined(__sun)
 typedef size_t portability_executable_path_length;
 #else

--- a/source/portability/include/portability/portability_executable_path.h
+++ b/source/portability/include/portability/portability_executable_path.h
@@ -35,18 +35,14 @@ typedef char portability_executable_path_str[PORTABILITY_PATH_SIZE];
 	defined(__CYGWIN__) || defined(__CYGWIN32__) || \
 	defined(__MINGW32__) || defined(__MINGW64__)
 typedef DWORD portability_executable_path_length;
-
 #elif defined(__FreeBSD__)
 typedef size_t portability_executable_path_length;
-
 #elif defined(unix) || defined(__unix__) || defined(__unix) || \
 	defined(linux) || defined(__linux__) || defined(__linux) || defined(__gnu_linux) || \
 	defined(__NetBSD__) || defined(__DragonFly__)
-
 typedef ssize_t portability_executable_path_length;
 #elif (defined(__APPLE__) && defined(__MACH__)) || defined(__MACOSX__)
 typedef uint32_t portability_executable_path_length;
-
 #elif defined(sun) || defined(__sun)
 typedef size_t portability_executable_path_length;
 #else

--- a/source/portability/source/portability_executable_path.c
+++ b/source/portability/source/portability_executable_path.c
@@ -39,6 +39,13 @@ int portability_executable_path(portability_executable_path_str path, portabilit
 	defined(__CYGWIN__) || defined(__CYGWIN32__) || \
 	defined(__MINGW32__) || defined(__MINGW64__)
 	*length = GetModuleFileName(NULL, path, path_max_length);
+#elif defined(__FreeBSD__)
+	int name[] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+	*length = sizeof(char) * path_max_length;
+	if (sysctl(name, sizeof(name) / sizeof(name[0]), path, length, NULL, 0) < 0)
+	{
+		return 1;
+	}
 #elif defined(unix) || defined(__unix__) || defined(__unix) || \
 	defined(linux) || defined(__linux__) || defined(__linux) || defined(__gnu_linux)
 	*length = readlink("/proc/self/exe", path, path_max_length);
@@ -57,13 +64,7 @@ int portability_executable_path(portability_executable_path_str path, portabilit
 	}
 
 	*length = strnlen(path, PORTABILITY_PATH_SIZE);
-#elif defined(__FreeBSD__)
-	int name[] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
-	*length = sizeof(char) * path_max_length;
-	if (sysctl(name, sizeof(name) / sizeof(name[0]), path, length, NULL, 0) < 0)
-	{
-		return 1;
-	}
+
 #elif defined(__NetBSD__)
 	*length = readlink("/proc/curproc/exe", path, path_max_length);
 #elif defined(__DragonFly__)

--- a/source/portability/source/portability_executable_path.c
+++ b/source/portability/source/portability_executable_path.c
@@ -64,7 +64,6 @@ int portability_executable_path(portability_executable_path_str path, portabilit
 	}
 
 	*length = strnlen(path, PORTABILITY_PATH_SIZE);
-
 #elif defined(__NetBSD__)
 	*length = readlink("/proc/curproc/exe", path, path_max_length);
 #elif defined(__DragonFly__)

--- a/source/tests/serial_test/source/serial_test.cpp
+++ b/source/tests/serial_test/source/serial_test.cpp
@@ -350,7 +350,7 @@ TEST_F(serial_test, DefaultConstructor)
 	#else
 			"0x000A7EF2",
 	#endif
-#elif defined(__linux) || defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) 
+#elif defined(__linux) || defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
 			"0xa7ef2",
 #else
 			"<unknown>",

--- a/source/tests/serial_test/source/serial_test.cpp
+++ b/source/tests/serial_test/source/serial_test.cpp
@@ -350,7 +350,7 @@ TEST_F(serial_test, DefaultConstructor)
 	#else
 			"0x000A7EF2",
 	#endif
-#elif defined(__linux) || defined(__linux__) || defined(__APPLE__)
+#elif defined(__linux) || defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) 
 			"0xa7ef2",
 #else
 			"<unknown>",

--- a/tools/metacall-configure.sh
+++ b/tools/metacall-configure.sh
@@ -61,6 +61,7 @@ case "$(uname -s)" in
 	Darwin*)	OPERATIVE_SYSTEM=Darwin;;
 	CYGWIN*)	OPERATIVE_SYSTEM=Cygwin;;
 	MINGW*)		OPERATIVE_SYSTEM=MinGW;;
+	FreeBSD*)	OPERATIVE_SYSTEM=FreeBSD;;
 	*)			OPERATIVE_SYSTEM="Unknown"
 esac
 

--- a/tools/metacall-environment.sh
+++ b/tools/metacall-environment.sh
@@ -711,7 +711,6 @@ sub_c(){
 		echo "-DLibClang_INCLUDE_DIR=${LIBCLANG_PREFIX}/include" >> $CMAKE_CONFIG_PATH
 		echo "-DLibClang_LIBRARY=${LIBCLANG_PREFIX}/lib/libclang.dylib" >> $CMAKE_CONFIG_PATH
 		echo "-DLibClang_CMAKE_DEBUG=ON" >> $CMAKE_CONFIG_PATH
-
 	elif [ "${OPERATIVE_SYSTEM}" = "FreeBSD" ]; then
 		LLVM_VERSION_STRING=19
 		$SUDO_CMD pkg install -y libffi llvm${LLVM_VERSION_STRING} gcc

--- a/tools/metacall-environment.sh
+++ b/tools/metacall-environment.sh
@@ -559,6 +559,8 @@ sub_nodejs(){
 			brew install libgit2@1.8
 			brew link libgit2@1.8 --force --overwrite
 		fi
+	elif [ "${OPERATIVE_SYSTEM}" = "FreeBSD" ]; then
+		$SUDO_CMD pkg install -y node22 npm-node22
 	fi
 }
 

--- a/tools/metacall-environment.sh
+++ b/tools/metacall-environment.sh
@@ -559,8 +559,23 @@ sub_nodejs(){
 			brew install libgit2@1.8
 			brew link libgit2@1.8 --force --overwrite
 		fi
-	elif [ "${OPERATIVE_SYSTEM}" = "FreeBSD" ]; then
-		$SUDO_CMD pkg install -y node22 npm-node22
+		
+		elif [ "${OPERATIVE_SYSTEM}" = "FreeBSD" ]; then
+		$SUDO_CMD pkg install -y node22 npm-node22 python3 gmake
+		NODE_VERSION=$(node22 --version | sed 's/v//')
+		fetch -o /tmp/node-v${NODE_VERSION}.tar.gz https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}.tar.gz
+		tar xzf /tmp/node-v${NODE_VERSION}.tar.gz -C /tmp
+		sed -i '' '/ASSERT_TRIVIALLY_COPYABLE(T);/d' /tmp/node-v${NODE_VERSION}/deps/v8/src/base/small-vector.h
+		cd /tmp/node-v${NODE_VERSION}
+		./configure --shared
+		gmake -j$(sysctl -n hw.ncpu)
+		$SUDO_CMD cp out/Release/lib/libnode.so.* /usr/local/lib/
+		cd $ROOT_DIR
+		rm -rf /tmp/node-v${NODE_VERSION} /tmp/node-v${NODE_VERSION}.tar.gz
+		mkdir -p "$ROOT_DIR/build"
+		CMAKE_CONFIG_PATH="$ROOT_DIR/build/CMakeConfig.txt"
+		echo "-DNodeJS_EXECUTABLE=/usr/local/bin/node22" >> $CMAKE_CONFIG_PATH
+
 	fi
 }
 

--- a/tools/metacall-environment.sh
+++ b/tools/metacall-environment.sh
@@ -559,10 +559,10 @@ sub_nodejs(){
 			brew install libgit2@1.8
 			brew link libgit2@1.8 --force --overwrite
 		fi
-		
+
 		elif [ "${OPERATIVE_SYSTEM}" = "FreeBSD" ]; then
 		$SUDO_CMD pkg install -y node22 npm-node22 python3 gmake
-		NODE_VERSION=$(node22 --version | sed 's/v//')
+		NODE_VERSION=$(node --version | sed 's/v//')
 		fetch -o /tmp/node-v${NODE_VERSION}.tar.gz https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}.tar.gz
 		tar xzf /tmp/node-v${NODE_VERSION}.tar.gz -C /tmp
 		sed -i '' '/ASSERT_TRIVIALLY_COPYABLE(T);/d' /tmp/node-v${NODE_VERSION}/deps/v8/src/base/small-vector.h
@@ -574,7 +574,7 @@ sub_nodejs(){
 		rm -rf /tmp/node-v${NODE_VERSION} /tmp/node-v${NODE_VERSION}.tar.gz
 		mkdir -p "$ROOT_DIR/build"
 		CMAKE_CONFIG_PATH="$ROOT_DIR/build/CMakeConfig.txt"
-		echo "-DNodeJS_EXECUTABLE=/usr/local/bin/node22" >> $CMAKE_CONFIG_PATH
+		echo "-DNodeJS_EXECUTABLE=/usr/local/bin/node" >> $CMAKE_CONFIG_PATH
 
 	fi
 }

--- a/tools/metacall-environment.sh
+++ b/tools/metacall-environment.sh
@@ -569,7 +569,8 @@ sub_nodejs(){
 		cd /tmp/node-v${NODE_VERSION}
 		CC=cc CXX=c++ ./configure --shared
 		gmake -j$(sysctl -n hw.ncpu)
-		$SUDO_CMD cp out/Release/lib/libnode.so.* /usr/local/lib/
+		$SUDO_CMD cp out/Release/obj.target/libnode.so.* /usr/local/lib/
+		$SUDO_CMD ln -sf libnode.so.127 /usr/local/lib/libnode.so
 		cd $ROOT_DIR
 		rm -rf /tmp/node-v${NODE_VERSION} /tmp/node-v${NODE_VERSION}.tar.gz
 		mkdir -p "$ROOT_DIR/build"

--- a/tools/metacall-environment.sh
+++ b/tools/metacall-environment.sh
@@ -193,6 +193,8 @@ sub_python(){
 		pip3 install numpy
 		pip3 install joblib
 		pip3 install scikit-learn
+	elif [ "${OPERATIVE_SYSTEM}" = "FreeBSD" ]; then
+		$SUDO_CMD pkg install -y python3
 	fi
 }
 

--- a/tools/metacall-environment.sh
+++ b/tools/metacall-environment.sh
@@ -567,7 +567,7 @@ sub_nodejs(){
 		tar xzf /tmp/node-v${NODE_VERSION}.tar.gz -C /tmp
 		sed -i '' '/ASSERT_TRIVIALLY_COPYABLE(T);/d' /tmp/node-v${NODE_VERSION}/deps/v8/src/base/small-vector.h
 		cd /tmp/node-v${NODE_VERSION}
-		./configure --shared
+		CC=cc CXX=c++ ./configure --shared
 		gmake -j$(sysctl -n hw.ncpu)
 		$SUDO_CMD cp out/Release/lib/libnode.so.* /usr/local/lib/
 		cd $ROOT_DIR

--- a/tools/metacall-environment.sh
+++ b/tools/metacall-environment.sh
@@ -694,6 +694,14 @@ sub_c(){
 		echo "-DLibClang_INCLUDE_DIR=${LIBCLANG_PREFIX}/include" >> $CMAKE_CONFIG_PATH
 		echo "-DLibClang_LIBRARY=${LIBCLANG_PREFIX}/lib/libclang.dylib" >> $CMAKE_CONFIG_PATH
 		echo "-DLibClang_CMAKE_DEBUG=ON" >> $CMAKE_CONFIG_PATH
+
+	elif [ "${OPERATIVE_SYSTEM}" = "FreeBSD" ]; then
+		LLVM_VERSION_STRING=19
+		$SUDO_CMD pkg install -y libffi llvm${LLVM_VERSION_STRING}
+		mkdir -p "$ROOT_DIR/build"
+		CMAKE_CONFIG_PATH="$ROOT_DIR/build/CMakeConfig.txt"
+		echo "-DLibClang_INCLUDE_DIR=/usr/local/llvm${LLVM_VERSION_STRING}/include" >> $CMAKE_CONFIG_PATH
+		echo "-DLibClang_LIBRARY=/usr/local/llvm${LLVM_VERSION_STRING}/lib/libclang.so" >> $CMAKE_CONFIG_PATH
 	fi
 }
 

--- a/tools/metacall-environment.sh
+++ b/tools/metacall-environment.sh
@@ -697,7 +697,7 @@ sub_c(){
 
 	elif [ "${OPERATIVE_SYSTEM}" = "FreeBSD" ]; then
 		LLVM_VERSION_STRING=19
-		$SUDO_CMD pkg install -y libffi llvm${LLVM_VERSION_STRING}
+		$SUDO_CMD pkg install -y libffi llvm${LLVM_VERSION_STRING} gcc
 		mkdir -p "$ROOT_DIR/build"
 		CMAKE_CONFIG_PATH="$ROOT_DIR/build/CMakeConfig.txt"
 		echo "-DLibClang_INCLUDE_DIR=/usr/local/llvm${LLVM_VERSION_STRING}/include" >> $CMAKE_CONFIG_PATH

--- a/tools/metacall-environment.sh
+++ b/tools/metacall-environment.sh
@@ -559,12 +559,12 @@ sub_nodejs(){
 			brew install libgit2@1.8
 			brew link libgit2@1.8 --force --overwrite
 		fi
-
-		elif [ "${OPERATIVE_SYSTEM}" = "FreeBSD" ]; then
+	elif [ "${OPERATIVE_SYSTEM}" = "FreeBSD" ]; then
 		$SUDO_CMD pkg install -y node22 npm-node22 python3 gmake
 		NODE_VERSION=$(node --version | sed 's/v//')
 		fetch -o /tmp/node-v${NODE_VERSION}.tar.gz https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}.tar.gz
 		tar xzf /tmp/node-v${NODE_VERSION}.tar.gz -C /tmp
+		# TODO: Dirty fix, review or delete this
 		sed -i '' '/ASSERT_TRIVIALLY_COPYABLE(T);/d' /tmp/node-v${NODE_VERSION}/deps/v8/src/base/small-vector.h
 		cd /tmp/node-v${NODE_VERSION}
 		CC=cc CXX=c++ ./configure --shared
@@ -576,7 +576,6 @@ sub_nodejs(){
 		mkdir -p "$ROOT_DIR/build"
 		CMAKE_CONFIG_PATH="$ROOT_DIR/build/CMakeConfig.txt"
 		echo "-DNodeJS_EXECUTABLE=/usr/local/bin/node" >> $CMAKE_CONFIG_PATH
-
 	fi
 }
 

--- a/tools/metacall-environment.sh
+++ b/tools/metacall-environment.sh
@@ -68,6 +68,7 @@ case "$(uname -s)" in
 	Darwin*)	OPERATIVE_SYSTEM=Darwin;;
 	CYGWIN*)	OPERATIVE_SYSTEM=Cygwin;;
 	MINGW*)		OPERATIVE_SYSTEM=MinGW;;
+	FreeBSD*)	OPERATIVE_SYSTEM=FreeBSD;;
 	*)			OPERATIVE_SYSTEM="Unknown"
 esac
 
@@ -112,6 +113,8 @@ sub_base(){
 		fi
 	elif [ "${OPERATIVE_SYSTEM}" = "Darwin" ]; then
 		brew install llvm cmake git wget gnupg ca-certificates
+	elif [ "${OPERATIVE_SYSTEM}" = "FreeBSD" ]; then
+		$SUDO_CMD pkg install -y cmake git gmake wget gnupg ca_root_nss
 	fi
 }
 


### PR DESCRIPTION
Starting FreeBSD CI support for metacall/core.                                                                                                     
  - Added FreeBSD OS detection to environment and configure scripts
  - Added base package installation via pkg
  - Added freebsd-test.yml using cross-platform-actions for FreeBSD 14.2 