### PR TITLE
fix(valgrind): add max-stackframe flag and update python suppressions to 3.13

### DIFF
--- a/source/tests/memcheck/valgrind-python.supp
+++ b/source/tests/memcheck/valgrind-python.supp
@@ -1,5 +1,5 @@
+# From: https://github.com/python/cpython/blob/v3.13.0/Misc/valgrind-python.supp
 #
-# From: https://github.com/python/cpython/blob/master/Misc/valgrind-python.supp
 #
 # This is a valgrind suppression file that should be used when using valgrind.
 #
@@ -7,160 +7,219 @@
 #
 #	cd python/dist/src
 #	valgrind --tool=memcheck --suppressions=Misc/valgrind-python.supp \
-#		./python -E -tt ./Lib/test/regrtest.py -u bsddb,network
+#		./python -E ./Lib/test/regrtest.py -u gui,network
 #
 # You must edit Objects/obmalloc.c and uncomment Py_USING_MEMORY_DEBUGGER
-# to use the preferred suppressions with Py_ADDRESS_IN_RANGE.
+# to use the preferred suppressions with address_in_range.
 #
 # If you do not want to recompile Python, you can uncomment
-# suppressions for PyObject_Free and PyObject_Realloc.
+# suppressions for _PyObject_Free and _PyObject_Realloc.
 #
 # See Misc/README.valgrind for more information.
 
 # all tool names: Addrcheck,Memcheck,cachegrind,helgrind,massif
 {
-	ADDRESS_IN_RANGE/Invalid read of size 4
-	Memcheck:Addr4
-	fun:Py_ADDRESS_IN_RANGE
+   ADDRESS_IN_RANGE/Invalid read of size 4
+   Memcheck:Addr4
+   fun:address_in_range
 }
 
 {
-	ADDRESS_IN_RANGE/Invalid read of size 4
-	Memcheck:Value4
-	fun:Py_ADDRESS_IN_RANGE
+   ADDRESS_IN_RANGE/Invalid read of size 4
+   Memcheck:Value4
+   fun:address_in_range
 }
 
 {
-	ADDRESS_IN_RANGE/Invalid read of size 8 (x86_64 aka amd64)
-	Memcheck:Value8
-	fun:Py_ADDRESS_IN_RANGE
+   ADDRESS_IN_RANGE/Invalid read of size 8 (x86_64 aka amd64)
+   Memcheck:Value8
+   fun:address_in_range
 }
 
 {
-	ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
-	Memcheck:Cond
-	fun:Py_ADDRESS_IN_RANGE
+   ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
+   Memcheck:Cond
+   fun:address_in_range
 }
 
 #
 # Leaks (including possible leaks)
-#	 Hmmm, I wonder if this masks some real leaks.  I think it does.
-#	 Will need to fix that.
+#    Hmmm, I wonder if this masks some real leaks.  I think it does.
+#    Will need to fix that.
 #
 
 {
-	Suppress leaking the GIL.  Happens once per process, see comment in ceval.c.
-	Memcheck:Leak
-	fun:malloc
-	fun:PyThread_allocate_lock
-	fun:PyEval_InitThreads
+   Suppress leaking the GIL after a fork.
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_allocate_lock
+   fun:PyEval_ReInitThreads
 }
 
 {
-	Suppress leaking the GIL after a fork.
-	Memcheck:Leak
-	fun:malloc
-	fun:PyThread_allocate_lock
-	fun:PyEval_ReInitThreads
+   Suppress leaking the autoTLSkey.  This looks like it shouldn't leak though.
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_create_key
+   fun:_PyGILState_Init
+   fun:Py_InitializeEx
+   fun:Py_Main
 }
 
 {
-	Suppress leaking the autoTLSkey.  This looks like it shouldn't leak though.
-	Memcheck:Leak
-	fun:malloc
-	fun:PyThread_create_key
-	fun:_PyGILState_Init
-	fun:Py_InitializeEx
-	fun:Py_Main
+   Hmmm, is this a real leak or like the GIL?
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_ReInitTLS
 }
 
 {
-	Hmmm, is this a real leak or like the GIL?
-	Memcheck:Leak
-	fun:malloc
-	fun:PyThread_ReInitTLS
+   Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:realloc
+   fun:_PyObject_GC_Resize
+   fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
 }
 
 {
-	Handle PyMalloc confusing valgrind (possibly leaked)
-	Memcheck:Leak
-	fun:realloc
-	fun:_PyObject_GC_Resize
-	fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
+   Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:malloc
+   fun:_PyObject_GC_New
+   fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
 }
 
 {
-	Handle PyMalloc confusing valgrind (possibly leaked)
-	Memcheck:Leak
-	fun:malloc
-	fun:_PyObject_GC_New
-	fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
+   Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:malloc
+   fun:_PyObject_GC_NewVar
+   fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
 }
 
+#
+# Leaks: dlopen() called without dlclose()
+#
+
 {
-	Handle PyMalloc confusing valgrind (possibly leaked)
-	Memcheck:Leak
-	fun:malloc
-	fun:_PyObject_GC_NewVar
-	fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
+   dlopen() called without dlclose()
+   Memcheck:Leak
+   fun:malloc
+   fun:malloc
+   fun:strdup
+   fun:_dl_load_cache_lookup
 }
