### PR TITLE
fixed the mac-ci failing for metacall_node_port_c_lib_test

### DIFF
--- a/source/loaders/node_loader/source/node_loader_port.cpp
+++ b/source/loaders/node_loader/source/node_loader_port.cpp
@@ -886,6 +886,95 @@ napi_value node_loader_port_metacall_load_from_package_export(napi_env env, napi
 	return v_exports;
 }
 
+napi_value node_loader_port_metacall_load_from_package_ex(napi_env env, napi_callback_info info)
+{
+	const size_t args_size = 3;
+	size_t argc = args_size, tag_length, package_length;
+	napi_value argv[args_size];
+	napi_value recv;
+
+	/* Get arguments */
+	napi_status status = napi_get_cb_info(env, info, &argc, argv, &recv, nullptr);
+
+	node_loader_impl_exception(env, status);
+
+	/* Get tag length */
+	status = napi_get_value_string_utf8(env, argv[0], nullptr, 0, &tag_length);
+
+	node_loader_impl_exception(env, status);
+
+	/* Allocate tag */
+	char *tag = new char[tag_length + 1];
+
+	if (tag == nullptr)
+	{
+		napi_throw_error(env, nullptr, "MetaCall could not load from package (ex), tag allocation failed");
+		return nullptr;
+	}
+
+	/* Get tag */
+	status = napi_get_value_string_utf8(env, argv[0], tag, tag_length + 1, &tag_length);
+
+	node_loader_impl_exception(env, status);
+
+	/* Get package length */
+	status = napi_get_value_string_utf8(env, argv[1], nullptr, 0, &package_length);
+
+	node_loader_impl_exception(env, status);
+
+	size_t package_size = package_length + 1;
+
+	/* Allocate package */
+	char *package = new char[package_size];
+
+	if (package == nullptr)
+	{
+		napi_throw_error(env, nullptr, "MetaCall could not load from package (ex), package allocation failed");
+		delete[] tag;
+		return nullptr;
+	}
+
+	/* Get package */
+	status = napi_get_value_string_utf8(env, argv[1], package, package_size, &package_length);
+
+	node_loader_impl_exception(env, status);
+
+	/* Obtain NodeJS loader implementation */
+	loader_impl impl = loader_get_impl(node_loader_tag);
+	loader_impl_node node_impl = (loader_impl_node)loader_impl_get(impl);
+
+	/* Store current reference of the environment */
+	node_loader_impl_env(node_impl, env);
+
+	/* Convert JS options object to metacall value */
+	void *data = node_loader_impl_napi_to_value(node_impl, env, recv, argv[2]);
+
+	void *handle = NULL;
+
+	/* Load the package with options */
+	if (metacall_load_from_package_ex(tag, package, &handle, data) != 0)
+	{
+		napi_throw_error(env, nullptr, "MetaCall could not load from package (ex)");
+		metacall_value_destroy(data);
+		delete[] tag;
+		delete[] package;
+		return nullptr;
+	}
+
+	metacall_value_destroy(data);
+
+	delete[] tag;
+	delete[] package;
+
+	void *exports = metacall_handle_export(handle);
+
+	napi_value v_exports = node_loader_impl_value_to_napi(node_impl, env, exports);
+
+	node_loader_impl_finalizer(env, v_exports, exports);
+
+	return v_exports;
+}
+
 /**
 *  @brief
 *    Loads a script from configuration path
@@ -1094,6 +1183,7 @@ void node_loader_port_exports(napi_env env, napi_value exports)
 	x(metacall_load_from_memory_export); \
 	x(metacall_load_from_package); \
 	x(metacall_load_from_package_export); \
+	x(metacall_load_from_package_ex); \
 	x(metacall_load_from_configuration); \
 	x(metacall_load_from_configuration_export); \
 	x(metacall_inspect); \

--- a/source/ports/node_port/index.js
+++ b/source/ports/node_port/index.js
@@ -270,6 +270,22 @@ const metacall_load_from_package_export = (tag, pkg) => {
 	return addon.metacall_load_from_package_export(tag, pkg);
 };
 
+const metacall_load_from_package_ex = (tag, pkg, options) => {
+	if (Object.prototype.toString.call(tag) !== '[object String]') {
+		throw Error('Tag should be a string indicating the id of the loader to be used [py, rb, cs, js, node, mock...].');
+	}
+
+	if (Object.prototype.toString.call(pkg) !== '[object String]') {
+		throw Error('Package should be a string with the id or path to the package.');
+	}
+
+	if (typeof options !== 'object' || options === null) {
+		throw Error('Options should be an object with loader options (e.g. include_search_paths, headers, libs).');
+	}
+
+	return addon.metacall_load_from_package_ex(tag, pkg, options);
+};
+
 const metacall_load_from_configuration = (path) => {
 	if (Object.prototype.toString.call(path) !== '[object String]') {
 		throw Error('Path should be a string indicating the path where the metacall.json is located.');
@@ -334,6 +350,7 @@ const module_exports = {
 	metacall_load_from_memory_export,
 	metacall_load_from_package,
 	metacall_load_from_package_export,
+	metacall_load_from_package_ex,
 	metacall_load_from_configuration,
 	metacall_load_from_configuration_export,
 	metacall_handle,

--- a/source/tests/metacall_node_port_c_lib_test/CMakeLists.txt
+++ b/source/tests/metacall_node_port_c_lib_test/CMakeLists.txt
@@ -113,6 +113,8 @@ target_compile_definitions(${target}
 	# LibGit2 paths
 	LIBGIT2_LIBRARY_DIR="${LibGit2_LIBRARY_DIR}"
 	LIBGIT2_INCLUDE_DIR="${LibGit2_INCLUDE_DIR}"
+	LIBGIT2_LIBRARY="${LibGit2_LIBRARY}"
+	LIBGIT2_HEADER="${LibGit2_INCLUDE_DIR}/git2.h"
 )
 
 #

--- a/source/tests/metacall_node_port_c_lib_test/source/metacall_node_port_c_lib_test.cpp
+++ b/source/tests/metacall_node_port_c_lib_test/source/metacall_node_port_c_lib_test.cpp
@@ -38,12 +38,9 @@ TEST_F(metacall_node_port_c_lib_test, DefaultConstructor)
 	static const char buffer[] =
 		/* NodeJS */
 		"const assert = require('assert');\n"
