### PR TITLE
ci: add cargo clippy check to Rust CI pipeline

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           toolchain: stable
           override: true
-          components: rustfmt
+          components: rustfmt, clippy
 
       - name: Build the Rust Port
         working-directory: source/ports/rs_port
@@ -50,6 +50,10 @@ jobs:
       - name: Check Rust Formatting
         working-directory: source/ports/rs_port
         run: cargo fmt --check
+
+      - name: Run Clippy
+        working-directory: source/ports/rs_port
+        run: cargo clippy -- -D warnings
 
       - name: Test the Rust Port
         working-directory: source/ports/rs_port


### PR DESCRIPTION
## What
Added `cargo clippy` check to the Rust CI pipeline inside the `test` job.

## Why
Clippy was already installed but not enforced in CI. This ensures 
code quality warnings are caught automatically on every PR.

## Changes
- Added `clippy` to components in the Install Rust step
- Added "Run Clippy" step after "Check Rust Formatting" and before "Test the Rust Port"
- Uses `-- -D warnings` flag to fail CI on any clippy warning

## Notes
- Follows the same pattern as the previously merged cargo fmt --check (#747)
- Runs on all 3 platforms: ubuntu, windows, macos