+{
+   dlopen() called without dlclose()
+   Memcheck:Leak
+   fun:malloc
+   fun:malloc
+   fun:strdup
+   fun:_dl_map_object
+}
+{
+   dlopen() called without dlclose()
+   Memcheck:Leak
+   fun:malloc
+   fun:*
+   fun:_dl_new_object
+}
+{
+   dlopen() called without dlclose()
+   Memcheck:Leak
+   fun:calloc
+   fun:*
+   fun:_dl_new_object
+}
+{
+   dlopen() called without dlclose()
+   Memcheck:Leak
+   fun:calloc
+   fun:*
+   fun:_dl_check_map_versions
+}
+
 
 #
 # Non-python specific leaks
 #
 
 {
-	Handle pthread issue (possibly leaked)
-	Memcheck:Leak
-	fun:calloc
-	fun:allocate_dtv
-	fun:_dl_allocate_tls_storage
-	fun:_dl_allocate_tls
+   Handle pthread issue (possibly leaked)
+   Memcheck:Leak
+   fun:calloc
+   fun:allocate_dtv
+   fun:_dl_allocate_tls_storage
+   fun:_dl_allocate_tls
 }
 
 {
-	Handle pthread issue (possibly leaked)
-	Memcheck:Leak
-	fun:memalign
-	fun:_dl_allocate_tls_storage
-	fun:_dl_allocate_tls
+   Handle pthread issue (possibly leaked)
+   Memcheck:Leak
+   fun:memalign
+   fun:_dl_allocate_tls_storage
+   fun:_dl_allocate_tls
 }
 
-{
-	ADDRESS_IN_RANGE/Invalid read of size 4
-	Memcheck:Addr4
-	fun:PyObject_Free
-}
+###{
+###   ADDRESS_IN_RANGE/Invalid read of size 4
+###   Memcheck:Addr4
+###   fun:_PyObject_Free
+###}
+###
+###{
+###   ADDRESS_IN_RANGE/Invalid read of size 4
+###   Memcheck:Value4
+###   fun:_PyObject_Free
+###}
+###
+###{
+###   ADDRESS_IN_RANGE/Use of uninitialised value of size 8
+###   Memcheck:Addr8
+###   fun:_PyObject_Free
+###}
+###
+###{
+###   ADDRESS_IN_RANGE/Use of uninitialised value of size 8
+###   Memcheck:Value8
+###   fun:_PyObject_Free
+###}
+###
+###{
+###   ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
+###   Memcheck:Cond
+###   fun:_PyObject_Free
+###}
 
-{
-	ADDRESS_IN_RANGE/Invalid read of size 4
-	Memcheck:Value4
-	fun:PyObject_Free
-}
-
-{
-	ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
-	Memcheck:Cond
-	fun:PyObject_Free
-}
-
-{
-	ADDRESS_IN_RANGE/Invalid read of size 4
-	Memcheck:Addr4
-	fun:PyObject_Realloc
-}
-
-{
-	ADDRESS_IN_RANGE/Invalid read of size 4
-	Memcheck:Value4
-	fun:PyObject_Realloc
-}
-
-{
-	ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
-	Memcheck:Cond
-	fun:PyObject_Realloc
-}
+###{
+###   ADDRESS_IN_RANGE/Invalid read of size 4
+###   Memcheck:Addr4
+###   fun:_PyObject_Realloc
+###}
+###
+###{
+###   ADDRESS_IN_RANGE/Invalid read of size 4
+###   Memcheck:Value4
+###   fun:_PyObject_Realloc
+###}
+###
+###{
+###   ADDRESS_IN_RANGE/Use of uninitialised value of size 8
+###   Memcheck:Addr8
+###   fun:_PyObject_Realloc
+###}
+###
+###{
+###   ADDRESS_IN_RANGE/Use of uninitialised value of size 8
+###   Memcheck:Value8
+###   fun:_PyObject_Realloc
+###}
+###
+###{
+###   ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
+###   Memcheck:Cond
+###   fun:_PyObject_Realloc
+###}
 
 ###
 ### All the suppressions below are for errors that occur within libraries