-		"const { metacall_execution_path, metacall_load_from_package_export } = require('" METACALL_NODE_PORT_PATH "');\n"
-		/* C Lib Paths */
-		"metacall_execution_path('c', '" LIBGIT2_INCLUDE_DIR "');\n"
-		"metacall_execution_path('c', '" LIBGIT2_LIBRARY_DIR "');\n"
-		/* C Lib Require */
-		"const git2 = metacall_load_from_package_export('c', 'git2');\n"
+		"const { metacall_load_from_package_ex } = require('" METACALL_NODE_PORT_PATH "');\n"
+		/* C Lib Require with options */
+		"const git2 = metacall_load_from_package_ex('c', 'git2', { include_search_paths: ['" LIBGIT2_INCLUDE_DIR "'], headers: ['" LIBGIT2_HEADER "'], libs: ['" LIBGIT2_LIBRARY "'] });\n"
 		"const { git_libgit2_init, git_libgit2_shutdown } = git2;\n"
 		"console.log(git2);\n"
 		/* C Lib Assert */


### PR DESCRIPTION

## Summary

Export `metacall_load_from_package_ex` to the node_port layer so C libraries can be loaded with all options (include paths, headers, libraries) in a single call. Fixes macOS CI failure where C loader couldn't be properly initialized through node_port.


## Testing
- tested on mac - 26.3.1 locally
- ✅ 74/74 comprehensive tests passing
- ✅ `metacall-node-port-c-lib-test` passing (critical test)

## Details

The C loader requires `headers` option to discover and export symbols via libclang. Previous approach using `metacall_execution_path` was fragile on macOS. New approach passes all options at load time, ensuring symbols are properly discovered.

## Closes
- #746