### PR TITLE
fix(msan): add Google Benchmark to MSan ignorelist

### DIFF
--- a/source/tests/sanitizer/msan-ignorelist.txt
+++ b/source/tests/sanitizer/msan-ignorelist.txt
@@ -13,5 +13,9 @@
 src:*/googletest/*
 fun:testing::*
 
-# Google Benchmark library not built with MSan
-src:*/_deps/googlebenchmark*
+# Google Benchmark is ignored because it is built with MSan support
+# but its internal implementation triggers false positives. The googlebenchmark
+# library is instrumented separately with the correct MSan flags and ignorelist
+# via InstallGBench.cmake, so we suppress the googlebenchmark sources here to avoid
+# noise from the benchmark framework itself.
+src:*/googlebenchmark/*

--- a/source/tests/sanitizer/msan-ignorelist.txt
+++ b/source/tests/sanitizer/msan-ignorelist.txt
@@ -12,3 +12,6 @@
 # noise from the testing framework itself.
 src:*/googletest/*
 fun:testing::*
+
+# Google Benchmark library not built with MSan
+src:*/_deps/googlebenchmark*


### PR DESCRIPTION
Google Benchmark library is fetched via FetchContent and not built with MSan instrumentation, causing false positives in bench tests.

Added `src:*/_deps/googlebenchmark*` to `msan-ignorelist.txt` to suppress false positives from the benchmark library.

Verified locally: set-bench and log-bench pass with this change.