@@ -169,223 +228,309 @@
 ###
 
 {
-	Generic ubuntu ld problems
-	Memcheck:Addr8
-	obj:/lib/ld-2.4.so
-	obj:/lib/ld-2.4.so
-	obj:/lib/ld-2.4.so
-	obj:/lib/ld-2.4.so
+   Generic ubuntu ld problems
+   Memcheck:Addr8
+   obj:/lib/ld-2.4.so
+   obj:/lib/ld-2.4.so
+   obj:/lib/ld-2.4.so
+   obj:/lib/ld-2.4.so
 }
 
 {
-	Generic gentoo ld problems
-	Memcheck:Cond
-	obj:/lib/ld-2.3.4.so
-	obj:/lib/ld-2.3.4.so
-	obj:/lib/ld-2.3.4.so
-	obj:/lib/ld-2.3.4.so
+   Generic gentoo ld problems
+   Memcheck:Cond
+   obj:/lib/ld-2.3.4.so
+   obj:/lib/ld-2.3.4.so
+   obj:/lib/ld-2.3.4.so
+   obj:/lib/ld-2.3.4.so
 }
 
 {
-	DBM problems, see test_dbm
-	Memcheck:Param
-	write(buf)
-	fun:write
-	obj:/usr/lib/libdb1.so.2
-	obj:/usr/lib/libdb1.so.2
-	obj:/usr/lib/libdb1.so.2
-	obj:/usr/lib/libdb1.so.2
-	fun:dbm_close
+   DBM problems, see test_dbm
+   Memcheck:Param
+   write(buf)
+   fun:write
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_close
 }
 
 {
-	DBM problems, see test_dbm
-	Memcheck:Value8
-	fun:memmove
-	obj:/usr/lib/libdb1.so.2
-	obj:/usr/lib/libdb1.so.2
-	obj:/usr/lib/libdb1.so.2
-	obj:/usr/lib/libdb1.so.2
-	fun:dbm_store
-	fun:dbm_ass_sub
+   DBM problems, see test_dbm
+   Memcheck:Value8
+   fun:memmove
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_store
+   fun:dbm_ass_sub
 }
 
 {
-	DBM problems, see test_dbm
-	Memcheck:Cond
-	obj:/usr/lib/libdb1.so.2
-	obj:/usr/lib/libdb1.so.2
-	obj:/usr/lib/libdb1.so.2
-	fun:dbm_store
-	fun:dbm_ass_sub
+   DBM problems, see test_dbm
+   Memcheck:Cond
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_store
+   fun:dbm_ass_sub
 }
 
 {
-	DBM problems, see test_dbm
-	Memcheck:Cond
-	fun:memmove
-	obj:/usr/lib/libdb1.so.2
-	obj:/usr/lib/libdb1.so.2
-	obj:/usr/lib/libdb1.so.2
-	obj:/usr/lib/libdb1.so.2
-	fun:dbm_store
-	fun:dbm_ass_sub
+   DBM problems, see test_dbm
+   Memcheck:Cond
+   fun:memmove
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_store
+   fun:dbm_ass_sub
 }
 
 {
-	GDBM problems, see test_gdbm
-	Memcheck:Param
-	write(buf)
-	fun:write
-	fun:gdbm_open
+   GDBM problems, see test_gdbm
+   Memcheck:Param
+   write(buf)
+   fun:write
+   fun:gdbm_open
 
 }
 
 {
-	ZLIB problems, see test_gzip
-	Memcheck:Cond
-	obj:/lib/libz.so.1.2.3
-	obj:/lib/libz.so.1.2.3
-	fun:deflate
+   Uninitialised byte(s) false alarm, see bpo-35561
+   Memcheck:Param
+   epoll_ctl(event)
+   fun:epoll_ctl
+   fun:pyepoll_internal_ctl
 }
 
 {
-	Avoid problems w/readline doing a putenv and leaking on exit
-	Memcheck:Leak
-	fun:malloc
-	fun:xmalloc
-	fun:sh_set_lines_and_columns
-	fun:_rl_get_screen_size
-	fun:_rl_init_terminal_io
-	obj:/lib/libreadline.so.4.3
-	fun:rl_initialize
+   ZLIB problems, see test_gzip
+   Memcheck:Cond
+   obj:/lib/libz.so.1.2.3
+   obj:/lib/libz.so.1.2.3
+   fun:deflate
 }
+
+{
+   Avoid problems w/readline doing a putenv and leaking on exit
+   Memcheck:Leak
+   fun:malloc
+   fun:xmalloc
+   fun:sh_set_lines_and_columns
+   fun:_rl_get_screen_size
+   fun:_rl_init_terminal_io
+   obj:/lib/libreadline.so.4.3
+   fun:rl_initialize
+}
+
+# Valgrind emits "Conditional jump or move depends on uninitialised value(s)"
+# false alarms on GCC builtin strcmp() function. The GCC code is correct.
+#
+# Valgrind bug: https://bugs.kde.org/show_bug.cgi?id=264936
+{
+   bpo-38118: Valgrind emits false alarm on GCC builtin strcmp()
+   Memcheck:Cond
+   fun:PyUnicode_Decode
+}
+
 
 ###
 ### These occur from somewhere within the SSL, when running
 ###  test_socket_sll.  They are too general to leave on by default.
 ###
 ###{
-###	somewhere in SSL stuff
-###	Memcheck:Cond
-###	fun:memset
+###   somewhere in SSL stuff
+###   Memcheck:Cond
+###   fun:memset
 ###}
 ###{
-###	somewhere in SSL stuff
-###	Memcheck:Value4
-###	fun:memset
+###   somewhere in SSL stuff
+###   Memcheck:Value4
+###   fun:memset
 ###}
 ###
 ###{
-###	somewhere in SSL stuff
-###	Memcheck:Cond
-###	fun:MD5_Update
+###   somewhere in SSL stuff
+###   Memcheck:Cond
+###   fun:MD5_Update
 ###}
 ###
 ###{
-###	somewhere in SSL stuff
-###	Memcheck:Value4
-###	fun:MD5_Update
+###   somewhere in SSL stuff
+###   Memcheck:Value4
+###   fun:MD5_Update
 ###}
