### PR TITLE
fix(rs_port): mismatched type in MetacallDestroy

### DIFF
--- a/source/ports/rs_port/Cargo.toml
+++ b/source/ports/rs_port/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "metacall"
 readme = "README.md"
 repository = "https://github.com/metacall/core/tree/develop/source/ports/rs_port"
-version = "0.5.9"
+version = "0.5.10"
 
 [lib]
 crate-type = ["lib"]

--- a/source/ports/rs_port/src/init.rs
+++ b/source/ports/rs_port/src/init.rs
@@ -4,11 +4,11 @@ use crate::{
 };
 use std::ptr;
 
-pub struct MetaCallDestroy(unsafe extern "C" fn());
+pub struct MetaCallDestroy(unsafe extern "C" fn() -> i32);
 
 impl Drop for MetaCallDestroy {
     fn drop(&mut self) {
-        unsafe { self.0() }
+        unsafe { self.0(); }
     }
 }
 


### PR DESCRIPTION
# Description

Fix a build error 

```
error[E0308]: mismatched types
  --> /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/metacall-0.5.9/src/init.rs:31:24
   |
31 |     Ok(MetaCallDestroy(metacall_destroy))
   |        --------------- ^^^^^^^^^^^^^^^^ expected fn pointer, found fn item
   |        |
   |        arguments to this struct are incorrect
   |
   = note: expected fn pointer `unsafe extern "C" fn() -> ()`
                 found fn item `unsafe extern "C" fn() -> i32 {bindings::metacall_destroy}`
note: tuple struct defined here
  --> /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/metacall-0.5.9/src/init.rs:7:12
   |
 7 | pub struct MetaCallDestroy(unsafe extern "C" fn());
   |            ^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0308`.
warning: metacall@0.5.9: Library metacall found in: /usr/local/lib with runtime search path: /usr/local/lib
error: could not compile `metacall` (lib) due to 1 previous error
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests/screenshots (if any) that prove my fix is effective or that my feature works.
- [ ] I have tested the tests implicated (if any) by my own code and they pass (`make test` or `ctest -VV -R <test-name>`).
- [ ] If my change is significant or breaking, I have passed all tests with `./docker-compose.sh test &> output` and attached the output.
- [ ] I have tested my code with `OPTION_BUILD_ADDRESS_SANITIZER` or `./docker-compose.sh test-address-sanitizer &> output` and `OPTION_TEST_MEMORYCHECK`.
- [ ] I have tested my code with `OPTION_BUILD_THREAD_SANITIZER` or `./docker-compose.sh test-thread-sanitizer &> output`.
- [ ] I have tested with `Helgrind` in case my code works with threading.
- [ ] I have run `make clang-format` in order to format my code and my code follows the style guidelines.

If you are unclear about any of the above checks, have a look at our documentation [here](https://github.com/metacall/core/blob/develop/docs/README.md#63-debugging).
