### PR TITLE
cs_loader: support stateful class instances

### DIFF
--- a/source/loaders/cs_loader/netcore/CSLoader.Tests/CSLoader.Tests.csproj
+++ b/source/loaders/cs_loader/netcore/CSLoader.Tests/CSLoader.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\source\project.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/source/loaders/cs_loader/netcore/CSLoader.Tests/LoaderTests.cs
+++ b/source/loaders/cs_loader/netcore/CSLoader.Tests/LoaderTests.cs
@@ -1,0 +1,207 @@
+using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
+using CSLoader.Contracts;
+using CSLoader.Providers;
+
+namespace CSLoader.Tests
+{
+	public class LoaderTests
+	{
+		public class DummyStatefulTarget
+		{
+			private int _multiplier = 10;
+
+			public int MultiplyAndAdd(int a, int b)  => (a * b) + _multiplier;
+
+			public void SetMultiplier(int newMultiplier) => _multiplier = newMultiplier;
+		}
+
+		public class CapturingLog : ILog
+		{
+			public List<string> Message { get; } = new List<string>();
+			public void Error(string message) => Message.Add($"ERROR: {message}");
+
+			public void Error(string message, Exception ex) =>
+				Message.Add($"ERROR: {message} - Exception: {ex.Message}");
+			public void Info(string message) => Message.Add($"INFO: {message}");
+			public void Debug(string message) => Message.Add($"DEBUG: {message}");
+		}
+
+		public static class DummyStaticTarget
+		{
+			public static int Multiply(int a, int b) => a * b;
+		}
+
+
+		[Fact]
+		public void FunctionContainer_ShouldStoreTargetInstanceAndCorrectMethodInfo()
+		{
+			var targetInstance = new DummyStatefulTarget();
+			var methodInfo = typeof(DummyStatefulTarget).GetMethod(nameof(DummyStatefulTarget.MultiplyAndAdd));
+
+			var container = new FunctionContainer(methodInfo, targetInstance);
+
+			Assert.NotNull(container.TargetInstance);
+			Assert.Equal("DummyStatefulTarget", container.TargetInstance.GetType().Name);
+			// change later when i change the function name to be more dynamic
+			Assert.EndsWith("MultiplyAndAdd", container.FunctionName);
+			Assert.False(container.Method.IsStatic);
+		}
+
+		[Fact]
+		public void FunctionContainer_Invoke_ShouldPersistStateChanges()
+		{
+			var targetInstance = new DummyStatefulTarget();
+
+			var multiplyMethod = typeof(DummyStatefulTarget).GetMethod(nameof(DummyStatefulTarget.MultiplyAndAdd));
+			var setMethod = typeof(DummyStatefulTarget).GetMethod(nameof(DummyStatefulTarget.SetMultiplier));
+
+			var multiplyContainer = new FunctionContainer(multiplyMethod, targetInstance);
+			var setContainer = new FunctionContainer(setMethod, targetInstance);
+
+			var result1 = multiplyContainer.Method.Invoke(
+				multiplyContainer.TargetInstance, new object[] { 5, 2 });
+
+			Assert.Equal(20, (int)result1); // (5 * 2) + 10
+
+			setContainer.Method.Invoke(
+				setContainer.TargetInstance, new object[] { 100 });
+
+			var result2 = multiplyContainer.Method.Invoke(
+				multiplyContainer.TargetInstance, new object[] { 5, 2 });
+
+			Assert.Equal(110, (int)result2); // (5 * 2) + 100
+		}
+
+		[Fact]
+		public void FunctionContainer_StaticMethod_ShouldHaveNullTargetInstance()
+		{
+			var methodInfo = typeof(DummyStaticTarget).GetMethod(nameof(DummyStaticTarget.Multiply));
+
+			var container = new FunctionContainer(methodInfo, null);
+
+			Assert.Null(container.TargetInstance);
+			Assert.Equal("Multiply", container.FunctionName);
+			Assert.True(container.Method.IsStatic);
+		}
+
+		[Fact]
+		public void FunctionContainer_StaticMethod_ShouldInvokeCorrectly()
+		{
+			var methodInfo = typeof(DummyStaticTarget).GetMethod(nameof(DummyStaticTarget.Multiply));
+			var container = new FunctionContainer(methodInfo, null);
+
+			var result = container.Method.Invoke(null, new object[] { 5, 2 });
+
+			Assert.Equal(10, (int)result);
+		}
+
+		[Fact]
+		public void FunctionContainer_TwoInstances_ShouldHaveIndependentState()
+		{
+			var instance1 = new DummyStatefulTarget();
+			var instance2 = new DummyStatefulTarget();
+
+			var setMethod = typeof(DummyStatefulTarget).GetMethod(nameof(DummyStatefulTarget.SetMultiplier));
+			var multiplyMethod = typeof(DummyStatefulTarget).GetMethod(nameof(DummyStatefulTarget.MultiplyAndAdd));
+
+			var set1 = new FunctionContainer(setMethod, instance1);
+			var set2 = new FunctionContainer(setMethod, instance2);
+			var multiply1 = new FunctionContainer(multiplyMethod, instance1);
+			var multiply2 = new FunctionContainer(multiplyMethod, instance2);
+
+			// changing only instance1's state
+			set1.Method.Invoke(set1.TargetInstance, new object[] { 50 });
+
+			var result1 = multiply1.Method.Invoke(multiply1.TargetInstance, new object[] { 5, 2 });
+			var result2 = multiply2.Method.Invoke(multiply2.TargetInstance, new object[] { 5, 2 });
+
+			Assert.Equal(60, (int)result1); // (5 * 2) + 50
+			Assert.Equal(20, (int)result2); // (5 * 2) + 10 (default state)
+
+		}
+
+		[Fact]
+		public void FunctionContainer_GetReflectFunction_ShouldUseMethodName()
+		{
+			var methodInfo = typeof(DummyStatefulTarget).GetMethod(nameof(DummyStatefulTarget.MultiplyAndAdd));
+			var container = new FunctionContainer(methodInfo, new DummyStatefulTarget());
+
+			var reflectFunction = container.GetReflectFunction();
+
+			Assert.Equal("MultiplyAndAdd", reflectFunction.name);
+			Assert.Equal(2, reflectFunction.paramcount);
+		}
+
+		[Fact]
+		public void LoaderV2EachScriptLoad_ShouldHaveSeperateHandle()
+		{
+			var log = new CapturingLog();
+			var loader = new LoaderV2(log);
+
+
+			string loaded1 = loader.LoadFromSourceFunctions(new[]
+			{
+				"public class ScriptA { public static int ValueA () => 42; }"
+			});
+			string loaded2 = loader.LoadFromSourceFunctions(new []
+			{
+				"public class ScriptB { public int ValueB () => 84; }"
+			});
+
+			Assert.True(loaded1 != null, string.Join("\n", log.Message));
+			Assert.True(loaded1 != null, "ScriptA failed to compile");
+			Assert.True(loaded2 != null, "ScriptB failed to compile");
+
+			var metadata = loader.GetLoadedFunctionsMetadata();
+			Assert.Contains("ValueA", metadata.Keys);
+			Assert.Contains("ValueB", metadata.Keys);
+
+			Assert.Equal(2, loader.LoadContextCount);
+		}
+
+		[Fact]
+		public void LoaderV2_UnloadScript_ShouldRemoveOnlyThatScriptsFunctions()
+		{
+			var log = new LoaderTests.CapturingLog();
+			var loader = new LoaderV2(log);
+
+			string handle1 = loader.LoadFromSourceFunctionsWithHandle(new[]
+			{
+				"public class ScriptA { public static int ValueA() => 20; }"
+			});
+
+			string handle2 = loader.LoadFromSourceFunctionsWithHandle(new[]
+			{
+				"public class ScriptB { public static int ValueB() => 40; }"
+			});
+
+			var before = loader.GetLoadedFunctionsMetadata();
+			Assert.True(before.ContainsKey("ValueA"), "ValueA should be loaded before unloading ScriptA" + string.Join("\n", log.Message));
+			Assert.True(before.ContainsKey("ValueB"), "ValueB should be loaded before unloading ScriptA" + string.Join("\n", log.Message));
+
+			//Unload only ScriptA
+			loader.UnloadScript(handle1);
+
+			var metadata = loader.GetLoadedFunctionsMetadata();
+			Assert.DoesNotContain("ValueA", metadata.Keys);
+			Assert.Contains("ValueB", metadata.Keys);
+		}
+
+		[Fact]
+		public void LoaderV2_ALCShouldFullyUnload_AfterUnloadScript()
+		{
+			var log = new LoaderTests.CapturingLog();
+			var loader = new LoaderV2(log);
+
+			string handle = loader.LoadFromSourceFunctionsWithHandle(new[]
+			{
+				"public class Temp { public static int X() => 20; }"
+			});
+
+			loader.UnloadScript(handle);
+
+			Assert.Equal(0, loader.LoadContextCount);
+		}
+	}
+}