+
+# Fedora's package "openssl-1.0.1-0.1.beta2.fc17.x86_64" on x86_64
+# See http://bugs.python.org/issue14171
+{
+   openssl 1.0.1 prng 1
+   Memcheck:Cond
+   fun:bcmp
+   fun:fips_get_entropy
+   fun:FIPS_drbg_instantiate
+   fun:RAND_init_fips
+   fun:OPENSSL_init_library
+   fun:SSL_library_init
+   fun:init_hashlib
+}
+
+{
+   openssl 1.0.1 prng 2
+   Memcheck:Cond
+   fun:fips_get_entropy
+   fun:FIPS_drbg_instantiate
+   fun:RAND_init_fips
+   fun:OPENSSL_init_library
+   fun:SSL_library_init
+   fun:init_hashlib
+}
+
+{
+   openssl 1.0.1 prng 3
+   Memcheck:Value8
+   fun:_x86_64_AES_encrypt_compact
+   fun:AES_encrypt
+}
 
 #
 # All of these problems come from using test_socket_ssl
 #
 {
-	from test_socket_ssl
-	Memcheck:Cond
-	fun:BN_bin2bn
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BN_bin2bn
 }
 
 {
-	from test_socket_ssl
-	Memcheck:Cond
-	fun:BN_num_bits_word
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BN_num_bits_word
 }
 
 {
-	from test_socket_ssl
-	Memcheck:Value4
-	fun:BN_num_bits_word
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:BN_num_bits_word
 }
 
 {
-	from test_socket_ssl
-	Memcheck:Cond
-	fun:BN_mod_exp_mont_word
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BN_mod_exp_mont_word
 }
 
 {
-	from test_socket_ssl
-	Memcheck:Cond
-	fun:BN_mod_exp_mont
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BN_mod_exp_mont
 }
 
 {
-	from test_socket_ssl
-	Memcheck:Param
-	write(buf)
-	fun:write
-	obj:/usr/lib/libcrypto.so.0.9.7
+   from test_socket_ssl
+   Memcheck:Param
+   write(buf)
+   fun:write
+   obj:/usr/lib/libcrypto.so.0.9.7
 }
 
 {
-	from test_socket_ssl
-	Memcheck:Cond
-	fun:RSA_verify
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:RSA_verify
 }
 
 {
-	from test_socket_ssl
-	Memcheck:Value4
-	fun:RSA_verify
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:RSA_verify
 }
 
 {
-	from test_socket_ssl
-	Memcheck:Value4
-	fun:DES_set_key_unchecked
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:DES_set_key_unchecked
 }
 
 {
-	from test_socket_ssl
-	Memcheck:Value4
-	fun:DES_encrypt2
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:DES_encrypt2
 }
 
 {
-	from test_socket_ssl
-	Memcheck:Cond
-	obj:/usr/lib/libssl.so.0.9.7
+   from test_socket_ssl
+   Memcheck:Cond
+   obj:/usr/lib/libssl.so.0.9.7
 }
 
 {
-	from test_socket_ssl
-	Memcheck:Value4
-	obj:/usr/lib/libssl.so.0.9.7
+   from test_socket_ssl
+   Memcheck:Value4
+   obj:/usr/lib/libssl.so.0.9.7
 }
 
 {
-	from test_socket_ssl
-	Memcheck:Cond
-	fun:BUF_MEM_grow_clean
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BUF_MEM_grow_clean
 }
 
 {
-	from test_socket_ssl
-	Memcheck:Cond
-	fun:memcpy
-	fun:ssl3_read_bytes
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:memcpy
+   fun:ssl3_read_bytes
 }
 
 {
-	from test_socket_ssl
-	Memcheck:Cond
-	fun:SHA1_Update
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:SHA1_Update
 }
 
 {
-	from test_socket_ssl
-	Memcheck:Value4
-	fun:SHA1_Update
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:SHA1_Update
 }
+
+{
+   test_buffer_non_debug
+   Memcheck:Addr4
+   fun:PyUnicodeUCS2_FSConverter
+}
+
+{
+   test_buffer_non_debug
+   Memcheck:Addr4
+   fun:PyUnicode_FSConverter
+}
+
+{
+   wcscmp_false_positive
+   Memcheck:Addr8
+   fun:wcscmp
+   fun:_PyOS_GetOpt
+   fun:Py_Main
+   fun:main
+}
+
+# Additional suppressions for the unified decimal tests:
+{
+   test_decimal
+   Memcheck:Addr4
+   fun:PyUnicodeUCS2_FSConverter
+}
+
+{
+   test_decimal2
+   Memcheck:Addr4
+   fun:PyUnicode_FSConverter
+}
+

--- a/source/tests/memcheck/valgrind-python.supp
+++ b/source/tests/memcheck/valgrind-python.supp
@@ -19,27 +19,27 @@
 
 # all tool names: Addrcheck,Memcheck,cachegrind,helgrind,massif
 {
-   ADDRESS_IN_RANGE/Invalid read of size 4
-   Memcheck:Addr4
-   fun:address_in_range
+	ADDRESS_IN_RANGE/Invalid read of size 4
+	Memcheck:Addr4
+	fun:address_in_range
 }
 
 {
-   ADDRESS_IN_RANGE/Invalid read of size 4
-   Memcheck:Value4
-   fun:address_in_range
+	ADDRESS_IN_RANGE/Invalid read of size 4
+	Memcheck:Value4
+	fun:address_in_range
 }
 
 {
-   ADDRESS_IN_RANGE/Invalid read of size 8 (x86_64 aka amd64)
-   Memcheck:Value8
-   fun:address_in_range
+	ADDRESS_IN_RANGE/Invalid read of size 8 (x86_64 aka amd64)
+	Memcheck:Value8
+	fun:address_in_range
 }
 
 {
-   ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
-   Memcheck:Cond
-   fun:address_in_range
+	ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
+	Memcheck:Cond
+	fun:address_in_range
 }
 
 #
