### PR TITLE
fix(py_loader): add missing Py_XDECREF on inspect_signature results and cleanup on PyList_SetItem failure

### DIFF
--- a/source/loaders/py_loader/source/py_loader_impl.c
+++ b/source/loaders/py_loader/source/py_loader_impl.c
@@ -1304,7 +1304,8 @@ PyObject *py_loader_impl_value_to_capi(loader_impl impl, type_id id, value v)
 
 			if (PyList_SetItem(list, iterator, item) != 0)
 			{
-				/* TODO: Report error */
+				Py_DECREF(list);
+				return NULL;
 			}
 		}
 
@@ -3317,6 +3318,7 @@ int py_loader_impl_discover_func(loader_impl impl, PyObject *func, function f)
 		signature_set_return(s, py_loader_impl_discover_type(impl, return_annotation, func_name, NULL));
 
 		Py_DecRef(return_annotation);
+		Py_XDECREF(result);
 
 		return 0;
 	}
@@ -3330,6 +3332,7 @@ int py_loader_impl_discover_func(loader_impl impl, PyObject *func, function f)
 			signature s = function_signature(f);
 
 			signature_set_return(s, NULL);
+			Py_XDECREF(result);
 
 			return 0;
 		}
@@ -3414,6 +3417,7 @@ int py_loader_impl_discover_method(loader_impl impl, PyObject *callable, method 
 		signature_set_return(s, py_loader_impl_discover_type(impl, return_annotation, m_name, NULL));
 
 		Py_DecRef(return_annotation);
+		Py_XDECREF(result);
 
 		return 0;
 	}
@@ -3427,6 +3431,7 @@ int py_loader_impl_discover_method(loader_impl impl, PyObject *callable, method 
 			signature s = method_signature(m);
 
 			signature_set_return(s, NULL);
+			Py_XDECREF(result);
 
 			return 0;
 		}
@@ -3558,6 +3563,7 @@ int py_loader_impl_discover_constructor(loader_impl impl, PyObject *py_class, kl
 	}
 
 	Py_DecRef(parameters);
+	Py_XDECREF(result);
 
 	return ret;
 }
@@ -3700,6 +3706,8 @@ int py_loader_impl_discover_class(loader_impl impl, PyObject *py_class, klass c)
 				class_register_static_attribute(c, static_attr);
 				class_register_attribute(c, attr);
 			}
+
+			Py_XDECREF(method_static);
 		}
 
 		Py_DecRef(dict_items);


### PR DESCRIPTION
## Changes

Found via valgrind running the release-python test suite with a custom python+valgrind build (tools/instrumentation/python-valgrind).

- `Py_DECREF(list)` + early return on `PyList_SetItem` failure
- `Py_XDECREF(result)` in `py_loader_impl_discover_func` (2 places)
- `Py_XDECREF(result)` in `py_loader_impl_discover_method` (2 places)
- `Py_XDECREF(result)` in `py_loader_impl_discover_constructor`
- `Py_XDECREF(method_static)` in `py_loader_impl_discover_class`

Valgrind logs: https://gist.github.com/MrSpideyNihal/4b9568aa50e724ca2f0250b45b17880e