--- a/source/loaders/cs_loader/netcore/source/Contracts/ILoader.cs
+++ b/source/loaders/cs_loader/netcore/source/Contracts/ILoader.cs
@@ -17,9 +17,9 @@ namespace CSLoader.Contracts
     {
         ReflectFunction[] Functions();
 
-        bool LoadFromSourceFunctions(string[] source);
-        void LoadFunctions(Assembly assembly);
-        bool LoadFromAssembly(string assemblyFile);
+        string LoadFromSourceFunctions(string[] source);
+        void LoadFunctions(Assembly assembly, string scriptHandle);
+        string LoadFromAssembly(string assemblyFile);
 
         unsafe ExecutionResult* Execute(string function, Parameters[] parameters);
         unsafe ExecutionResult* Execute(string function);

--- a/source/loaders/cs_loader/netcore/source/FunctionContainer.cs
+++ b/source/loaders/cs_loader/netcore/source/FunctionContainer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -10,22 +10,26 @@ namespace CSLoader
 {
     public class FunctionContainer
     {
-        public FunctionContainer(MethodInfo info)
+        public FunctionContainer(MethodInfo info, object targetInstance, string scriptHandle = null, string overrideName = null )
         {
-            this.FunctionName = info.Name;
-            this.RetunType = info.ReturnType;
+            //this.FunctionName = $"{info.DeclaringType.FullName}.{info.Name}";
+			//change it back later
+			this.FunctionName = overrideName ?? info.Name;
+			this.ReturnType = info.ReturnType;
             this.Parameters = info.GetParameters();
             this.Assembly = info.Module.Assembly;
             this.Class = info.DeclaringType.FullName;
+            this.Method = info;
+            this.TargetInstance = targetInstance;
+            this.ScriptHandle = scriptHandle;
 
-            this.Method = this.Assembly.GetType(this.Class).GetTypeInfo().GetMethod(this.FunctionName);
         }
 
         public string FunctionName { get; set; }
 
         public string Class { get; set; }
 
-        public Type RetunType { get; set; }
+        public Type ReturnType { get; set; }
 
         public ParameterInfo[] Parameters { get; set; }
 
@@ -33,12 +37,16 @@ namespace CSLoader
 
         public MethodInfo Method { get; set; }
 
+        public object TargetInstance { get; set; }
+
+        public string ScriptHandle { get; set; }
+
         public ReflectFunction GetReflectFunction()
         {
             ReflectFunction r = new ReflectFunction();
 
             r.name = this.FunctionName;
-            r.returnType = MetacallDef.Get(this.RetunType);
+            r.returnType = MetacallDef.Get(this.ReturnType);
             r.paramcount = this.Parameters.Length;
             r.pars = new ReflectParam[10];
 

--- a/source/loaders/cs_loader/netcore/source/MetacallEntryPoint.cs
+++ b/source/loaders/cs_loader/netcore/source/MetacallEntryPoint.cs
@@ -38,7 +38,7 @@ namespace CSLoader
         public unsafe static bool LoadFromPointer(string[] source)
         {
             try {
-                return loader.LoadFromSourceFunctions(source);
+                return loader.LoadFromSourceFunctions(source) != null;
             } catch (Exception ex) {
                 // TODO: Implement error handling
                 log.Error(ex.Message, ex);
@@ -60,7 +60,7 @@ namespace CSLoader
         {
             try
             {
-                return loader.LoadFromSourceFunctions(new string[] { source });
+                return loader.LoadFromSourceFunctions(new string[] { source }) != null;
             }
             catch (Exception ex)
             {
@@ -169,7 +169,7 @@ namespace CSLoader
 
         public static bool LoadFromAssembly(string assemblyFile)
         {
-            return loader.LoadFromAssembly(assemblyFile);
+            return loader.LoadFromAssembly(assemblyFile) != null;
         }
 
         public static bool LoadFromAssemblyC([System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPWStr)] string assemblyFile)

--- a/source/loaders/cs_loader/netcore/source/Providers/LoaderBase.cs
+++ b/source/loaders/cs_loader/netcore/source/Providers/LoaderBase.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis;
 using System.IO;
+using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis.Emit;
 using static CSLoader.MetacallDef;
 using CSLoader.Contracts;
@@ -35,7 +36,8 @@ namespace CSLoader.Providers
     {
         protected readonly ILog log;
         protected readonly List<string> paths = new List<string>();
-        protected LoaderBase(ILog log)
+
+protected LoaderBase(ILog log)
         {
             this.log = log;
         }
@@ -69,7 +71,7 @@ namespace CSLoader.Providers
             return Array.Empty<string>();
         }
 
-        protected abstract Assembly MakeAssembly(MemoryStream stream);
+        protected abstract Assembly MakeAssembly(MemoryStream stream, string scriptHandle);
 
         private static bool IsFullPath(string path)
         {
@@ -127,7 +129,7 @@ namespace CSLoader.Providers
                 return false;
             }
 
-            return LoadFromSourceFunctions(sources.ToArray());
+            return LoadFromSourceFunctions(sources.ToArray()) != null ;
         }
 
         private int PrintDiagnostics(ImmutableArray<Diagnostic> diagnostics)
@@ -150,7 +152,14 @@ namespace CSLoader.Providers
             return errorCount;
         }
 
-        public bool LoadFromSourceFunctions(string[] source)
+		// existing contract
+        public string LoadFromSourceFunctions(string[] source)
+        {
+			string scriptHandle = Guid.NewGuid().ToString();
+			bool success =  LoadFromSourceFunctions(source, scriptHandle);
+			return success ? scriptHandle : null;
+		}
+        public bool LoadFromSourceFunctions(string[] source, string scriptHandle)
         {
             Assembly assembly = null;
 
@@ -158,14 +167,32 @@ namespace CSLoader.Providers
 
             SyntaxTree[] syntaxTrees = source.Select(x => CSharpSyntaxTree.ParseText(x, parseOptions)).ToArray();
 
-            string assemblyName = Path.GetRandomFileName();
+			bool hasTopLevelStatements = syntaxTrees.Any(tree => tree.GetRoot().DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.GlobalStatementSyntax>().Any());
+
+			var outputKind = hasTopLevelStatements ? OutputKind.ConsoleApplication : OutputKind.DynamicallyLinkedLibrary;
+
+			string assemblyName = Path.GetRandomFileName();
 
             MetadataReference[] references;
 
             var mainPath = Path.GetDirectoryName(typeof(object).GetTypeInfo().Assembly.Location) + Path.DirectorySeparatorChar;
             var assemblyFiles = System.IO.Directory.GetFiles(mainPath, "*.dll");
+			// filter to managed assemblies only
+			// This is necessary to avoid loading native assemblies which would cause MetadataReference.CreateFromFile to throw an exception
+			assemblyFiles = assemblyFiles.Where(x =>
+			{
+				try
+				{
+					System.Reflection.AssemblyName.GetAssemblyName(x);
+					return true;
+				}
+				catch
+				{
+					return false;
+				}
+			}).ToArray();
 
-            assemblyFiles = assemblyFiles.Concat(this.AdditionalLibs()).Distinct().ToArray();
+			assemblyFiles = assemblyFiles.Concat(this.AdditionalLibs()).Distinct().ToArray();
 
             // Console exists in both System.Console and System.Private.CoreLib in NetCore 1.x
             // So it must be removed in order to avoid name collision
@@ -173,14 +200,26 @@ namespace CSLoader.Providers
                 assemblyFiles = assemblyFiles.Where(asm => !asm.Contains("System.Console")).ToArray();
             #endif
 
-            references = assemblyFiles.Select(x => MetadataReference.CreateFromFile(x)).ToArray();
+            references = assemblyFiles.Select(x =>
+            {
+	            try
+	            {
+					return (MetadataReference)MetadataReference.CreateFromFile(x);
+	            }
+	            catch
+	            {
+		            return null;
+	            }
+            })
+	            .Where(r => r != null)
+	            .ToArray();
 
             CSharpCompilation compilation = CSharpCompilation.Create(
                 assemblyName,
                 syntaxTrees: syntaxTrees,
                 references: references,
                 options: new CSharpCompilationOptions(
-                    OutputKind.DynamicallyLinkedLibrary,
+                    outputKind,
                     #if DEBUG
                     optimizationLevel: OptimizationLevel.Debug,
                     #else
@@ -216,9 +255,9 @@ namespace CSLoader.Providers
                 {
                     ms.Seek(0, SeekOrigin.Begin);
 
-                    assembly = this.MakeAssembly(ms);
+                    assembly = this.MakeAssembly(ms, scriptHandle);
 
-                    this.LoadFunctions(assembly);
+                    this.LoadFunctions(assembly, scriptHandle);
 
                     ms.Dispose();
 
@@ -227,28 +266,96 @@ namespace CSLoader.Providers
             }
         }
 
-        public void LoadFunctions(Assembly assembly)
+        public void LoadFunctions(Assembly assembly, string scriptHandle)
         {
-            foreach (var item in assembly.DefinedTypes.SelectMany(x => x.GetMethods()).Where(x => x.IsStatic))
-            {
-                var con = new FunctionContainer(item);
+			this.log.Info(" >>> NEW C# LOADER IS ACTUALLY RUNNING! <<<");
+			try
+			{
+				Type[] types = assembly.GetTypes();
+				this.log.Info($"[CSLoader] Found {types.Length} types in assembly {assembly.FullName}");
+				foreach (Type type in types)
+				{
+					this.log.Info($"[CSLoader] Inspecting Type: {type.Name}");
 
-                this.log.Info("CSLoader loading function: " + item.Name);
+					// Handle top-level function class
+					bool isTopLevelClass = (type.Name == "<Program>$" || type.Name == "Program") && type.GetMethod("<Main>$", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.DeclaredOnly) != null;
 
-                if (!this.functions.ContainsKey(item.Name))
-                {
-                    this.functions.Add(item.Name, con);
-                }
-                else
-                {
-                    this.functions[item.Name] = con;
-                }
-            }
+
+					if (isTopLevelClass)
+					{
+						const string prefix = "<<Main>$>g__";
+						var allMethods =
+							type.GetMethods(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+						foreach (var m in allMethods)
+						{
+							if (m.Name.StartsWith(prefix))
+							{
+								int pipe = m.Name.IndexOf('|');
+								if (pipe > 0)
+								{
+									string funcName = m.Name.Substring(prefix.Length, pipe - prefix.Length);
+									this.functions[funcName] = new FunctionContainer(m, null, scriptHandle, funcName);
+									this.log.Info($"[CSLoader] Loading top-level function: {funcName}");
+								}
+							}
+						}
+						continue;
+					}
+
+					if (type.Name.StartsWith("<") && type.Name != "<Program>$") continue;
+
+					bool isStaticClass = type.IsAbstract && type.IsSealed;
+
+					if (type.IsClass && (!type.IsAbstract || isStaticClass))
+					{
+						object classInstance = null;
+						if (!isStaticClass)
+						{
+							try
+							{
+								classInstance = Activator.CreateInstance(type);
+								this.log.Info($"[CSLoader] Instantiated: {type.Name}");
+							}
+							catch (Exception ex)
+							{
+								this.log.Info($"[CSLoader] Could not instantiate '{type.Name}': {ex.Message}");
+							}
+						}
+						
+						var methods = type.GetMethods((BindingFlags.Public | BindingFlags.Instance |
+						                               BindingFlags.Static | BindingFlags.DeclaredOnly));
+						this.log.Info($"[CSLoader] Found {methods.Length} methods in {type.Name}");
+
+						foreach (MethodInfo method in methods)
+						{
+							if (method.DeclaringType == typeof(object)) continue;
+
+							//string exportedName = $"{type.Name}.{method.Name}";
+							// Change it back later
+							string exportedName = method.Name;
+							object target = method.IsStatic ? null : classInstance;
+
+
+							var con = new FunctionContainer(method, target, scriptHandle);
+
+							this.log.Info($"[CSLoader] Loading function: {exportedName} | Static: {method.IsStatic}");
+
+							
+							this.functions[exportedName] = con;
+						}
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				this.log.Info($"[SCREAMING DEBUG] FATAL CRASH IN C#: {ex.Message}");
+			}
+			
 
             GC.Collect();
         }
 
-        public bool LoadFromAssembly(string assemblyFile)
+        public string LoadFromAssembly(string assemblyFile)
         {
             Assembly asm = null;
 
@@ -259,9 +366,10 @@ namespace CSLoader.Providers
                 paths.Add(path);
             }
 
+
             try
             {
-                asm = this.LoadFile(assemblyFile);
+                asm = this.LoadFile(assemblyFile, assemblyFile);
             }
             catch (Exception ex)
             {
@@ -269,22 +377,22 @@ namespace CSLoader.Providers
 
                 try
                 {
-                    asm = this.Load(new AssemblyName(System.IO.Path.GetFileNameWithoutExtension(assemblyFile)));
+                    asm = this.Load(new AssemblyName(System.IO.Path.GetFileNameWithoutExtension(assemblyFile)), assemblyFile);
                 }
                 catch (Exception exName)
                 {
                     this.log.Error(exName.Message, exName);
-                    return false;
+                    return null;
                 }
             }
 
             if (asm != null)
             {
-                this.LoadFunctions(asm);
-                return true;
+                this.LoadFunctions(asm, assemblyFile);
+				return assemblyFile;
             }
 
-            return false;
+			return null;
         }
 
         public unsafe ExecutionResult* Execute(string function, Parameters[] parameters)
@@ -298,15 +406,15 @@ namespace CSLoader.Providers
                 objs[i] = MetacallDef.GetValue(parameters[i].type, parameters[i].ptr);
             }
 
-            var result = con.Method.Invoke(null, objs.Take(con.Parameters.Length).ToArray());
+            var result = con.Method.Invoke(con.TargetInstance, objs.Take(con.Parameters.Length).ToArray());
 
             if (result == null)
             {
-                return CreateExecutionResult(false, MetacallDef.Get(con.RetunType));
+                return CreateExecutionResult(false, MetacallDef.Get(con.ReturnType));
             }
             else
             {
-                return CreateExecutionResult(false, MetacallDef.Get(con.RetunType), result);
+                return CreateExecutionResult(false, MetacallDef.Get(con.ReturnType), result);
             }
         }
 
@@ -315,15 +423,15 @@ namespace CSLoader.Providers
             var con = this.functions[function];
             try
             {
-                var result = con.Method.Invoke(null, null);
+                var result = con.Method.Invoke(con.TargetInstance, null);
 
                 if (result == null)
                 {
-                    return CreateExecutionResult(false, MetacallDef.Get(con.RetunType));
+                    return CreateExecutionResult(false, MetacallDef.Get(con.ReturnType));
                 }
                 else
                 {
-                    return CreateExecutionResult(false, MetacallDef.Get(con.RetunType), result);
+                    return CreateExecutionResult(false, MetacallDef.Get(con.ReturnType), result);
                 }
             }
             catch (Exception ex)
@@ -354,7 +462,7 @@ namespace CSLoader.Providers
         }
 
         public abstract void Unload();
-        protected abstract Assembly Load(AssemblyName assemblyName);
-        protected abstract Assembly LoadFile(string assemblyFile);
+        protected abstract Assembly Load(AssemblyName assemblyName, string scriptHandle);
+        protected abstract Assembly LoadFile(string assemblyFile, string scriptHandle);
     }
 }

--- a/source/loaders/cs_loader/netcore/source/Providers/LoaderV2.cs
+++ b/source/loaders/cs_loader/netcore/source/Providers/LoaderV2.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.IO;
+using System.Runtime.CompilerServices;
 using CSLoader.Contracts;
 
 namespace CSLoader.Providers
@@ -16,7 +17,7 @@ namespace CSLoader.Providers
             AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(AssemblyResolveEventHandler);
             AppDomain.CurrentDomain.TypeResolve += new ResolveEventHandler(AssemblyResolveEventHandler);
 
-            loadContext = new CollectibleAssemblyLoadContext();
+            loadContext = new Dictionary<string, CollectibleAssemblyLoadContext>();
         }
 
         private Assembly AssemblyResolveEventHandler(object sender, ResolveEventArgs args)
@@ -72,68 +73,128 @@ namespace CSLoader.Providers
             return System.IO.Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "*.dll");
         }
 
-        protected override Assembly MakeAssembly(MemoryStream stream)
+        protected override Assembly MakeAssembly(MemoryStream stream, string scriptHandle)
         {
-            return loadContext.LoadFromStream(stream);
+	        var alc = new CollectibleAssemblyLoadContext();
+			loadContext[scriptHandle] = alc;
+            return alc.LoadFromStream(stream);
         }
 
-        protected override Assembly Load(AssemblyName assemblyName)
+        protected override Assembly Load(AssemblyName assemblyName, string scriptHandle)
         {
-            // First check default context to resolve references
-            Assembly asm = null;
-
-            try
+            // Use alc for the current handle if it exits
+			if (loadContext.TryGetValue(scriptHandle, out var alc))
             {
-                asm = loadContext.LoadFromAssemblyName(assemblyName);
+                try
+                {
+                    return alc.LoadFromAssemblyName(assemblyName);
+                }
+                catch
+                {
+                    // Fall through to default load
+                }
             }
-            catch
-            {
-                // Fallback to default load
-                asm = Assembly.Load(assemblyName);
-            }
-
-            return asm;
+			// fallback to default
+            return Assembly.Load(assemblyName);
         }
 
-        protected override Assembly LoadFile(string assemblyFile)
+        protected override Assembly LoadFile(string assemblyFile, string scriptHandle)
         {
+	        var alc = new CollectibleAssemblyLoadContext();
+	        loadContext[scriptHandle] = alc;
             using (var fs = new FileStream(assemblyFile, FileMode.Open, FileAccess.Read))
             {
-                return loadContext.LoadFromStream(fs);
+                return alc.LoadFromStream(fs);
             }
         }
+
+        public Dictionary<string, int> GetLoadedFunctionsMetadata()
+        {
+	        var metadata = new Dictionary<string, int>();
+
+	        foreach (var kvp in this.functions)
+	        {
+		        string functionName = kvp.Key;
+		        int parameterCount = kvp.Value.Parameters.Length;
+
+				metadata.Add(functionName, parameterCount);
+	        }
+
+	        return metadata;
+        }
+
+        // get the count of loaded context for testing
+        public int LoadContextCount => loadContext.Count;
+
+		// returns a handle so test can ref it
+        public string LoadFromSourceFunctionsWithHandle(string[] source)
+        {
+			string handle = Guid.NewGuid().ToString();
+			LoadFromSourceFunctions(source, handle);
+			return handle;
+        }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void UnloadContext(string scriptHandle)
+        {
+			// Remove all functions in this script
+	        var toRemove = new List<string>();
+
+	        foreach (var kvp in functions)
+	        {
+				if (kvp.Value.ScriptHandle == scriptHandle) toRemove.Add(kvp.Key);
+	        }
+	        foreach (var key in toRemove)
+	        {
+		        functions.Remove(key);
+	        }
+
+	        if (loadContext.TryGetValue(scriptHandle, out var alc))
+	        {
+				alc.Unload();
+				loadContext.Remove(scriptHandle);
+	        }
+        }
+
+        public void UnloadScript(string scriptHandle)
+        {
+			if (!loadContext.ContainsKey(scriptHandle)) return;
+
+			var weakRef = new WeakReference(loadContext[scriptHandle], true);
+
+			// JIT will fully exit before the GC loop
+			UnloadContext(scriptHandle);
+
+			for (int i = 0; weakRef.IsAlive && i < 20; i++)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+				GC.Collect();
+			}
+
+			if (weakRef.IsAlive)
+			{
+				log.Error($"AssemblyLoadContext for script {scriptHandle} did not unload.");
+			}
+			else
+			{
+				log.Info($"AssemblyLoadContext for script {scriptHandle} unloaded successfully.");
+			}
+		}
 
         public override void Unload()
         {
-            if (loadContext != null)
-            {
-                contextWeakRef = new WeakReference(loadContext);
-                loadContext.Unload();
-                loadContext = null;
+			// finally unload all scripts
+			var handles = new List<string>(loadContext.Keys);
+			foreach (var handle in handles)
+			{
+				UnloadScript(handle);
+			}
 
-                // Clear strong references to allow unload
-                functions.Clear();
+			AppDomain.CurrentDomain.AssemblyResolve -= AssemblyResolveEventHandler;
+			AppDomain.CurrentDomain.TypeResolve -= AssemblyResolveEventHandler;
+		}
 
-                for (int i = 0; contextWeakRef.IsAlive && i < 10; i++)
-                {
-                    GC.Collect();
-                    GC.WaitForPendingFinalizers();
-                    GC.Collect();
-                }
-
-                if (contextWeakRef.IsAlive)
-                {
-                    // TODO: Review this?
-                    log.Error("AssemblyLoadContext did not unload.");
-                }
-                else
-                {
-                    log.Info("AssemblyLoadContext unloaded successfully.");
-                }
-            }
-        }
-
-        private CollectibleAssemblyLoadContext loadContext;
+        private readonly Dictionary<string, CollectibleAssemblyLoadContext> loadContext = new Dictionary<string, CollectibleAssemblyLoadContext>();
         private WeakReference contextWeakRef;
     }
 }

