### PR TITLE
Migrate value-returning error sites to metacall_error_throw

### DIFF
--- a/source/loaders/rb_loader/source/rb_loader_impl.c
+++ b/source/loaders/rb_loader/source/rb_loader_impl.c
@@ -13,6 +13,8 @@
 #include <loader/loader.h>
 #include <loader/loader_impl.h>
 
+#include <metacall/metacall_error.h>
+
 #include <portability/portability_path.h>
 
 #include <reflect/reflect_context.h>
@@ -593,11 +595,9 @@ value rb_object_interface_get(object obj, object_impl impl, struct accessor_type
 
 	if (exception != Qnil)
 	{
-		log_write("metacall", LOG_LEVEL_ERROR, "Error getting object '%s' member '%s'", object_name(obj), key);
-
 		rb_set_errinfo(Qnil);
 
-		return NULL;
+		return metacall_error_throw("rb_loader", -1, NULL, "Error getting object '%s' member '%s'", object_name(obj), key);
 	}
 
 	value result = NULL;
@@ -772,11 +772,9 @@ value rb_class_interface_static_get(klass cls, class_impl impl, struct accessor_
 
 	if (exception != Qnil)
 	{
-		log_write("metacall", LOG_LEVEL_ERROR, "Error getting class '%s' member '%s'", class_name(cls), attr_name);
-
 		rb_set_errinfo(Qnil);
 
-		return NULL;
+		return metacall_error_throw("rb_loader", -1, NULL, "Error getting class '%s' member '%s'", class_name(cls), attr_name);
 	}
 
 	value result = NULL;

--- a/source/metacall/source/metacall.c
+++ b/source/metacall/source/metacall.c
@@ -563,9 +563,7 @@ void *metacallhv(void *handle, const char *name, void *args[])
 {
 	if (loader_impl_handle_validate(handle) != 0)
 	{
-		// TODO: Implement type error return a value
-		log_write("metacall", LOG_LEVEL_ERROR, "Handle %p passed to metacallhv is not valid", handle);
-		return NULL;
+		return metacall_error_throw("metacall", -1, NULL, "Handle %p passed to metacallhv is not valid", handle);
 	}
 
 	value f_val = loader_handle_get(handle, name);
@@ -583,9 +581,7 @@ void *metacallhv_s(void *handle, const char *name, void *args[], size_t size)
 {
 	if (loader_impl_handle_validate(handle) != 0)
 	{
-		// TODO: Implement type error return a value
-		log_write("metacall", LOG_LEVEL_ERROR, "Handle %p passed to metacallhv_s is not valid", handle);
-		return NULL;
+		return metacall_error_throw("metacall", -1, NULL, "Handle %p passed to metacallhv_s is not valid", handle);
 	}
 
 	value f_val = loader_handle_get(handle, name);
@@ -908,9 +904,7 @@ void *metacallht_s(void *handle, const char *name, const enum metacall_value_id 
 {
 	if (loader_impl_handle_validate(handle) != 0)
 	{
-		// TODO: Implement type error return a value
-		log_write("metacall", LOG_LEVEL_ERROR, "Handle %p passed to metacallht_s is not valid", handle);
-		return NULL;
+		return metacall_error_throw("metacall", -1, NULL, "Handle %p passed to metacallht_s is not valid", handle);
 	}
 
 	value f_val = loader_handle_get(handle, name);
@@ -1047,9 +1041,7 @@ void *metacall_handle_function(void *handle, const char *name)
 {
 	if (loader_impl_handle_validate(handle) != 0)
 	{
-		// TODO: Implement type error return a value
-		log_write("metacall", LOG_LEVEL_ERROR, "Handle %p passed to metacall_handle_function is not valid", handle);
-		return NULL;
+		return metacall_error_throw("metacall", -1, NULL, "Handle %p passed to metacall_handle_function is not valid", handle);
 	}
 
 	value f_val = loader_handle_get(handle, name);
@@ -1147,9 +1139,7 @@ void *metacall_handle_export(void *handle)
 {
 	if (loader_impl_handle_validate(handle) != 0)
 	{
-		// TODO: Implement type error return a value
-		log_write("metacall", LOG_LEVEL_ERROR, "Handle %p passed to metacall_handle_export is not valid", handle);
-		return NULL;
+		return metacall_error_throw("metacall", -1, NULL, "Handle %p passed to metacall_handle_export is not valid", handle);
 	}
 
 	return loader_handle_export(handle);

--- a/source/metacall/source/metacall.c
+++ b/source/metacall/source/metacall.c
@@ -1175,9 +1175,7 @@ void *metacallfv_s(void *func, void *args[], size_t size)
 		{
 			if (value_validate(args[iterator]) != 0)
 			{
-				// TODO: Implement type error return a value
-				log_write("metacall", LOG_LEVEL_ERROR, "Invalid argument at position %" PRIuS " when calling to metacallfv_s", iterator);
-				return NULL;
+				return metacall_error_throw("metacall", -1, NULL, "Invalid argument at position %" PRIuS " when calling to metacallfv_s", iterator);
 			}
 
 			type t = signature_get_type(s, iterator);
@@ -1428,16 +1426,12 @@ void *metacallfmv(void *func, void *keys[], void *values[])
 		{
 			if (value_validate(keys[iterator]) != 0)
 			{
-				// TODO: Implement type error return a value
-				log_write("metacall", LOG_LEVEL_ERROR, "Invalid key at position %" PRIuS " when calling to metacallfmv", iterator);
-				return NULL;
+				return metacall_error_throw("metacall", -1, NULL, "Invalid key at position %" PRIuS " when calling to metacallfmv", iterator);
 			}
 
 			if (value_validate(values[iterator]) != 0)
 			{
-				// TODO: Implement type error return a value
-				log_write("metacall", LOG_LEVEL_ERROR, "Invalid value at position %" PRIuS " when calling to metacallfmv", iterator);
-				return NULL;
+				return metacall_error_throw("metacall", -1, NULL, "Invalid value at position %" PRIuS " when calling to metacallfmv", iterator);
 			}
 
 			type_id key_id = value_type_id((value)keys[iterator]);
@@ -1771,16 +1765,12 @@ void *metacallfmv_await_s(void *func, void *keys[], void *values[], size_t size,
 		{
 			if (value_validate(keys[iterator]) != 0)
 			{
-				// TODO: Implement type error return a value
-				log_write("metacall", LOG_LEVEL_ERROR, "Invalid key at position %" PRIuS " when calling to metacallfmv_await_s", iterator);
-				return NULL;
+				return metacall_error_throw("metacall", -1, NULL, "Invalid key at position %" PRIuS " when calling to metacallfmv_await_s", iterator);
 			}
 
 			if (value_validate(values[iterator]) != 0)
 			{
-				// TODO: Implement type error return a value
-				log_write("metacall", LOG_LEVEL_ERROR, "Invalid value at position %" PRIuS " when calling to metacallfmv_await_s", iterator);
-				return NULL;
+				return metacall_error_throw("metacall", -1, NULL, "Invalid value at position %" PRIuS " when calling to metacallfmv_await_s", iterator);
 			}
 
 			type_id key_id = value_type_id((value)keys[iterator]);

--- a/source/metacall/source/metacall.c
+++ b/source/metacall/source/metacall.c
@@ -2143,35 +2143,27 @@ void *metacallv_method(void *target, const char *name, method_invoke_ptr call, v
 {
 	if (v == NULL)
 	{
-		// TODO: Implement type error return a value
-		log_write("metacall", LOG_LEVEL_ERROR, "Method %s in %p is not implemented (bad allocation)", name, target);
-		return NULL;
+		return metacall_error_throw("metacall", -1, NULL, "Method %s in %p is not implemented (bad allocation)", name, target);
 	}
 
 	if (vector_size(v) == 0)
 	{
-		// TODO: Implement type error return a value
-		log_write("metacall", LOG_LEVEL_ERROR, "Method %s in %p is not implemented", name, target);
 		vector_destroy(v);
-		return NULL;
+		return metacall_error_throw("metacall", -1, NULL, "Method %s in %p is not implemented", name, target);
 	}
 
 	if (vector_size(v) > 1)
 	{
-		// TODO: Implement type error return a value
-		log_write("metacall", LOG_LEVEL_ERROR, "Method %s in %p is overloaded, you should use 'metacallt_class' instead for disambiguate the call", name, target);
 		vector_destroy(v);
-		return NULL;
+		return metacall_error_throw("metacall", -1, NULL, "Method %s in %p is overloaded, you should use 'metacallt_class' instead for disambiguate the call", name, target);
 	}
 
 	method m = vector_at_type(v, 0, method);
 
 	if (m == NULL)
 	{
-		// TODO: Implement type error return a value
-		log_write("metacall", LOG_LEVEL_ERROR, "Method %s in %p is invalid (NULL)", name, target);
 		vector_destroy(v);
-		return NULL;
+		return metacall_error_throw("metacall", -1, NULL, "Method %s in %p is invalid (NULL)", name, target);
 	}
 
 	signature s = method_signature(m);
@@ -2181,10 +2173,8 @@ void *metacallv_method(void *target, const char *name, method_invoke_ptr call, v
 	{
 		if (value_validate(args[iterator]) != 0)
 		{
-			// TODO: Implement type error return a value
-			log_write("metacall", LOG_LEVEL_ERROR, "Invalid argument at position %" PRIuS " when calling to metacallv_method", iterator);
 			vector_destroy(v);
-			return NULL;
+			return metacall_error_throw("metacall", -1, NULL, "Invalid argument at position %" PRIuS " when calling to metacallv_method", iterator);
 		}
 
 		type t = signature_get_type(s, iterator);
@@ -2267,8 +2257,7 @@ void *metacallt_class(void *cls, const char *name, const enum metacall_value_id 
 
 	if (m == NULL)
 	{
-		log_write("metacall", LOG_LEVEL_ERROR, "Method %s in class <%p> is not implemented with the parameter types being received", name, cls);
-		return NULL;
+		return metacall_error_throw("metacall", -1, NULL, "Method %s in class <%p> is not implemented with the parameter types being received", name, cls);
 	}
 
 	return class_static_call(cls, m, args, size);
@@ -2305,8 +2294,7 @@ void *metacallt_object(void *obj, const char *name, const enum metacall_value_id
 
 	if (m == NULL)
 	{
-		log_write("metacall", LOG_LEVEL_ERROR, "Method %s in object <%p> is not implemented with the parameter types being received", name, obj);
-		return NULL;
+		return metacall_error_throw("metacall", -1, NULL, "Method %s in object <%p> is not implemented with the parameter types being received", name, obj);
 	}
 
 	return object_call(obj, m, args, size);


### PR DESCRIPTION
## Summary
Replaces `log_write + return NULL` with `metacall_error_throw` across
value-returning entrypoints in `metacall.c` and the loaders, so errors
propagate as throwable values instead of being silently swallowed.

Pattern follows `rapid_json_serial_impl.cpp:422`:

```c
  return metacall_error_throw("metacall", -1, NULL, "<message>", <args>);
```

## Scope
In:
- value-returning functions (return type `void *` / `value`)
- removes the old log + NULL return; single throw statement

Out:
- int-returning functions
- metacall_error_last / metacall_error_clear (still TODO)
- stacktrace propagation
- debug-mode log inside metacall_error_throw

## Progress
- [x] handle-validation entrypoints (metacallhv, metacallhv_s, metacallht_s, metacall_handle_function, metacall_handle_export)
- [ ] "method not implemented" cluster (metacallv_method and friends)
- [ ] remaining value-returning sites in metacall.c
- [ ] per-loader passes (py_loader, node_loader, ...)