@@ -49,52 +49,52 @@
 #
 
 {
-   Suppress leaking the GIL after a fork.
-   Memcheck:Leak
-   fun:malloc
-   fun:PyThread_allocate_lock
-   fun:PyEval_ReInitThreads
+	Suppress leaking the GIL after a fork.
+	Memcheck:Leak
+	fun:malloc
+	fun:PyThread_allocate_lock
+	fun:PyEval_ReInitThreads
 }
 
 {
-   Suppress leaking the autoTLSkey.  This looks like it shouldn't leak though.
-   Memcheck:Leak
-   fun:malloc
-   fun:PyThread_create_key
-   fun:_PyGILState_Init
-   fun:Py_InitializeEx
-   fun:Py_Main
+	Suppress leaking the autoTLSkey.  This looks like it shouldn't leak though.
+	Memcheck:Leak
+	fun:malloc
+	fun:PyThread_create_key
+	fun:_PyGILState_Init
+	fun:Py_InitializeEx
+	fun:Py_Main
 }
 
 {
-   Hmmm, is this a real leak or like the GIL?
-   Memcheck:Leak
-   fun:malloc
-   fun:PyThread_ReInitTLS
+	Hmmm, is this a real leak or like the GIL?
+	Memcheck:Leak
+	fun:malloc
+	fun:PyThread_ReInitTLS
 }
 
 {
-   Handle PyMalloc confusing valgrind (possibly leaked)
-   Memcheck:Leak
-   fun:realloc
-   fun:_PyObject_GC_Resize
-   fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
+	Handle PyMalloc confusing valgrind (possibly leaked)
+	Memcheck:Leak
+	fun:realloc
+	fun:_PyObject_GC_Resize
+	fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
 }
 
 {
-   Handle PyMalloc confusing valgrind (possibly leaked)
-   Memcheck:Leak
-   fun:malloc
-   fun:_PyObject_GC_New
-   fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
+	Handle PyMalloc confusing valgrind (possibly leaked)
+	Memcheck:Leak
+	fun:malloc
+	fun:_PyObject_GC_New
+	fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
 }
 
 {
-   Handle PyMalloc confusing valgrind (possibly leaked)
-   Memcheck:Leak
-   fun:malloc
-   fun:_PyObject_GC_NewVar
-   fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
+	Handle PyMalloc confusing valgrind (possibly leaked)
+	Memcheck:Leak
+	fun:malloc
+	fun:_PyObject_GC_NewVar
+	fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
 }
 
 #
@@ -102,41 +102,41 @@
 #
 
 {
-   dlopen() called without dlclose()
-   Memcheck:Leak
-   fun:malloc
-   fun:malloc
-   fun:strdup
-   fun:_dl_load_cache_lookup
+	dlopen() called without dlclose()
+	Memcheck:Leak
+	fun:malloc
+	fun:malloc
+	fun:strdup
+	fun:_dl_load_cache_lookup
 }
 {
-   dlopen() called without dlclose()
-   Memcheck:Leak
-   fun:malloc
-   fun:malloc
-   fun:strdup
-   fun:_dl_map_object
+	dlopen() called without dlclose()
+	Memcheck:Leak
+	fun:malloc
+	fun:malloc
+	fun:strdup
+	fun:_dl_map_object
 }
 {
-   dlopen() called without dlclose()
-   Memcheck:Leak
-   fun:malloc
-   fun:*
-   fun:_dl_new_object
+	dlopen() called without dlclose()
+	Memcheck:Leak
+	fun:malloc
+	fun:*
+	fun:_dl_new_object
 }
 {
-   dlopen() called without dlclose()
-   Memcheck:Leak
-   fun:calloc
-   fun:*
-   fun:_dl_new_object
+	dlopen() called without dlclose()
+	Memcheck:Leak
+	fun:calloc
+	fun:*
+	fun:_dl_new_object
 }
 {
-   dlopen() called without dlclose()
-   Memcheck:Leak
-   fun:calloc
-   fun:*
-   fun:_dl_check_map_versions
+	dlopen() called without dlclose()
+	Memcheck:Leak
+	fun:calloc
+	fun:*
+	fun:_dl_check_map_versions
 }
 
 
@@ -145,80 +145,80 @@
 #
 
 {
-   Handle pthread issue (possibly leaked)
-   Memcheck:Leak
-   fun:calloc
-   fun:allocate_dtv
-   fun:_dl_allocate_tls_storage
-   fun:_dl_allocate_tls
+	Handle pthread issue (possibly leaked)
+	Memcheck:Leak
+	fun:calloc
+	fun:allocate_dtv
+	fun:_dl_allocate_tls_storage
+	fun:_dl_allocate_tls
 }
 
 {
-   Handle pthread issue (possibly leaked)
-   Memcheck:Leak
-   fun:memalign
-   fun:_dl_allocate_tls_storage
-   fun:_dl_allocate_tls
+	Handle pthread issue (possibly leaked)
+	Memcheck:Leak
+	fun:memalign
+	fun:_dl_allocate_tls_storage
+	fun:_dl_allocate_tls
 }
 
 ###{
-###   ADDRESS_IN_RANGE/Invalid read of size 4
-###   Memcheck:Addr4
-###   fun:_PyObject_Free
+###	ADDRESS_IN_RANGE/Invalid read of size 4
+###	Memcheck:Addr4
+###	fun:_PyObject_Free
 ###}
 ###
 ###{
-###   ADDRESS_IN_RANGE/Invalid read of size 4
-###   Memcheck:Value4
-###   fun:_PyObject_Free
+###	ADDRESS_IN_RANGE/Invalid read of size 4
+###	Memcheck:Value4
+###	fun:_PyObject_Free
 ###}
 ###
 ###{
-###   ADDRESS_IN_RANGE/Use of uninitialised value of size 8
-###   Memcheck:Addr8
-###   fun:_PyObject_Free
+###	ADDRESS_IN_RANGE/Use of uninitialised value of size 8
+###	Memcheck:Addr8
+###	fun:_PyObject_Free
 ###}
 ###
 ###{
-###   ADDRESS_IN_RANGE/Use of uninitialised value of size 8
-###   Memcheck:Value8
-###   fun:_PyObject_Free
+###	ADDRESS_IN_RANGE/Use of uninitialised value of size 8
+###	Memcheck:Value8
+###	fun:_PyObject_Free
 ###}
 ###
 ###{
-###   ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
-###   Memcheck:Cond
-###   fun:_PyObject_Free
+###	ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
+###	Memcheck:Cond
+###	fun:_PyObject_Free
 ###}
 
 ###{
