### PR TITLE
pin @rspack/core to 1.7.8 in node napi test

### DIFF
--- a/source/tests/metacall_node_napi_test/cmake/run_test.cmake
+++ b/source/tests/metacall_node_napi_test/cmake/run_test.cmake
@@ -17,10 +17,10 @@ endif()
 set(rspack_package "${TEST_DIR}/node_modules/@rspack/core/package.json")
 
 if(NOT EXISTS "${rspack_package}")
-	message(STATUS "Installing @rspack/core into ${TEST_DIR}")
+	message(STATUS "Installing @rspack/core@1.7.8 into ${TEST_DIR}")
 
 	execute_process(
-		COMMAND "${NPM_EXECUTABLE}" --prefix "${TEST_DIR}" install @rspack/core
+		COMMAND "${NPM_EXECUTABLE}" --prefix "${TEST_DIR}" install @rspack/core@1.7.8
 		WORKING_DIRECTORY "${TEST_DIR}"
 		RESULT_VARIABLE npm_result
 		OUTPUT_VARIABLE npm_output


### PR DESCRIPTION
The Windows NAPI test was installing @rspack/core unpinned, so newer
rspack releases regressed it in CI. Pin to 1.7.8 — latest stable on the
date the test landed (820f2704, 2026-03-12) — so it stays reproducible.

## Tests
- Windows CI on fork: https://github.com/ROKUMATE/MetaCall-core/actions/runs/26561106472
- `metacall-node-napi-test` passes
