### PR TITLE
fix(py_port): normalise Python3_SITE_PACKAGES path for Windows install

### DIFF
--- a/source/ports/py_port/CMakeLists.txt
+++ b/source/ports/py_port/CMakeLists.txt
@@ -33,6 +33,11 @@ if(NOT OPTION_BUILD_GUIX)
 		OUTPUT_STRIP_TRAILING_WHITESPACE
 	)
 
+	# Normalise to forward slashes so install(DESTINATION ...) doesn't bake
+	# backslash sequences (e.g. "\Program Files") into cmake_install.cmake,
+	# which CMake then misparses as invalid escape characters on Windows.
+	file(TO_CMAKE_PATH "${Python3_SITE_PACKAGES}" Python3_SITE_PACKAGES)
+
 	# Install into a temporary folder so we can track the installed files in the install_manifest.txt
 	set(PY_PORT_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/install")
 


### PR DESCRIPTION
On Windows, sysconfig.get_paths()['purelib'] returns a backslash path
(e.g. `C:\Program Files\Python3\Lib\site-packages`) which gets baked
into cmake_install.cmake and fails to parse with "Invalid character
escape '\P'". Fix: call file(TO_CMAKE_PATH ...) to normalise to forward
slashes before passing to install(DESTINATION).

CI Fork Run - https://github.com/ROKUMATE/MetaCall-core/actions/runs/28289593754