-###   ADDRESS_IN_RANGE/Invalid read of size 4
-###   Memcheck:Addr4
-###   fun:_PyObject_Realloc
+###	ADDRESS_IN_RANGE/Invalid read of size 4
+###	Memcheck:Addr4
+###	fun:_PyObject_Realloc
 ###}
 ###
 ###{
-###   ADDRESS_IN_RANGE/Invalid read of size 4
-###   Memcheck:Value4
-###   fun:_PyObject_Realloc
+###	ADDRESS_IN_RANGE/Invalid read of size 4
+###	Memcheck:Value4
+###	fun:_PyObject_Realloc
 ###}
 ###
 ###{
-###   ADDRESS_IN_RANGE/Use of uninitialised value of size 8
-###   Memcheck:Addr8
-###   fun:_PyObject_Realloc
+###	ADDRESS_IN_RANGE/Use of uninitialised value of size 8
+###	Memcheck:Addr8
+###	fun:_PyObject_Realloc
 ###}
 ###
 ###{
-###   ADDRESS_IN_RANGE/Use of uninitialised value of size 8
-###   Memcheck:Value8
-###   fun:_PyObject_Realloc
+###	ADDRESS_IN_RANGE/Use of uninitialised value of size 8
+###	Memcheck:Value8
+###	fun:_PyObject_Realloc
 ###}
 ###
 ###{
-###   ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
-###   Memcheck:Cond
-###   fun:_PyObject_Realloc
+###	ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
+###	Memcheck:Cond
+###	fun:_PyObject_Realloc
 ###}
 
 ###
@@ -228,104 +228,104 @@
 ###
 
 {
-   Generic ubuntu ld problems
-   Memcheck:Addr8
-   obj:/lib/ld-2.4.so
-   obj:/lib/ld-2.4.so
-   obj:/lib/ld-2.4.so
-   obj:/lib/ld-2.4.so
+	Generic ubuntu ld problems
+	Memcheck:Addr8
+	obj:/lib/ld-2.4.so
+	obj:/lib/ld-2.4.so
+	obj:/lib/ld-2.4.so
+	obj:/lib/ld-2.4.so
 }
 
 {
-   Generic gentoo ld problems
-   Memcheck:Cond
-   obj:/lib/ld-2.3.4.so
-   obj:/lib/ld-2.3.4.so
-   obj:/lib/ld-2.3.4.so
-   obj:/lib/ld-2.3.4.so
+	Generic gentoo ld problems
+	Memcheck:Cond
+	obj:/lib/ld-2.3.4.so
+	obj:/lib/ld-2.3.4.so
+	obj:/lib/ld-2.3.4.so
+	obj:/lib/ld-2.3.4.so
 }
 
 {
-   DBM problems, see test_dbm
-   Memcheck:Param
-   write(buf)
-   fun:write
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   fun:dbm_close
+	DBM problems, see test_dbm
+	Memcheck:Param
+	write(buf)
+	fun:write
+	obj:/usr/lib/libdb1.so.2
+	obj:/usr/lib/libdb1.so.2
+	obj:/usr/lib/libdb1.so.2
+	obj:/usr/lib/libdb1.so.2
+	fun:dbm_close
 }
 
 {
-   DBM problems, see test_dbm
-   Memcheck:Value8
-   fun:memmove
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   fun:dbm_store
-   fun:dbm_ass_sub
+	DBM problems, see test_dbm
+	Memcheck:Value8
+	fun:memmove
+	obj:/usr/lib/libdb1.so.2
+	obj:/usr/lib/libdb1.so.2
+	obj:/usr/lib/libdb1.so.2
+	obj:/usr/lib/libdb1.so.2
+	fun:dbm_store
+	fun:dbm_ass_sub
 }
 
 {
-   DBM problems, see test_dbm
-   Memcheck:Cond
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   fun:dbm_store
-   fun:dbm_ass_sub
+	DBM problems, see test_dbm
+	Memcheck:Cond
+	obj:/usr/lib/libdb1.so.2
+	obj:/usr/lib/libdb1.so.2
+	obj:/usr/lib/libdb1.so.2
+	fun:dbm_store
+	fun:dbm_ass_sub
 }
 
 {
-   DBM problems, see test_dbm
-   Memcheck:Cond
-   fun:memmove
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   fun:dbm_store
-   fun:dbm_ass_sub
+	DBM problems, see test_dbm
+	Memcheck:Cond
+	fun:memmove
+	obj:/usr/lib/libdb1.so.2
+	obj:/usr/lib/libdb1.so.2
+	obj:/usr/lib/libdb1.so.2
+	obj:/usr/lib/libdb1.so.2
+	fun:dbm_store
+	fun:dbm_ass_sub
 }
 
 {
-   GDBM problems, see test_gdbm
-   Memcheck:Param
-   write(buf)
-   fun:write
-   fun:gdbm_open
+	GDBM problems, see test_gdbm
+	Memcheck:Param
+	write(buf)
+	fun:write
+	fun:gdbm_open
 
 }
 
 {
-   Uninitialised byte(s) false alarm, see bpo-35561
-   Memcheck:Param
-   epoll_ctl(event)
-   fun:epoll_ctl
-   fun:pyepoll_internal_ctl
+	Uninitialised byte(s) false alarm, see bpo-35561
+	Memcheck:Param
+	epoll_ctl(event)
+	fun:epoll_ctl
+	fun:pyepoll_internal_ctl
 }
 
 {
-   ZLIB problems, see test_gzip
-   Memcheck:Cond
-   obj:/lib/libz.so.1.2.3
-   obj:/lib/libz.so.1.2.3
-   fun:deflate
+	ZLIB problems, see test_gzip
+	Memcheck:Cond
+	obj:/lib/libz.so.1.2.3
+	obj:/lib/libz.so.1.2.3
+	fun:deflate
 }
 
 {
-   Avoid problems w/readline doing a putenv and leaking on exit
-   Memcheck:Leak
-   fun:malloc
-   fun:xmalloc
-   fun:sh_set_lines_and_columns
-   fun:_rl_get_screen_size
-   fun:_rl_init_terminal_io
-   obj:/lib/libreadline.so.4.3
-   fun:rl_initialize
+	Avoid problems w/readline doing a putenv and leaking on exit
+	Memcheck:Leak
+	fun:malloc
+	fun:xmalloc
+	fun:sh_set_lines_and_columns
+	fun:_rl_get_screen_size
+	fun:_rl_init_terminal_io
+	obj:/lib/libreadline.so.4.3
+	fun:rl_initialize
 }
 
 # Valgrind emits "Conditional jump or move depends on uninitialised value(s)"