--- a/source/scripts/csharp/hello/source/hello.cs
+++ b/source/scripts/csharp/hello/source/hello.cs
@@ -1,27 +1,6 @@
 using System;
 
-namespace Scripts
-{
-	public class Program
-	{
-		public static void SayHello()
-		{
-			Console.WriteLine("HELLO");
-		}
-
-		public static void Say(string text)
-		{
-			 Console.WriteLine(text);
-		}
-		
-		public static int Sum(int a, int b)
-		{
-			return a + b;
-		}
-		
-		public static string Concat(string a, string b)
-		{
-			return a + b;
-		}
-	}
-}
+void SayHello() => Console.WriteLine("HELLO");
+void Say(string text) => Console.WriteLine(text);
+int Sum(int a, int b) => a + b;
+string Concat(string a, string b) => a + b;

--- a/source/scripts/csharp/static/source/static.cs
+++ b/source/scripts/csharp/static/source/static.cs
@@ -1,10 +1,4 @@
 using System;
 
-namespace Static
-{
-	public static class Something
-	{
-		public static void Said(string message) => Console.WriteLine(message);
-		public static int Three() => 3;
-	}
-}
+void Said(string message) => Console.WriteLine(message);
+int Three() => 3;


### PR DESCRIPTION
# Description

This PR completely modifies the C# loader's reflection logic to support instantiating and persisting non-static (stateful) classes from the host language

## Type of change

- [ ] Updated FunctionContainer.cs to hold TargetInstance state.
- [ ] Modified LoaderBase.cs to dynamically instantiate classes before registering their methods
- [ ] Fixed the static method bug where pure static classes were being ignored
- [ ] Added fallback for classes without parameterless constructors
- [ ] Added a dedicated xUnit test to validate reflection logic and state persistence across the bridge.

Note: This also lays the groundwork to issue #123. the logic is now modular enough that we can begin wrapping ProcessType inside CollectibleAssemblyLoadContext for proper unloading.

@viferga the loader can now list functions in a file and passing the tests.
