### PR TITLE
Added Tag enum with from_extension method and add execution_path func…

### DIFF
--- a/source/ports/rs_port/Cargo.toml
+++ b/source/ports/rs_port/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "metacall"
 readme = "README.md"
 repository = "https://github.com/metacall/core/tree/develop/source/ports/rs_port"
-version = "0.5.8"
+version = "0.5.9"
 
 [lib]
 crate-type = ["lib"]

--- a/source/ports/rs_port/src/load.rs
+++ b/source/ports/rs_port/src/load.rs
@@ -1,5 +1,8 @@
 use crate::{
-    bindings::{metacall_clear, metacall_load_from_file, metacall_load_from_memory},
+    bindings::{
+        metacall_clear, metacall_execution_path, metacall_load_from_file,
+        metacall_load_from_memory,
+    },
     cstring_enum,
     types::MetaCallLoaderError,
 };
@@ -36,6 +39,30 @@ pub enum Tag {
     Rust,
     TypeScript,
     Wasm,
+}
+
+impl Tag {
+    /// Returns the matching tag for a given file extension, or `None` if unsupported.
+    pub fn from_extension(ext: &str) -> Option<Self> {
+        match ext {
+            "c" => Some(Tag::C),
+            "cob" | "cbl" => Some(Tag::Cobol),
+            "cr" => Some(Tag::Crystal),
+            "cs" => Some(Tag::CSharp),
+            "dart" => Some(Tag::Dart),
+            "java" => Some(Tag::Java),
+            "jl" => Some(Tag::Julia),
+            "js" | "mjs" | "cjs" => Some(Tag::NodeJS),
+            "jsm" => Some(Tag::JSM),
+            "lua" => Some(Tag::Lua),
+            "py" => Some(Tag::Python),
+            "rb" => Some(Tag::Ruby),
+            "rs" => Some(Tag::Rust),
+            "ts" => Some(Tag::TypeScript),
+            "wasm" => Some(Tag::Wasm),
+            _ => None,
+        }
+    }
 }
 
 impl fmt::Display for Tag {
@@ -201,6 +228,18 @@ pub fn from_memory(
     } != 0
     {
         return Err(MetaCallLoaderError::FromMemoryFailure);
+    }
+
+    Ok(())
+}
+
+/// Sets the execution path for the given loader tag.
+pub fn execution_path(tag: Tag, path: impl AsRef<Path>) -> Result<(), MetaCallLoaderError> {
+    let c_tag = cstring_enum!(tag, MetaCallLoaderError)?;
+    let c_path = cstring_enum!(path.as_ref().to_str().unwrap(), MetaCallLoaderError)?;
+
+    if unsafe { metacall_execution_path(c_tag.as_ptr(), c_path.as_ptr()) } != 0 {
+        return Err(MetaCallLoaderError::ExecutionPathFailure);
     }
 
     Ok(())

--- a/source/ports/rs_port/src/load.rs
+++ b/source/ports/rs_port/src/load.rs
@@ -1,7 +1,6 @@
 use crate::{
     bindings::{
-        metacall_clear, metacall_execution_path, metacall_load_from_file,
-        metacall_load_from_memory,
+        metacall_clear, metacall_execution_path, metacall_load_from_file, metacall_load_from_memory,
     },
     cstring_enum,
     types::MetaCallLoaderError,

--- a/source/ports/rs_port/src/load.rs
+++ b/source/ports/rs_port/src/load.rs
@@ -46,20 +46,31 @@ impl Tag {
     pub fn from_extension(ext: &str) -> Option<Self> {
         match ext {
             "c" => Some(Tag::C),
-            "cob" | "cbl" => Some(Tag::Cobol),
+            "cob" | "cbl" | "cpy" => Some(Tag::Cobol),
             "cr" => Some(Tag::Crystal),
-            "cs" => Some(Tag::CSharp),
+            "cs" | "vb" => Some(Tag::CSharp),
             "dart" => Some(Tag::Dart),
             "java" => Some(Tag::Java),
             "jl" => Some(Tag::Julia),
-            "js" | "mjs" | "cjs" => Some(Tag::NodeJS),
+            "js" | "mjs" | "cjs" | "node" => Some(Tag::NodeJS),
             "jsm" => Some(Tag::JSM),
             "lua" => Some(Tag::Lua),
+            "mock" => Some(Tag::Mock),
             "py" => Some(Tag::Python),
             "rb" => Some(Tag::Ruby),
             "rs" => Some(Tag::Rust),
-            "ts" => Some(Tag::TypeScript),
+            "ts" | "jsx" | "tsx" => Some(Tag::TypeScript),
+            "wat" | "wasm" => Some(Tag::Wasm),
+            _ => None,
+        }
+    }
+
+    /// Returns the matching tag for a package extension (compiled artifacts like .dll, .rlib).
+    pub fn from_package_extension(ext: &str) -> Option<Self> {
+        match ext {
+            "dll" => Some(Tag::CSharp),
             "wasm" => Some(Tag::Wasm),
+            "rlib" => Some(Tag::Rust),
             _ => None,
         }
     }

--- a/source/ports/rs_port/src/types/metacall_error.rs
+++ b/source/ports/rs_port/src/types/metacall_error.rs
@@ -87,6 +87,8 @@ pub enum MetaCallLoaderError {
     FromFileFailure,
     /// Failed to load from memory.
     FromMemoryFailure,
+    /// Failed to set execution path.
+    ExecutionPathFailure,
     /// Not a file or permission denied.
     NotAFileOrPermissionDenied(PathBuf),
     /// Null character detected.


### PR DESCRIPTION
## Summary
- Expose `metacall_execution_path` as a safe Rust wrapper (`load::execution_path`), resolving the missing API from #643
- Add `Tag::from_extension()` method for detecting MetaCall runtime tags from file extensions
- Add `ExecutionPathFailure` error variant to `MetaCallLoaderError`

## Why this change
The `metacall_execution_path` C API exists in the Python and Node.js ports but was missing from the Rust port. This blocks Rust consumers (like MetaSSR) from configuring loader search paths for polyglot support. The `Tag::from_extension()` helper enables automatic language detection from file extensions.

## Changes
- `source/ports/rs_port/src/load.rs`: Added `Tag::from_extension()` and `execution_path()` function
- `source/ports/rs_port/src/types/metacall_error.rs`: Added `ExecutionPathFailure` variant