@@ -333,9 +333,9 @@
 #
 # Valgrind bug: https://bugs.kde.org/show_bug.cgi?id=264936
 {
-   bpo-38118: Valgrind emits false alarm on GCC builtin strcmp()
-   Memcheck:Cond
-   fun:PyUnicode_Decode
+	bpo-38118: Valgrind emits false alarm on GCC builtin strcmp()
+	Memcheck:Cond
+	fun:PyUnicode_Decode
 }
 
 
@@ -344,193 +344,193 @@
 ###  test_socket_sll.  They are too general to leave on by default.
 ###
 ###{
-###   somewhere in SSL stuff
-###   Memcheck:Cond
-###   fun:memset
+###	somewhere in SSL stuff
+###	Memcheck:Cond
+###	fun:memset
 ###}
 ###{
-###   somewhere in SSL stuff
-###   Memcheck:Value4
-###   fun:memset
-###}
-###
-###{
-###   somewhere in SSL stuff
-###   Memcheck:Cond
-###   fun:MD5_Update
+###	somewhere in SSL stuff
+###	Memcheck:Value4
+###	fun:memset
 ###}
 ###
 ###{
-###   somewhere in SSL stuff
-###   Memcheck:Value4
-###   fun:MD5_Update
+###	somewhere in SSL stuff
+###	Memcheck:Cond
+###	fun:MD5_Update
+###}
+###
+###{
+###	somewhere in SSL stuff
+###	Memcheck:Value4
+###	fun:MD5_Update
 ###}
 
 # Fedora's package "openssl-1.0.1-0.1.beta2.fc17.x86_64" on x86_64
 # See http://bugs.python.org/issue14171
 {
-   openssl 1.0.1 prng 1
-   Memcheck:Cond
-   fun:bcmp
-   fun:fips_get_entropy
-   fun:FIPS_drbg_instantiate
-   fun:RAND_init_fips
-   fun:OPENSSL_init_library
-   fun:SSL_library_init
-   fun:init_hashlib
+	openssl 1.0.1 prng 1
+	Memcheck:Cond
+	fun:bcmp
+	fun:fips_get_entropy
+	fun:FIPS_drbg_instantiate
+	fun:RAND_init_fips
+	fun:OPENSSL_init_library
+	fun:SSL_library_init
+	fun:init_hashlib
 }
 
 {
-   openssl 1.0.1 prng 2
-   Memcheck:Cond
-   fun:fips_get_entropy
-   fun:FIPS_drbg_instantiate
-   fun:RAND_init_fips
-   fun:OPENSSL_init_library
-   fun:SSL_library_init
-   fun:init_hashlib
+	openssl 1.0.1 prng 2
+	Memcheck:Cond
+	fun:fips_get_entropy
+	fun:FIPS_drbg_instantiate
+	fun:RAND_init_fips
+	fun:OPENSSL_init_library
+	fun:SSL_library_init
+	fun:init_hashlib
 }
 
 {
-   openssl 1.0.1 prng 3
-   Memcheck:Value8
-   fun:_x86_64_AES_encrypt_compact
-   fun:AES_encrypt
+	openssl 1.0.1 prng 3
+	Memcheck:Value8
+	fun:_x86_64_AES_encrypt_compact
+	fun:AES_encrypt
 }
 
 #
 # All of these problems come from using test_socket_ssl
 #
 {
-   from test_socket_ssl
-   Memcheck:Cond
-   fun:BN_bin2bn
+	from test_socket_ssl
+	Memcheck:Cond
+	fun:BN_bin2bn
 }
 
 {
-   from test_socket_ssl
-   Memcheck:Cond
-   fun:BN_num_bits_word
+	from test_socket_ssl
+	Memcheck:Cond
+	fun:BN_num_bits_word
 }
 
 {
-   from test_socket_ssl
-   Memcheck:Value4
-   fun:BN_num_bits_word
+	from test_socket_ssl
+	Memcheck:Value4
+	fun:BN_num_bits_word
 }
 
 {
-   from test_socket_ssl
-   Memcheck:Cond
-   fun:BN_mod_exp_mont_word
+	from test_socket_ssl
+	Memcheck:Cond
+	fun:BN_mod_exp_mont_word
 }
 
 {
-   from test_socket_ssl
-   Memcheck:Cond
-   fun:BN_mod_exp_mont
+	from test_socket_ssl
+	Memcheck:Cond
+	fun:BN_mod_exp_mont
 }
 
 {
-   from test_socket_ssl
-   Memcheck:Param
-   write(buf)
-   fun:write
-   obj:/usr/lib/libcrypto.so.0.9.7
+	from test_socket_ssl
+	Memcheck:Param
+	write(buf)
+	fun:write
+	obj:/usr/lib/libcrypto.so.0.9.7
 }
 
 {
-   from test_socket_ssl
-   Memcheck:Cond
-   fun:RSA_verify
+	from test_socket_ssl
+	Memcheck:Cond
+	fun:RSA_verify
 }
 
 {
-   from test_socket_ssl
-   Memcheck:Value4
-   fun:RSA_verify
+	from test_socket_ssl
+	Memcheck:Value4
+	fun:RSA_verify
 }
 
 {
-   from test_socket_ssl
-   Memcheck:Value4
-   fun:DES_set_key_unchecked
+	from test_socket_ssl
+	Memcheck:Value4
+	fun:DES_set_key_unchecked
 }
 
 {
-   from test_socket_ssl
-   Memcheck:Value4
-   fun:DES_encrypt2
+	from test_socket_ssl
+	Memcheck:Value4
+	fun:DES_encrypt2
 }
 
 {
-   from test_socket_ssl
-   Memcheck:Cond
-   obj:/usr/lib/libssl.so.0.9.7
+	from test_socket_ssl
+	Memcheck:Cond
+	obj:/usr/lib/libssl.so.0.9.7
 }
 
 {
-   from test_socket_ssl
-   Memcheck:Value4
-   obj:/usr/lib/libssl.so.0.9.7
+	from test_socket_ssl
+	Memcheck:Value4
+	obj:/usr/lib/libssl.so.0.9.7
 }
 
 {
-   from test_socket_ssl
-   Memcheck:Cond
-   fun:BUF_MEM_grow_clean
+	from test_socket_ssl
+	Memcheck:Cond
+	fun:BUF_MEM_grow_clean
 }
 
 {
-   from test_socket_ssl
-   Memcheck:Cond
-   fun:memcpy
-   fun:ssl3_read_bytes
+	from test_socket_ssl
+	Memcheck:Cond
+	fun:memcpy
+	fun:ssl3_read_bytes
 }
 
 {
-   from test_socket_ssl
-   Memcheck:Cond
-   fun:SHA1_Update
+	from test_socket_ssl
+	Memcheck:Cond
+	fun:SHA1_Update
 }
 
 {
-   from test_socket_ssl
-   Memcheck:Value4
-   fun:SHA1_Update
+	from test_socket_ssl
+	Memcheck:Value4
+	fun:SHA1_Update
 }
 
 {
-   test_buffer_non_debug
-   Memcheck:Addr4
-   fun:PyUnicodeUCS2_FSConverter
+	test_buffer_non_debug
+	Memcheck:Addr4
+	fun:PyUnicodeUCS2_FSConverter
 }
 
 {
-   test_buffer_non_debug
-   Memcheck:Addr4
-   fun:PyUnicode_FSConverter
+	test_buffer_non_debug
+	Memcheck:Addr4
+	fun:PyUnicode_FSConverter
 }
 
 {
-   wcscmp_false_positive
-   Memcheck:Addr8
-   fun:wcscmp
-   fun:_PyOS_GetOpt
-   fun:Py_Main
-   fun:main
+	wcscmp_false_positive
+	Memcheck:Addr8
+	fun:wcscmp
+	fun:_PyOS_GetOpt
+	fun:Py_Main
+	fun:main
 }
 
 # Additional suppressions for the unified decimal tests:
 {
-   test_decimal
-   Memcheck:Addr4
-   fun:PyUnicodeUCS2_FSConverter
+	test_decimal
+	Memcheck:Addr4
+	fun:PyUnicodeUCS2_FSConverter
 }
 
 {
-   test_decimal2
-   Memcheck:Addr4
-   fun:PyUnicode_FSConverter
+	test_decimal2
+	Memcheck:Addr4
+	fun:PyUnicode_FSConverter
 }
 

