### PR TITLE
resolve `search_paths` relative to config file dir

### DIFF
--- a/source/loader/source/loader_impl.c
+++ b/source/loader/source/loader_impl.c
@@ -400,24 +400,20 @@ int loader_impl_dependencies_load(loader_impl impl, const char *key_str, value *
 		if (value_type_id(paths_array[iterator]) == TYPE_STRING)
 		{
 			/* Resolve the path against the loader config file's directory so
-			 * relative paths like "../lib/python39.dll" in py_loader.json
-			 * resolve correctly regardless of CWD.
+			 * relative paths like "../lib/python39.dll" resolve correctly.
 			 * Reference: https://github.com/metacall/core/issues/760 */
 			char library_path[PORTABILITY_PATH_SIZE];
 
 			configuration_object_child_path(impl->config, paths_array[iterator], library_path);
 
-			if (library_path[0] != '\0')
+			dynlink handle = dynlink_load_absolute(library_path, DYNLINK_FLAGS_BIND_LAZY | DYNLINK_FLAGS_BIND_GLOBAL);
+
+			if (handle != NULL && set_insert(impl->library_map, (const set_key)key_str, (set_value)handle) == 0)
 			{
-				dynlink handle = dynlink_load_absolute(library_path, DYNLINK_FLAGS_BIND_LAZY | DYNLINK_FLAGS_BIND_GLOBAL);
-
-				if (handle != NULL && set_insert(impl->library_map, (const set_key)key_str, (set_value)handle) == 0)
-				{
-					return 0;
-				}
-
-				dynlink_unload(handle);
+				return 0;
 			}
+
+			dynlink_unload(handle);
 		}
 	}
 

--- a/source/loader/source/loader_impl.c
+++ b/source/loader/source/loader_impl.c
@@ -425,7 +425,10 @@ void loader_impl_dependencies_search_paths(loader_impl impl, const loader_tag ta
 	{
 		"search_paths": ["C:\Program Files\ruby\bin\ruby_builtin_dlls"]
 	}
-	*/
+	Relative paths are resolved against the loader configuration file's directory
+	(via configuration_object_child_path) before being registered with the OS,
+	so SetDllDirectoryA always receives an absolute path independent of CWD.
+	Reference: https://github.com/metacall/core/issues/760 */
 	value search_paths_value = configuration_value_type(impl->config, "search_paths", TYPE_ARRAY);
 
 	/* Check if the loader has search paths and initialize them */
@@ -439,11 +442,13 @@ void loader_impl_dependencies_search_paths(loader_impl impl, const loader_tag ta
 		{
 			if (value_type_id(search_paths_array[iterator]) == TYPE_STRING)
 			{
-				const char *key_str = value_to_string(search_paths_array[iterator]);
+				char resolved_path[PORTABILITY_PATH_SIZE];
 
-				if (SetDllDirectoryA(key_str) == FALSE)
+				configuration_object_child_path(impl->config, search_paths_array[iterator], resolved_path);
+
+				if (SetDllDirectoryA(resolved_path) == FALSE)
 				{
-					log_write("metacall", LOG_LEVEL_ERROR, "Failed to register the DLL directory %s in loader '%s'; dependencies with other dependant DLLs may fail to load", key_str, tag);
+					log_write("metacall", LOG_LEVEL_ERROR, "Failed to register the DLL directory %s in loader '%s'; dependencies with other dependant DLLs may fail to load", resolved_path, tag);
 				}
 			}
 		}

--- a/source/loader/source/loader_impl.c
+++ b/source/loader/source/loader_impl.c
@@ -399,9 +399,15 @@ int loader_impl_dependencies_load(loader_impl impl, const char *key_str, value *
 	{
 		if (value_type_id(paths_array[iterator]) == TYPE_STRING)
 		{
-			const char *library_path = value_to_string(paths_array[iterator]);
+			/* Resolve the path against the loader config file's directory so
+			 * relative paths like "../lib/python39.dll" in py_loader.json
+			 * resolve correctly regardless of CWD.
+			 * Reference: https://github.com/metacall/core/issues/760 */
+			char library_path[PORTABILITY_PATH_SIZE];
 
-			if (library_path != NULL)
+			configuration_object_child_path(impl->config, paths_array[iterator], library_path);
+
+			if (library_path[0] != '\0')
 			{
 				dynlink handle = dynlink_load_absolute(library_path, DYNLINK_FLAGS_BIND_LAZY | DYNLINK_FLAGS_BIND_GLOBAL);
 


### PR DESCRIPTION
## Summary

`SetDllDirectoryA` was being called with raw strings from the loader JSON, so relative paths like `"../lib/ruby_builtin_dlls"` in `rb_loader.json` resolved against the process CWD instead of the config file's directory and failed to register.

Route the value through `configuration_object_child_path()` which already implements:
- absolute → use as-is
- relative → join with config dir + canonicalize via `portability_path_canonical`

## Scope

`search_paths` only. `dependencies` paths have the same issue and will be addressed in a follow-up PR (per maintainer discussion).

Refs: #760

## CI Checks 
- python release - windows - https://github.com/ROKUMATE/MetaCall-core/actions/runs/25692290172/job/75431587134
- windows test - https://github.com/ROKUMATE/MetaCall-core/actions/runs/25692280598