--- a/tools/instrumentation/valgrind/python/Dockerfile
+++ b/tools/instrumentation/valgrind/python/Dockerfile
@@ -54,5 +54,6 @@ RUN valgrind \
 	--show-reachable=yes \
 	--error-exitcode=1 \
 	--suppressions=/app/memcheck/valgrind-dl.supp \
+    --suppressions=/app/memcheck/valgrind-python.supp \
 	--suppressions=/app/memcheck/valgrind-python-all.supp \
 	python3.13 test.py

--- a/tools/instrumentation/valgrind/python/Dockerfile
+++ b/tools/instrumentation/valgrind/python/Dockerfile
@@ -49,6 +49,7 @@ RUN valgrind \
 	--trace-children=yes \
 	--track-origins=yes \
 	--error-limit=no \
+	--max-stackframe=8368224 \
 	--read-var-info=yes \
 	--show-reachable=yes \
 	--error-exitcode=1 \


### PR DESCRIPTION
- Add --max-stackframe=8368224 to valgrind command in Dockerfile to fix stack switching warning
- Update source/tests/memcheck/valgrind-python.supp from master branch to v3.13.0 tag

Key changes in suppressions:
- Py_ADDRESS_IN_RANGE → address_in_range (renamed in 3.13)
- PyObject_Free/Realloc → _PyObject_Free/_PyObject_Realloc (made private in 3.13)
- GIL suppression updated to match new fork behavior in 3.13
- Added new suppressions for epoll, openssl, readline, decimal tests

Before: stack switching warning present
After: stack warning gone, suppressions pinned to exact Python 3.13.0


The warning was :
==7== Warning: client switching stacks?  SP change: 0x1ffeffd020 --> 0x1ffe8020e0
==7==          to suppress, use: --max-stackframe=8367936 or greater

fix : 
--max-stackframe=8368224